### PR TITLE
fix: add focus-visible styles to interactive elements

### DIFF
--- a/src/components/ui/CodeBlock.astro
+++ b/src/components/ui/CodeBlock.astro
@@ -65,7 +65,7 @@ const { code, lang, title } = Astro.props;
     color: #9ca3af;
   }
 
-  .copy-button {
+  .code-block-header :global(.copy-button) {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -78,13 +78,13 @@ const { code, lang, title } = Astro.props;
     transition: color 0.2s, background-color 0.2s;
   }
 
-  .copy-button:hover {
+  .code-block-header :global(.copy-button:hover) {
     background-color: #374151;
     color: #f3f4f6;
   }
 
-  .copy-button:focus-visible {
-    outline: 2px solid var(--primary);
+  .code-block-header :global(.copy-button:focus-visible) {
+    outline: 2px solid var(--ring);
     outline-offset: 2px;
   }
 
@@ -96,6 +96,11 @@ const { code, lang, title } = Astro.props;
     margin: 0;
     padding: 1rem;
     border-radius: 0;
+  }
+
+  .code-block-content :global(pre:focus-visible) {
+    outline: 2px solid var(--ring);
+    outline-offset: -2px;
   }
 
   .sr-only {

--- a/src/components/ui/CodeTabs.astro
+++ b/src/components/ui/CodeTabs.astro
@@ -117,7 +117,7 @@ const tabsId = `code-tabs-${Math.random().toString(36).slice(2, 9)}`;
     border-bottom-color: var(--primary);
   }
 
-  .copy-button {
+  .code-tabs-header :global(.copy-button) {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -132,13 +132,13 @@ const tabsId = `code-tabs-${Math.random().toString(36).slice(2, 9)}`;
     transition: color 0.2s, background-color 0.2s;
   }
 
-  .copy-button:hover {
+  .code-tabs-header :global(.copy-button:hover) {
     background-color: #374151;
     color: #f3f4f6;
   }
 
-  .copy-button:focus-visible {
-    outline: 2px solid var(--primary);
+  .code-tabs-header :global(.copy-button:focus-visible) {
+    outline: 2px solid var(--ring);
     outline-offset: 2px;
   }
 
@@ -166,6 +166,11 @@ const tabsId = `code-tabs-${Math.random().toString(36).slice(2, 9)}`;
     margin: 0;
     padding: 1rem;
     border-radius: 0;
+  }
+
+  .code-content :global(pre:focus-visible) {
+    outline: 2px solid var(--ring);
+    outline-offset: -2px;
   }
 
   .sr-only {

--- a/src/components/ui/footer/footer-menu-link.astro
+++ b/src/components/ui/footer/footer-menu-link.astro
@@ -14,7 +14,7 @@ const slot = await Astro.slots.render("default")
   slot?.trim().length > 0 && (
     <a
       class={cn(
-        "text-muted-foreground hover:text-foreground focus-visible:outline-ring inline-flex cursor-pointer items-center gap-2 text-sm leading-5 outline-hidden transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        "text-muted-foreground hover:text-foreground inline-flex cursor-pointer items-center gap-2 text-sm leading-5 transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/src/components/ui/sidebar/sidebar-menu-button.astro
+++ b/src/components/ui/sidebar/sidebar-menu-button.astro
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const variants = cva(
-  "hover:bg-accent hover:text-accent-foreground focus-visible:outline-ring active:bg-accent active:text-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 disabled:pointer-events-none disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "hover:bg-accent hover:text-accent-foreground active:bg-accent active:text-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 disabled:pointer-events-none disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/src/components/ui/sidebar/sidebar-menu-sub-button.astro
+++ b/src/components/ui/sidebar/sidebar-menu-sub-button.astro
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const variants = cva(
-  "hover:bg-accent hover:text-accent-foreground focus-visible:outline-ring flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 disabled:pointer-events-none disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "hover:bg-accent hover:text-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 disabled:pointer-events-none disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       size: {


### PR DESCRIPTION
## 概要
フォーカスリングが表示されないUI要素の修正。`outline-hidden` が `outline-style: none` を設定してしまい、`focus-visible:outline-*` ユーティリティが効かない問題を解決。

## 変更内容
- **Sidebar メニューボタン**: `outline-hidden` と `focus-visible:outline-ring` を削除し、グローバルCSS の `outline-ring/50` を活用
- **Code Block コピーボタン**: スコープ付きCSS で `:global()` を使用して条件付きレンダリング内の要素にもスタイル適用
- **Code プレビュー**: `tabindex="0"` を持つ `<pre>` 要素にフォーカスリングを追加
- **フッターメニューリンク**: `outline-hidden` を削除してフォーカス表示を有効化
- **カラー統一**: フォーカスリングのカラーを `var(--primary)` から `var(--ring)` に統一

## アクセシビリティチェック
- ✅ フォーカスリングが全インタラクティブ要素に表示
- ✅ キーボードナビゲーション対応は既存実装で維持
- ✅ 色コントラスト考慮（`var(--ring)` は設計トークンで定義）

## テスト
- ✅ ビルド成功
- ✅ 手動テスト確認（Tab キーで全要素のフォーカスリング表示確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)