### PR TITLE
fix: add base path support for GitHub Pages deployment

### DIFF
--- a/src/components/ui/FrameworkTabs.astro
+++ b/src/components/ui/FrameworkTabs.astro
@@ -6,6 +6,7 @@
  * Uses static links (no JavaScript required).
  */
 import { FRAMEWORKS, FRAMEWORK_INFO, type Framework } from "@/lib/frameworks";
+import { withBase } from "@/lib/utils";
 
 interface Props {
   /** The pattern name (e.g., 'button', 'tabs') */
@@ -22,7 +23,7 @@ const { pattern, currentFramework } = Astro.props;
     FRAMEWORKS.map((fw) => {
       const info = FRAMEWORK_INFO[fw];
       const isActive = fw === currentFramework;
-      const href = `/patterns/${pattern}/${fw}/`;
+      const href = withBase(`/patterns/${pattern}/${fw}/`);
 
       return (
         <a

--- a/src/components/ui/pattern-sidebar/PatternSidebar.astro
+++ b/src/components/ui/pattern-sidebar/PatternSidebar.astro
@@ -6,6 +6,7 @@ import {
   SidebarMenuItem,
   SidebarMenuButton,
 } from "@/components/ui/sidebar";
+import { withBase } from "@/lib/utils";
 
 interface Props {
   currentPattern: string;
@@ -32,7 +33,7 @@ const frameworkLabel = FRAMEWORK_INFO[currentFramework].label;
       availablePatterns.map((pattern) => (
         <SidebarMenuItem>
           <SidebarMenuButton
-            href={`/patterns/${pattern.id}/${currentFramework}/`}
+            href={withBase(`/patterns/${pattern.id}/${currentFramework}/`)}
             active={currentPattern === pattern.id}
             aria-current={currentPattern === pattern.id ? "page" : undefined}
           >

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -14,6 +14,7 @@ import { Footer, FooterDescription, FooterGroup, FooterMenu, FooterMenuItem, Foo
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import MenuIcon from 'lucide-static/icons/menu.svg';
+import { withBase } from '@/lib/utils';
 
 interface Props {
   title: string;
@@ -24,9 +25,9 @@ const { title, description = 'APG Patterns Examples - Accessible component patte
 const currentPath = Astro.url.pathname;
 
 const navLinks = [
-  { text: 'Patterns', href: '/patterns/' },
-  { text: 'Guide', href: '/guide/' },
-  { text: 'About', href: '/about/' },
+  { text: 'Patterns', href: withBase('/patterns/') },
+  { text: 'Guide', href: withBase('/guide/') },
+  { text: 'About', href: withBase('/about/') },
 ];
 ---
 
@@ -36,7 +37,7 @@ const navLinks = [
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href={withBase('/favicon.svg')} />
     <title>{title} | APG Patterns Examples</title>
     <ThemeProvider />
   </head>
@@ -44,7 +45,7 @@ const navLinks = [
     <a href="#main-content" class="skip-link">Skip to main content</a>
 
     <Header>
-      <Logo href="/">
+      <Logo href={withBase('/')}>
         <LogoText>APG Patterns</LogoText>
       </Logo>
       <NavigationMenu class="mr-auto @max-lg:hidden">

--- a/src/layouts/PatternLayout.astro
+++ b/src/layouts/PatternLayout.astro
@@ -8,6 +8,7 @@ import {
   CollapsibleTrigger,
   CollapsibleContent,
 } from "@/components/ui/collapsible";
+import { withBase } from "@/lib/utils";
 
 interface Props {
   title: string;
@@ -47,7 +48,7 @@ const frameworkLabel = FRAMEWORK_INFO[framework].label;
                 {availablePatterns.map((p) => (
                   <li>
                     <a
-                      href={`/patterns/${p.id}/${framework}/`}
+                      href={withBase(`/patterns/${p.id}/${framework}/`)}
                       class:list={[
                         "flex items-center gap-2 px-4 py-2 text-sm hover:bg-muted/50 transition-colors",
                         pattern === p.id && "bg-muted font-medium"

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,15 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Prepends the base URL to a path for internal links.
+ * This ensures links work correctly when deployed to a subdirectory (e.g., GitHub Pages).
+ */
+export function withBase(path: string): string {
+  const base = import.meta.env.BASE_URL
+  // Remove trailing slash from base and leading slash from path to avoid double slashes
+  const normalizedBase = base.endsWith('/') ? base.slice(0, -1) : base
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `${normalizedBase}${normalizedPath}`
+}

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { Button } from '@/components/ui/button';
+import { withBase } from '@/lib/utils';
 ---
 
 <BaseLayout title="Page Not Found">
@@ -11,8 +12,8 @@ import { Button } from '@/components/ui/button';
       The page you're looking for doesn't exist or has been moved.
     </p>
     <div class="flex gap-4">
-      <Button href="/">Go Home</Button>
-      <Button variant="outline" href="/patterns/">Browse Patterns</Button>
+      <Button href={withBase('/')}>Go Home</Button>
+      <Button variant="outline" href={withBase('/patterns/')}>Browse Patterns</Button>
     </div>
   </div>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,24 +1,25 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { Tile, TileContent, TileTitle, TileDescription } from '@/components/ui/tile';
+import { withBase } from '@/lib/utils';
 
 const patterns = [
   {
     name: 'Toggle Button',
     description: 'Button with pressed state',
-    href: '/patterns/button/react/',
+    href: withBase('/patterns/button/react/'),
     icon: '🔘',
   },
   {
     name: 'Tabs',
     description: 'Tabbed interface with keyboard navigation',
-    href: '/patterns/tabs/react/',
+    href: withBase('/patterns/tabs/react/'),
     icon: '📑',
   },
   {
     name: 'Accordion',
     description: 'Collapsible content sections',
-    href: '/patterns/accordion/react/',
+    href: withBase('/patterns/accordion/react/'),
     icon: '📋',
   },
 ];
@@ -32,7 +33,7 @@ const patterns = [
     </p>
 
     <div class="grid gap-6 md:grid-cols-3">
-      <Tile variant="floating" href="/patterns/">
+      <Tile variant="floating" href={withBase('/patterns/')}>
         <TileContent>
           <TileTitle>Patterns</TileTitle>
           <TileDescription>
@@ -41,7 +42,7 @@ const patterns = [
         </TileContent>
       </Tile>
 
-      <Tile variant="floating" href="/guide/">
+      <Tile variant="floating" href={withBase('/guide/')}>
         <TileContent>
           <TileTitle>Guide</TileTitle>
           <TileDescription>
@@ -50,7 +51,7 @@ const patterns = [
         </TileContent>
       </Tile>
 
-      <Tile variant="floating" href="/about/">
+      <Tile variant="floating" href={withBase('/about/')}>
         <TileContent>
           <TileTitle>About</TileTitle>
           <TileDescription>

--- a/src/pages/patterns/[pattern]/index.astro
+++ b/src/pages/patterns/[pattern]/index.astro
@@ -3,6 +3,7 @@
 // This single file handles redirects for all patterns
 
 import { FRAMEWORKS, DEFAULT_FRAMEWORK } from "@/lib/frameworks";
+import { withBase } from "@/lib/utils";
 
 export function getStaticPaths() {
   // Add new patterns here as they are implemented
@@ -13,6 +14,8 @@ export function getStaticPaths() {
 const { pattern } = Astro.params;
 const defaultFramework = DEFAULT_FRAMEWORK;
 const validFrameworks = FRAMEWORKS;
+const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
+const defaultRedirectUrl = withBase(`/patterns/${pattern}/${defaultFramework}/`);
 ---
 
 <!doctype html>
@@ -20,16 +23,16 @@ const validFrameworks = FRAMEWORKS;
   <head>
     <meta charset="UTF-8" />
     <title>Redirecting...</title>
-    <script is:inline define:vars={{ pattern, defaultFramework, validFrameworks }}>
+    <script is:inline define:vars={{ pattern, defaultFramework, validFrameworks, basePath }}>
       const framework = localStorage.getItem('apg-selected-framework') || defaultFramework;
       const selectedFramework = validFrameworks.includes(framework) ? framework : defaultFramework;
-      window.location.replace(`/patterns/${pattern}/${selectedFramework}/`);
+      window.location.replace(`${basePath}/patterns/${pattern}/${selectedFramework}/`);
     </script>
     <noscript>
-      <meta http-equiv="refresh" content={`0;url=/patterns/${pattern}/${defaultFramework}/`} />
+      <meta http-equiv="refresh" content={`0;url=${defaultRedirectUrl}`} />
     </noscript>
   </head>
   <body>
-    <p>Redirecting to <a href={`/patterns/${pattern}/${defaultFramework}/`}>{defaultFramework}</a>...</p>
+    <p>Redirecting to <a href={defaultRedirectUrl}>{defaultFramework}</a>...</p>
   </body>
 </html>

--- a/src/pages/patterns/accordion/astro/index.astro
+++ b/src/pages/patterns/accordion/astro/index.astro
@@ -7,6 +7,7 @@ import AccessibilityDocs from '@patterns/accordion/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import sourceCode from '@patterns/accordion/Accordion.astro?raw';
+import { withBase } from '@/lib/utils';
 
 const defaultItems = [
   {
@@ -67,7 +68,7 @@ const disabledItems = [
 
 <PatternLayout title="Accordion - Astro" pattern="accordion" framework="astro">
     <nav class="mb-6 text-sm">
-      <a href="/patterns/" class="text-primary hover:underline">Patterns</a>
+      <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
       <span class="mx-2 text-muted-foreground">/</span>
       <span>Accordion</span>
     </nav>

--- a/src/pages/patterns/accordion/react/index.astro
+++ b/src/pages/patterns/accordion/react/index.astro
@@ -7,6 +7,7 @@ import AccessibilityDocs from '@patterns/accordion/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import sourceCode from '@patterns/accordion/Accordion.tsx?raw';
+import { withBase } from '@/lib/utils';
 
 const defaultItems = [
   {
@@ -67,7 +68,7 @@ const disabledItems = [
 
 <PatternLayout title="Accordion - React" pattern="accordion" framework="react">
     <nav class="mb-6 text-sm">
-      <a href="/patterns/" class="text-primary hover:underline">Patterns</a>
+      <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
       <span class="mx-2 text-muted-foreground">/</span>
       <span>Accordion</span>
     </nav>

--- a/src/pages/patterns/accordion/svelte/index.astro
+++ b/src/pages/patterns/accordion/svelte/index.astro
@@ -7,6 +7,7 @@ import AccessibilityDocs from '@patterns/accordion/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import sourceCode from '@patterns/accordion/Accordion.svelte?raw';
+import { withBase } from '@/lib/utils';
 
 const defaultItems = [
   {
@@ -67,7 +68,7 @@ const disabledItems = [
 
 <PatternLayout title="Accordion - Svelte" pattern="accordion" framework="svelte">
     <nav class="mb-6 text-sm">
-      <a href="/patterns/" class="text-primary hover:underline">Patterns</a>
+      <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
       <span class="mx-2 text-muted-foreground">/</span>
       <span>Accordion</span>
     </nav>

--- a/src/pages/patterns/accordion/vue/index.astro
+++ b/src/pages/patterns/accordion/vue/index.astro
@@ -7,6 +7,7 @@ import AccessibilityDocs from '@patterns/accordion/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import sourceCode from '@patterns/accordion/Accordion.vue?raw';
+import { withBase } from '@/lib/utils';
 
 const defaultItems = [
   {
@@ -67,7 +68,7 @@ const disabledItems = [
 
 <PatternLayout title="Accordion - Vue" pattern="accordion" framework="vue">
     <nav class="mb-6 text-sm">
-      <a href="/patterns/" class="text-primary hover:underline">Patterns</a>
+      <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
       <span class="mx-2 text-muted-foreground">/</span>
       <span>Accordion</span>
     </nav>

--- a/src/pages/patterns/button/astro/index.astro
+++ b/src/pages/patterns/button/astro/index.astro
@@ -7,11 +7,12 @@ import AccessibilityDocs from "@patterns/button/AccessibilityDocs.astro";
 import FrameworkTabs from "@/components/ui/FrameworkTabs.astro";
 import { ResponsiveTable } from "@/components/ui/table";
 import sourceCode from "@patterns/button/ToggleButton.astro?raw";
+import { withBase } from "@/lib/utils";
 ---
 
 <PatternLayout title="Toggle Button - Astro" pattern="button" framework="astro">
   <nav class="mb-6 text-sm">
-    <a href="/patterns/" class="text-primary hover:underline">Patterns</a>
+    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
     <span>Toggle Button</span>
   </nav>

--- a/src/pages/patterns/button/react/index.astro
+++ b/src/pages/patterns/button/react/index.astro
@@ -7,11 +7,12 @@ import AccessibilityDocs from '@patterns/button/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import sourceCode from '@patterns/button/ToggleButton.tsx?raw';
+import { withBase } from '@/lib/utils';
 ---
 
 <PatternLayout title="Toggle Button - React" pattern="button" framework="react">
   <nav class="mb-6 text-sm">
-    <a href="/patterns/" class="text-primary hover:underline">Patterns</a>
+    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
     <span>Toggle Button</span>
   </nav>

--- a/src/pages/patterns/button/svelte/index.astro
+++ b/src/pages/patterns/button/svelte/index.astro
@@ -7,11 +7,12 @@ import AccessibilityDocs from '@patterns/button/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import sourceCode from '@patterns/button/ToggleButton.svelte?raw';
+import { withBase } from '@/lib/utils';
 ---
 
 <PatternLayout title="Toggle Button - Svelte" pattern="button" framework="svelte">
   <nav class="mb-6 text-sm">
-    <a href="/patterns/" class="text-primary hover:underline">Patterns</a>
+    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
     <span>Toggle Button</span>
   </nav>

--- a/src/pages/patterns/button/vue/index.astro
+++ b/src/pages/patterns/button/vue/index.astro
@@ -7,11 +7,12 @@ import AccessibilityDocs from '@patterns/button/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import sourceCode from '@patterns/button/ToggleButton.vue?raw';
+import { withBase } from '@/lib/utils';
 ---
 
 <PatternLayout title="Toggle Button - Vue" pattern="button" framework="vue">
   <nav class="mb-6 text-sm">
-    <a href="/patterns/" class="text-primary hover:underline">Patterns</a>
+    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
     <span>Toggle Button</span>
   </nav>

--- a/src/pages/patterns/tabs/astro/index.astro
+++ b/src/pages/patterns/tabs/astro/index.astro
@@ -7,6 +7,7 @@ import AccessibilityDocs from "@patterns/tabs/AccessibilityDocs.astro";
 import FrameworkTabs from "@/components/ui/FrameworkTabs.astro";
 import { ResponsiveTable } from '@/components/ui/table';
 import sourceCode from "@patterns/tabs/Tabs.astro?raw";
+import { withBase } from "@/lib/utils";
 
 const demoTabs = [
   {
@@ -59,7 +60,7 @@ const verticalTabs = [
 
 <PatternLayout title="Tabs - Astro" pattern="tabs" framework="astro">
   <nav class="mb-6 text-sm">
-    <a href="/patterns/" class="text-primary hover:underline">Patterns</a>
+    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
     <span>Tabs</span>
   </nav>

--- a/src/pages/patterns/tabs/react/index.astro
+++ b/src/pages/patterns/tabs/react/index.astro
@@ -7,6 +7,7 @@ import AccessibilityDocs from '@patterns/tabs/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import sourceCode from '@patterns/tabs/Tabs.tsx?raw';
+import { withBase } from '@/lib/utils';
 
 const demoTabs = [
   { id: 'tab1', label: 'Overview', content: 'This is the overview panel content. It provides a general introduction to the product or service.' },
@@ -29,7 +30,7 @@ const verticalTabs = [
 
 <PatternLayout title="Tabs - React" pattern="tabs" framework="react">
   <nav class="mb-6 text-sm">
-    <a href="/patterns/" class="text-primary hover:underline">Patterns</a>
+    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
     <span>Tabs</span>
   </nav>

--- a/src/pages/patterns/tabs/svelte/index.astro
+++ b/src/pages/patterns/tabs/svelte/index.astro
@@ -7,6 +7,7 @@ import AccessibilityDocs from '@patterns/tabs/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import sourceCode from '@patterns/tabs/Tabs.svelte?raw';
+import { withBase } from '@/lib/utils';
 
 const demoTabs = [
   { id: 'tab1', label: 'Overview', content: 'This is the overview panel content. It provides a general introduction to the product or service.' },
@@ -29,7 +30,7 @@ const verticalTabs = [
 
 <PatternLayout title="Tabs - Svelte" pattern="tabs" framework="svelte">
   <nav class="mb-6 text-sm">
-    <a href="/patterns/" class="text-primary hover:underline">Patterns</a>
+    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
     <span>Tabs</span>
   </nav>

--- a/src/pages/patterns/tabs/vue/index.astro
+++ b/src/pages/patterns/tabs/vue/index.astro
@@ -7,6 +7,7 @@ import AccessibilityDocs from '@patterns/tabs/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import sourceCode from '@patterns/tabs/Tabs.vue?raw';
+import { withBase } from '@/lib/utils';
 
 const demoTabs = [
   { id: 'tab1', label: 'Overview', content: 'This is the overview panel content. It provides a general introduction to the product or service.' },
@@ -29,7 +30,7 @@ const verticalTabs = [
 
 <PatternLayout title="Tabs - Vue" pattern="tabs" framework="vue">
   <nav class="mb-6 text-sm">
-    <a href="/patterns/" class="text-primary hover:underline">Patterns</a>
+    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
     <span>Tabs</span>
   </nav>


### PR DESCRIPTION
## 概要
GitHub Pages のサブディレクトリ (`/apg-patterns-examples/`) にデプロイする際に、すべての内部リンクに base path を追加する機能を実装しました。

## 変更内容
- [x] 新機能追加 (withBase ユーティリティ関数)
- [x] バグ修正 (内部リンクが正しく機能しない問題)
- [x] リファクタリング

### 具体的な変更
- `src/lib/utils.ts`: `withBase()` ユーティリティ関数を追加
- 全レイアウト (`BaseLayout`, `PatternLayout`, `PatternSidebar`) のリンク修正
- 全ページの内部リンク修正 (トップページ、404ページ、パターンページ 12 個)
- `FrameworkTabs` コンポーネント修正
- リダイレクトページ (`[pattern]/index.astro`) の JavaScript と noscript 両方対応

## テスト
- [x] ビルド成功
- [x] 生成された HTML でリンクが正しくプレフィックス付きで出力されることを確認
- [x] リダイレクトページが正しく動作することを確認

## 破壊的変更
- [x] 破壊的変更なし