### PR TITLE
feat: add Table of Contents and Testing sections to pattern pages

### DIFF
--- a/src/components/ui/Heading.astro
+++ b/src/components/ui/Heading.astro
@@ -1,0 +1,20 @@
+---
+interface Props {
+  level: 2 | 3 | 4;
+  id?: string;
+  class?: string;
+}
+
+const { level, id, class: className } = Astro.props;
+const Tag = `h${level}` as 'h2' | 'h3' | 'h4';
+
+// Get text from slot and generate slug
+const slotContent = await Astro.slots.render('default');
+// Strip HTML tags to get plain text
+const text = slotContent.replace(/<[^>]*>/g, '').trim();
+const slug = id ?? text.toLowerCase().replace(/\s+/g, '-').replace(/[^\w-]/g, '');
+---
+
+<Tag id={slug} class={className}>
+  <slot />
+</Tag>

--- a/src/components/ui/toc/TableOfContents.astro
+++ b/src/components/ui/toc/TableOfContents.astro
@@ -1,0 +1,131 @@
+---
+export interface TocItem {
+  id: string;
+  text: string;
+}
+
+interface Props {
+  items: TocItem[];
+}
+
+const { items } = Astro.props;
+---
+
+<nav aria-label="Table of contents" class="toc">
+  <h2 class="text-sm font-semibold mb-3 text-foreground">On this page</h2>
+  <ul class="space-y-1 text-sm">
+    {items.map((item) => (
+      <li>
+        <a
+          href={`#${item.id}`}
+          class="toc-link block py-1 text-muted-foreground hover:text-foreground transition-colors"
+          data-toc-id={item.id}
+        >
+          {item.text}
+        </a>
+      </li>
+    ))}
+  </ul>
+</nav>
+
+<script>
+  // Store cleanup function to prevent listener duplication
+  let cleanupToc: (() => void) | null = null;
+
+  function initToc() {
+    // Cleanup previous listeners if any
+    if (cleanupToc) {
+      cleanupToc();
+      cleanupToc = null;
+    }
+
+    const tocLinks = document.querySelectorAll('.toc-link');
+    const headings = Array.from(document.querySelectorAll('h2[id]')) as HTMLElement[];
+
+    if (tocLinks.length === 0 || headings.length === 0) return;
+
+    // Offset from top of viewport to consider a heading as "current"
+    const SCROLL_OFFSET = 100;
+
+    function getActiveHeadingId(): string | null {
+      // Find the heading that is currently at or above the scroll position
+      // (the last heading that has scrolled past the offset line)
+      let activeId: string | null = null;
+
+      for (const heading of headings) {
+        const rect = heading.getBoundingClientRect();
+        // If the heading is at or above the offset line, it's a candidate
+        if (rect.top <= SCROLL_OFFSET) {
+          activeId = heading.id;
+        } else {
+          // Headings are in DOM order, so once we find one below the line,
+          // the previous one is the active section
+          break;
+        }
+      }
+
+      // If no heading has scrolled past, default to the first one
+      if (activeId === null && headings.length > 0) {
+        activeId = headings[0].id;
+      }
+
+      // Edge case: near bottom of page, activate last heading
+      const scrollBottom = window.scrollY + window.innerHeight;
+      const docHeight = document.documentElement.scrollHeight;
+      if (docHeight - scrollBottom < 50 && headings.length > 0) {
+        activeId = headings[headings.length - 1].id;
+      }
+
+      return activeId;
+    }
+
+    function updateActiveLink() {
+      const activeId = getActiveHeadingId();
+
+      tocLinks.forEach((link) => {
+        const linkId = link.getAttribute('data-toc-id');
+        const isActive = linkId === activeId;
+
+        // Use classList.toggle for efficient state updates
+        link.classList.toggle('text-muted-foreground', !isActive);
+        link.classList.toggle('text-primary', isActive);
+        link.classList.toggle('font-medium', isActive);
+
+        // Set aria-current for accessibility
+        if (isActive) {
+          link.setAttribute('aria-current', 'true');
+        } else {
+          link.removeAttribute('aria-current');
+        }
+      });
+    }
+
+    // Throttle scroll events for performance
+    let ticking = false;
+    function onScroll() {
+      if (!ticking) {
+        requestAnimationFrame(() => {
+          updateActiveLink();
+          ticking = false;
+        });
+        ticking = true;
+      }
+    }
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+
+    // Set initial active state
+    updateActiveLink();
+
+    // Store cleanup function
+    cleanupToc = () => {
+      window.removeEventListener('scroll', onScroll);
+    };
+  }
+
+  // Run on initial load
+  initToc();
+
+  // Re-run on view transitions (Astro)
+  document.addEventListener('astro:page-load', initToc);
+</script>

--- a/src/components/ui/toc/index.ts
+++ b/src/components/ui/toc/index.ts
@@ -1,0 +1,6 @@
+export { default as TableOfContents } from './TableOfContents.astro';
+
+export interface TocItem {
+  id: string;
+  text: string;
+}

--- a/src/layouts/PatternLayout.astro
+++ b/src/layouts/PatternLayout.astro
@@ -8,6 +8,7 @@ import {
   CollapsibleTrigger,
   CollapsibleContent,
 } from "@/components/ui/collapsible";
+import { TableOfContents, type TocItem } from "@/components/ui/toc";
 import { withBase } from "@/lib/utils";
 
 interface Props {
@@ -15,58 +16,78 @@ interface Props {
   description?: string;
   pattern: string;
   framework: Framework;
+  tocItems?: TocItem[];
 }
 
-const { title, description, pattern, framework } = Astro.props;
+const { title, description, pattern, framework, tocItems = [] } = Astro.props;
 const availablePatterns = getAvailablePatterns();
 const currentPatternData = availablePatterns.find((p) => p.id === pattern);
 const frameworkLabel = FRAMEWORK_INFO[framework].label;
+const hasToc = tocItems.length > 0;
 ---
 
 <BaseLayout title={title} description={description}>
-  <div class="lg:grid lg:grid-cols-[240px_1fr] lg:gap-8">
-    <!-- Sidebar (desktop only) -->
-    <aside class="hidden lg:block">
-      <PatternSidebar currentPattern={pattern} currentFramework={framework} />
-    </aside>
+  <div class="mx-auto max-w-7xl">
+    <div class:list={[
+      "lg:grid lg:gap-16 xl:gap-20",
+      hasToc
+        ? "lg:grid-cols-[240px_1fr] xl:grid-cols-[240px_1fr_200px]"
+        : "lg:grid-cols-[240px_1fr]"
+    ]}>
+      <!-- Sidebar (desktop only) -->
+      <aside class="hidden lg:block">
+        <div class="sticky top-20">
+          <PatternSidebar currentPattern={pattern} currentFramework={framework} />
+        </div>
+      </aside>
 
-    <!-- Main content -->
-    <div class="max-w-4xl min-w-0">
-      <!-- Mobile pattern navigation -->
-      <div class="lg:hidden mb-6">
-        <Collapsible class="border border-border rounded-lg">
-          <CollapsibleTrigger class="w-full px-4 py-3 text-left hover:bg-muted/50 rounded-lg">
-            <span class="text-base" aria-hidden="true">{currentPatternData?.icon}</span>
-            <span class="font-medium">{currentPatternData?.name}</span>
-            <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-primary/10 text-primary">
-              {frameworkLabel}
-            </span>
-          </CollapsibleTrigger>
-          <CollapsibleContent class="border-t border-border">
-            <nav aria-label="Pattern navigation" class="py-2">
-              <ul class="space-y-1">
-                {availablePatterns.map((p) => (
-                  <li>
-                    <a
-                      href={withBase(`/patterns/${p.id}/${framework}/`)}
-                      class:list={[
-                        "flex items-center gap-2 px-4 py-2 text-sm hover:bg-muted/50 transition-colors",
-                        pattern === p.id && "bg-muted font-medium"
-                      ]}
-                      aria-current={pattern === p.id ? "page" : undefined}
-                    >
-                      <span class="text-base" aria-hidden="true">{p.icon}</span>
-                      <span>{p.name}</span>
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </nav>
-          </CollapsibleContent>
-        </Collapsible>
+      <!-- Main content -->
+      <div class="max-w-4xl min-w-0">
+        <!-- Mobile pattern navigation -->
+        <div class="lg:hidden mb-6">
+          <Collapsible class="border border-border rounded-lg">
+            <CollapsibleTrigger class="w-full px-4 py-3 text-left hover:bg-muted/50 rounded-lg">
+              <span class="text-base" aria-hidden="true">{currentPatternData?.icon}</span>
+              <span class="font-medium">{currentPatternData?.name}</span>
+              <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-primary/10 text-primary">
+                {frameworkLabel}
+              </span>
+            </CollapsibleTrigger>
+            <CollapsibleContent class="border-t border-border">
+              <nav aria-label="Pattern navigation" class="py-2">
+                <ul class="space-y-1">
+                  {availablePatterns.map((p) => (
+                    <li>
+                      <a
+                        href={withBase(`/patterns/${p.id}/${framework}/`)}
+                        class:list={[
+                          "flex items-center gap-2 px-4 py-2 text-sm hover:bg-muted/50 transition-colors",
+                          pattern === p.id && "bg-muted font-medium"
+                        ]}
+                        aria-current={pattern === p.id ? "page" : undefined}
+                      >
+                        <span class="text-base" aria-hidden="true">{p.icon}</span>
+                        <span>{p.name}</span>
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </nav>
+            </CollapsibleContent>
+          </Collapsible>
+        </div>
+
+        <slot />
       </div>
 
-      <slot />
+      <!-- Right Sidebar: TOC (xl and above) -->
+      {hasToc && (
+        <aside class="hidden xl:block">
+          <div class="sticky top-20">
+            <TableOfContents items={tocItems} />
+          </div>
+        </aside>
+      )}
     </div>
   </div>
 </BaseLayout>

--- a/src/pages/patterns/accordion/astro/index.astro
+++ b/src/pages/patterns/accordion/astro/index.astro
@@ -6,8 +6,19 @@ import ExternalLink from '@/components/ui/ExternalLink.astro';
 import AccessibilityDocs from '@patterns/accordion/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/accordion/Accordion.astro?raw';
 import { withBase } from '@/lib/utils';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'implementation-notes', text: 'Implementation Notes' },
+  { id: 'resources', text: 'Resources' },
+];
 
 const defaultItems = [
   {
@@ -66,7 +77,7 @@ const disabledItems = [
 ];
 ---
 
-<PatternLayout title="Accordion - Astro" pattern="accordion" framework="astro">
+<PatternLayout title="Accordion - Astro" pattern="accordion" framework="astro" tocItems={tocItems}>
     <nav class="mb-6 text-sm">
       <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
       <span class="mx-2 text-muted-foreground">/</span>
@@ -85,7 +96,7 @@ const disabledItems = [
 
     <!-- Demo Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Demo</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
 
       <!-- Default (Single Expansion) -->
       <div class="mb-8">
@@ -133,13 +144,13 @@ const disabledItems = [
 
     <!-- Accessibility Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Accessibility Features</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
       <AccessibilityDocs />
     </section>
 
     <!-- Source Code Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
       <CodeBlock
         code={sourceCode}
         lang="astro"
@@ -149,7 +160,7 @@ const disabledItems = [
 
     <!-- Usage Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Usage</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
       <CodeBlock
         code={`---
 import Accordion from './Accordion.astro';
@@ -181,7 +192,7 @@ const items = [
 
     <!-- API Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">API</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
 
       <h3 class="text-lg font-medium mb-3">Props</h3>
       <ResponsiveTable class="mb-6">
@@ -265,7 +276,7 @@ const items = [
 
     <!-- Implementation Notes -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Implementation Notes</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Implementation Notes</Heading>
       <div class="prose dark:prose-invert max-w-none">
         <p>
           This Astro implementation uses Web Components (<code>customElements.define</code>)
@@ -283,7 +294,7 @@ const items = [
 
     <!-- Resources -->
     <section>
-      <h2 class="text-xl font-semibold mb-4">Resources</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
       <ul class="list-disc pl-6 space-y-2">
         <li>
           <ExternalLink

--- a/src/pages/patterns/accordion/react/index.astro
+++ b/src/pages/patterns/accordion/react/index.astro
@@ -4,10 +4,23 @@ import Accordion from '@patterns/accordion/Accordion';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
 import AccessibilityDocs from '@patterns/accordion/AccessibilityDocs.astro';
+import TestingDocs from '@patterns/accordion/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/accordion/Accordion.tsx?raw';
+import testCode from '@patterns/accordion/Accordion.test.tsx?raw';
 import { withBase } from '@/lib/utils';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
 
 const defaultItems = [
   {
@@ -66,7 +79,7 @@ const disabledItems = [
 ];
 ---
 
-<PatternLayout title="Accordion - React" pattern="accordion" framework="react">
+<PatternLayout title="Accordion - React" pattern="accordion" framework="react" tocItems={tocItems}>
     <nav class="mb-6 text-sm">
       <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
       <span class="mx-2 text-muted-foreground">/</span>
@@ -85,7 +98,7 @@ const disabledItems = [
 
     <!-- Demo Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Demo</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
 
       <!-- Default (Single Expansion) -->
       <div class="mb-8">
@@ -136,13 +149,13 @@ const disabledItems = [
 
     <!-- Accessibility Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Accessibility Features</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
       <AccessibilityDocs />
     </section>
 
     <!-- Source Code Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
       <CodeBlock
         code={sourceCode}
         lang="tsx"
@@ -152,7 +165,7 @@ const disabledItems = [
 
     <!-- Usage Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Usage</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
       <CodeBlock
         code={`import { Accordion } from './Accordion';
 
@@ -187,7 +200,7 @@ function App() {
 
     <!-- API Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">API</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
 
       <h3 class="text-lg font-medium mb-3">AccordionProps</h3>
       <ResponsiveTable class="mb-6">
@@ -288,9 +301,22 @@ function App() {
       </ResponsiveTable>
     </section>
 
+    <!-- Testing Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
+      <TestingDocs />
+      <div class="mt-6">
+        <CodeBlock
+          code={testCode}
+          lang="tsx"
+          title="Accordion.test.tsx"
+        />
+      </div>
+    </section>
+
     <!-- Resources -->
     <section>
-      <h2 class="text-xl font-semibold mb-4">Resources</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
       <ul class="list-disc pl-6 space-y-2">
         <li>
           <ExternalLink

--- a/src/pages/patterns/accordion/svelte/index.astro
+++ b/src/pages/patterns/accordion/svelte/index.astro
@@ -6,8 +6,21 @@ import ExternalLink from '@/components/ui/ExternalLink.astro';
 import AccessibilityDocs from '@patterns/accordion/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/accordion/Accordion.svelte?raw';
+import TestingDocs from '@patterns/accordion/TestingDocs.astro';
+import testCode from '@patterns/accordion/Accordion.test.svelte.ts?raw';
 import { withBase } from '@/lib/utils';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
 
 const defaultItems = [
   {
@@ -66,7 +79,7 @@ const disabledItems = [
 ];
 ---
 
-<PatternLayout title="Accordion - Svelte" pattern="accordion" framework="svelte">
+<PatternLayout title="Accordion - Svelte" pattern="accordion" framework="svelte" tocItems={tocItems}>
     <nav class="mb-6 text-sm">
       <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
       <span class="mx-2 text-muted-foreground">/</span>
@@ -85,7 +98,7 @@ const disabledItems = [
 
     <!-- Demo Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Demo</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
 
       <!-- Default (Single Expansion) -->
       <div class="mb-8">
@@ -136,13 +149,13 @@ const disabledItems = [
 
     <!-- Accessibility Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Accessibility Features</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
       <AccessibilityDocs />
     </section>
 
     <!-- Source Code Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
       <CodeBlock
         code={sourceCode}
         lang="svelte"
@@ -152,7 +165,7 @@ const disabledItems = [
 
     <!-- Usage Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Usage</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
       <CodeBlock
         code={`<script>
   import Accordion from './Accordion.svelte';
@@ -189,7 +202,7 @@ const disabledItems = [
 
     <!-- API Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">API</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
 
       <h3 class="text-lg font-medium mb-3">Props</h3>
       <ResponsiveTable class="mb-6">
@@ -251,9 +264,22 @@ const disabledItems = [
       />
     </section>
 
+    <!-- Testing Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
+      <TestingDocs />
+      <div class="mt-6">
+        <CodeBlock
+          code={testCode}
+          lang="typescript"
+          title="Accordion.test.svelte.ts"
+        />
+      </div>
+    </section>
+
     <!-- Resources -->
     <section>
-      <h2 class="text-xl font-semibold mb-4">Resources</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
       <ul class="list-disc pl-6 space-y-2">
         <li>
           <ExternalLink

--- a/src/pages/patterns/accordion/vue/index.astro
+++ b/src/pages/patterns/accordion/vue/index.astro
@@ -6,8 +6,21 @@ import ExternalLink from '@/components/ui/ExternalLink.astro';
 import AccessibilityDocs from '@patterns/accordion/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/accordion/Accordion.vue?raw';
+import TestingDocs from '@patterns/accordion/TestingDocs.astro';
+import testCode from '@patterns/accordion/Accordion.test.vue.ts?raw';
 import { withBase } from '@/lib/utils';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
 
 const defaultItems = [
   {
@@ -66,7 +79,7 @@ const disabledItems = [
 ];
 ---
 
-<PatternLayout title="Accordion - Vue" pattern="accordion" framework="vue">
+<PatternLayout title="Accordion - Vue" pattern="accordion" framework="vue" tocItems={tocItems}>
     <nav class="mb-6 text-sm">
       <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
       <span class="mx-2 text-muted-foreground">/</span>
@@ -85,7 +98,7 @@ const disabledItems = [
 
     <!-- Demo Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Demo</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
 
       <!-- Default (Single Expansion) -->
       <div class="mb-8">
@@ -136,13 +149,13 @@ const disabledItems = [
 
     <!-- Accessibility Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Accessibility Features</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
       <AccessibilityDocs />
     </section>
 
     <!-- Source Code Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
       <CodeBlock
         code={sourceCode}
         lang="vue"
@@ -152,7 +165,7 @@ const disabledItems = [
 
     <!-- Usage Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Usage</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
       <CodeBlock
         code={`<script setup>
 import Accordion from './Accordion.vue';
@@ -187,7 +200,7 @@ const items = [
 
     <!-- API Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">API</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
 
       <h3 class="text-lg font-medium mb-3">Props</h3>
       <ResponsiveTable class="mb-6">
@@ -263,9 +276,22 @@ const items = [
       />
     </section>
 
+    <!-- Testing Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
+      <TestingDocs />
+      <div class="mt-6">
+        <CodeBlock
+          code={testCode}
+          lang="typescript"
+          title="Accordion.test.vue.ts"
+        />
+      </div>
+    </section>
+
     <!-- Resources -->
     <section>
-      <h2 class="text-xl font-semibold mb-4">Resources</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
       <ul class="list-disc pl-6 space-y-2">
         <li>
           <ExternalLink

--- a/src/pages/patterns/button/astro/index.astro
+++ b/src/pages/patterns/button/astro/index.astro
@@ -1,5 +1,6 @@
 ---
 import PatternLayout from "../../../../layouts/PatternLayout.astro";
+import Heading from "@/components/ui/Heading.astro";
 import ToggleButton from "@patterns/button/ToggleButton.astro";
 import Icon from "@/components/ui/icon/icon.astro";
 import CodeBlock from "@/components/ui/CodeBlock.astro";
@@ -9,9 +10,18 @@ import FrameworkTabs from "@/components/ui/FrameworkTabs.astro";
 import { ResponsiveTable } from "@/components/ui/table";
 import sourceCode from "@patterns/button/ToggleButton.astro?raw";
 import { withBase } from "@/lib/utils";
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'resources', text: 'Resources' },
+];
 ---
 
-<PatternLayout title="Toggle Button - Astro" pattern="button" framework="astro">
+<PatternLayout title="Toggle Button - Astro" pattern="button" framework="astro" tocItems={tocItems}>
   <nav class="mb-6 text-sm">
     <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
@@ -30,7 +40,7 @@ import { withBase } from "@/lib/utils";
 
     <!-- Demo Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Demo</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
       <div class="p-6 rounded-lg border border-border bg-background">
         <div class="flex flex-wrap gap-4">
           <ToggleButton>
@@ -54,19 +64,19 @@ import { withBase } from "@/lib/utils";
 
     <!-- Accessibility Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Accessibility Features</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
       <AccessibilityDocs />
     </section>
 
     <!-- Source Code Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
       <CodeBlock code={sourceCode} lang="astro" title="ToggleButton.astro" />
     </section>
 
     <!-- Usage Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Usage</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
       <CodeBlock
         code={`---
 import ToggleButton from './ToggleButton.astro';
@@ -92,7 +102,7 @@ import Icon from './Icon.astro';
 
     <!-- API Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">API</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
 
       <h3 class="text-lg font-medium mb-3">Props</h3>
       <ResponsiveTable class="mb-6">
@@ -187,7 +197,7 @@ import Icon from './Icon.astro';
 
     <!-- Resources -->
     <section>
-      <h2 class="text-xl font-semibold mb-4">Resources</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
       <ul class="list-disc pl-6 space-y-2">
         <li>
           <ExternalLink

--- a/src/pages/patterns/button/react/index.astro
+++ b/src/pages/patterns/button/react/index.astro
@@ -1,5 +1,6 @@
 ---
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
+import Heading from '@/components/ui/Heading.astro';
 import { MuteDemo, DarkModeDemo, NotificationsDemo } from '@patterns/button/ToggleButtonDemo';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
@@ -10,9 +11,19 @@ import { ResponsiveTable } from '@/components/ui/table';
 import sourceCode from '@patterns/button/ToggleButton.tsx?raw';
 import testCode from '@patterns/button/ToggleButton.test.tsx?raw';
 import { withBase } from '@/lib/utils';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
 ---
 
-<PatternLayout title="Toggle Button - React" pattern="button" framework="react">
+<PatternLayout title="Toggle Button - React" pattern="button" framework="react" tocItems={tocItems}>
   <nav class="mb-6 text-sm">
     <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
@@ -31,7 +42,7 @@ import { withBase } from '@/lib/utils';
 
     <!-- Demo Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Demo</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
       <div class="p-6 rounded-lg border border-border bg-background">
         <div class="flex flex-wrap gap-4">
           <MuteDemo client:load />
@@ -43,13 +54,13 @@ import { withBase } from '@/lib/utils';
 
     <!-- Accessibility Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Accessibility Features</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
       <AccessibilityDocs />
     </section>
 
     <!-- Source Code Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
       <CodeBlock
         code={sourceCode}
         lang="tsx"
@@ -59,7 +70,7 @@ import { withBase } from '@/lib/utils';
 
     <!-- Usage Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Usage</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
       <CodeBlock
         code={`import { ToggleButton } from './ToggleButton';
 import { Volume2, VolumeOff } from 'lucide-react';
@@ -83,7 +94,7 @@ function App() {
 
     <!-- API Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">API</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
       <ResponsiveTable>
         <table class="w-full border-collapse">
           <thead>
@@ -135,7 +146,7 @@ function App() {
 
     <!-- Testing Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Testing</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
       <TestingDocs />
       <div class="mt-6">
         <CodeBlock
@@ -148,7 +159,7 @@ function App() {
 
     <!-- Resources -->
     <section>
-      <h2 class="text-xl font-semibold mb-4">Resources</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
       <ul class="list-disc pl-6 space-y-2">
         <li>
           <ExternalLink

--- a/src/pages/patterns/button/svelte/index.astro
+++ b/src/pages/patterns/button/svelte/index.astro
@@ -1,5 +1,6 @@
 ---
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
+import Heading from '@/components/ui/Heading.astro';
 import ToggleButtonDemo from '@patterns/button/ToggleButtonDemo.svelte';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
@@ -10,9 +11,19 @@ import { ResponsiveTable } from '@/components/ui/table';
 import sourceCode from '@patterns/button/ToggleButton.svelte?raw';
 import testCode from '@patterns/button/ToggleButton.test.svelte.ts?raw';
 import { withBase } from '@/lib/utils';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
 ---
 
-<PatternLayout title="Toggle Button - Svelte" pattern="button" framework="svelte">
+<PatternLayout title="Toggle Button - Svelte" pattern="button" framework="svelte" tocItems={tocItems}>
   <nav class="mb-6 text-sm">
     <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
@@ -31,7 +42,7 @@ import { withBase } from '@/lib/utils';
 
     <!-- Demo Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Demo</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
       <div class="p-6 rounded-lg border border-border bg-background">
         <ToggleButtonDemo client:load />
       </div>
@@ -39,13 +50,13 @@ import { withBase } from '@/lib/utils';
 
     <!-- Accessibility Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Accessibility Features</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
       <AccessibilityDocs />
     </section>
 
     <!-- Source Code Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
       <CodeBlock
         code={sourceCode}
         lang="svelte"
@@ -55,7 +66,7 @@ import { withBase } from '@/lib/utils';
 
     <!-- Usage Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Usage</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
       <CodeBlock
         code={`<script>
   import ToggleButton from './ToggleButton.svelte';
@@ -80,7 +91,7 @@ import { withBase } from '@/lib/utils';
 
     <!-- API Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">API</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
       <ResponsiveTable>
         <table class="w-full border-collapse">
           <thead>
@@ -129,7 +140,7 @@ import { withBase } from '@/lib/utils';
 
     <!-- Testing Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Testing</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
       <TestingDocs />
       <div class="mt-6">
         <CodeBlock
@@ -142,7 +153,7 @@ import { withBase } from '@/lib/utils';
 
     <!-- Resources -->
     <section>
-      <h2 class="text-xl font-semibold mb-4">Resources</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
       <ul class="list-disc pl-6 space-y-2">
         <li>
           <ExternalLink

--- a/src/pages/patterns/button/vue/index.astro
+++ b/src/pages/patterns/button/vue/index.astro
@@ -1,5 +1,6 @@
 ---
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
+import Heading from '@/components/ui/Heading.astro';
 import ToggleButtonDemo from '@patterns/button/ToggleButtonDemo.vue';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
@@ -10,9 +11,19 @@ import { ResponsiveTable } from '@/components/ui/table';
 import sourceCode from '@patterns/button/ToggleButton.vue?raw';
 import testCode from '@patterns/button/ToggleButton.test.vue.ts?raw';
 import { withBase } from '@/lib/utils';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
 ---
 
-<PatternLayout title="Toggle Button - Vue" pattern="button" framework="vue">
+<PatternLayout title="Toggle Button - Vue" pattern="button" framework="vue" tocItems={tocItems}>
   <nav class="mb-6 text-sm">
     <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
@@ -31,7 +42,7 @@ import { withBase } from '@/lib/utils';
 
     <!-- Demo Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Demo</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
       <div class="p-6 rounded-lg border border-border bg-background">
         <ToggleButtonDemo client:load />
       </div>
@@ -39,13 +50,13 @@ import { withBase } from '@/lib/utils';
 
     <!-- Accessibility Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Accessibility Features</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
       <AccessibilityDocs />
     </section>
 
     <!-- Source Code Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
       <CodeBlock
         code={sourceCode}
         lang="vue"
@@ -55,7 +66,7 @@ import { withBase } from '@/lib/utils';
 
     <!-- Usage Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Usage</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
       <CodeBlock
         code={`<script setup>
 import ToggleButton from './ToggleButton.vue';
@@ -87,7 +98,7 @@ const handleToggle = (pressed) => {
 
     <!-- API Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">API</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
 
       <h3 class="text-lg font-medium mb-2">Props</h3>
       <ResponsiveTable class="mb-6">
@@ -180,7 +191,7 @@ const handleToggle = (pressed) => {
 
     <!-- Testing Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Testing</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
       <TestingDocs />
       <div class="mt-6">
         <CodeBlock
@@ -193,7 +204,7 @@ const handleToggle = (pressed) => {
 
     <!-- Resources -->
     <section>
-      <h2 class="text-xl font-semibold mb-4">Resources</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
       <ul class="list-disc pl-6 space-y-2">
         <li>
           <ExternalLink

--- a/src/pages/patterns/dialog/astro/index.astro
+++ b/src/pages/patterns/dialog/astro/index.astro
@@ -6,10 +6,20 @@ import ExternalLink from '@/components/ui/ExternalLink.astro';
 import AccessibilityDocs from '@patterns/dialog/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/dialog/Dialog.astro?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'resources', text: 'Resources' },
+];
 ---
 
-<PatternLayout title="Dialog - Astro" pattern="dialog" framework="astro">
+<PatternLayout title="Dialog - Astro" pattern="dialog" framework="astro" tocItems={tocItems}>
   <nav class="mb-6 text-sm">
     <a href="/patterns/" class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
@@ -28,7 +38,7 @@ import sourceCode from '@patterns/dialog/Dialog.astro?raw';
 
   <!-- Demo Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Demo</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
 
     <!-- Basic Dialog -->
     <div class="mb-8">
@@ -73,13 +83,13 @@ import sourceCode from '@patterns/dialog/Dialog.astro?raw';
 
   <!-- Accessibility Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Accessibility Features</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
     <AccessibilityDocs />
   </section>
 
   <!-- Source Code Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
     <CodeBlock
       code={sourceCode}
       lang="astro"
@@ -89,7 +99,7 @@ import sourceCode from '@patterns/dialog/Dialog.astro?raw';
 
   <!-- Usage Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Usage</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
     <CodeBlock
       code={`---
 import Dialog from './Dialog.astro';
@@ -109,7 +119,7 @@ import Dialog from './Dialog.astro';
 
   <!-- API Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">API</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
 
     <h3 class="text-lg font-medium mb-3">Props</h3>
     <ResponsiveTable class="mb-6">
@@ -206,7 +216,7 @@ import Dialog from './Dialog.astro';
 
   <!-- Resources -->
   <section>
-    <h2 class="text-xl font-semibold mb-4">Resources</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
     <ul class="list-disc pl-6 space-y-2">
       <li>
         <ExternalLink

--- a/src/pages/patterns/dialog/react/index.astro
+++ b/src/pages/patterns/dialog/react/index.astro
@@ -6,10 +6,23 @@ import ExternalLink from '@/components/ui/ExternalLink.astro';
 import AccessibilityDocs from '@patterns/dialog/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/dialog/Dialog.tsx?raw';
+import TestingDocs from '@patterns/dialog/TestingDocs.astro';
+import testCode from '@patterns/dialog/Dialog.test.tsx?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
 ---
 
-<PatternLayout title="Dialog - React" pattern="dialog" framework="react">
+<PatternLayout title="Dialog - React" pattern="dialog" framework="react" tocItems={tocItems}>
   <nav class="mb-6 text-sm">
     <a href="/patterns/" class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
@@ -28,7 +41,7 @@ import sourceCode from '@patterns/dialog/Dialog.tsx?raw';
 
   <!-- Demo Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Demo</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
 
     <!-- Basic Dialog -->
     <div class="mb-8">
@@ -75,13 +88,13 @@ import sourceCode from '@patterns/dialog/Dialog.tsx?raw';
 
   <!-- Accessibility Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Accessibility Features</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
     <AccessibilityDocs />
   </section>
 
   <!-- Source Code Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
     <CodeBlock
       code={sourceCode}
       lang="tsx"
@@ -91,7 +104,7 @@ import sourceCode from '@patterns/dialog/Dialog.tsx?raw';
 
   <!-- Usage Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Usage</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
     <CodeBlock
       code={`import { DialogRoot, DialogTrigger, Dialog } from './Dialog';
 
@@ -115,7 +128,7 @@ function App() {
 
   <!-- API Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">API</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
 
     <h3 class="text-lg font-medium mb-3">DialogRoot Props</h3>
     <ResponsiveTable class="mb-6">
@@ -192,9 +205,22 @@ function App() {
     </ResponsiveTable>
   </section>
 
+  <!-- Testing Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
+    <TestingDocs />
+    <div class="mt-6">
+      <CodeBlock
+        code={testCode}
+        lang="tsx"
+        title="Dialog.test.tsx"
+      />
+    </div>
+  </section>
+
   <!-- Resources -->
   <section>
-    <h2 class="text-xl font-semibold mb-4">Resources</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
     <ul class="list-disc pl-6 space-y-2">
       <li>
         <ExternalLink

--- a/src/pages/patterns/dialog/svelte/index.astro
+++ b/src/pages/patterns/dialog/svelte/index.astro
@@ -6,10 +6,23 @@ import ExternalLink from '@/components/ui/ExternalLink.astro';
 import AccessibilityDocs from '@patterns/dialog/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/dialog/Dialog.svelte?raw';
+import TestingDocs from '@patterns/dialog/TestingDocs.astro';
+import testCode from '@patterns/dialog/Dialog.test.svelte.ts?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
 ---
 
-<PatternLayout title="Dialog - Svelte" pattern="dialog" framework="svelte">
+<PatternLayout title="Dialog - Svelte" pattern="dialog" framework="svelte" tocItems={tocItems}>
   <nav class="mb-6 text-sm">
     <a href="/patterns/" class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
@@ -28,7 +41,7 @@ import sourceCode from '@patterns/dialog/Dialog.svelte?raw';
 
   <!-- Demo Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Demo</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
 
     <!-- Basic Dialog -->
     <div class="mb-8">
@@ -68,13 +81,13 @@ import sourceCode from '@patterns/dialog/Dialog.svelte?raw';
 
   <!-- Accessibility Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Accessibility Features</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
     <AccessibilityDocs />
   </section>
 
   <!-- Source Code Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
     <CodeBlock
       code={sourceCode}
       lang="svelte"
@@ -84,7 +97,7 @@ import sourceCode from '@patterns/dialog/Dialog.svelte?raw';
 
   <!-- Usage Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Usage</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
     <CodeBlock
       code={`<script>
   import Dialog from './Dialog.svelte';
@@ -113,7 +126,7 @@ import sourceCode from '@patterns/dialog/Dialog.svelte?raw';
 
   <!-- API Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">API</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
 
     <h3 class="text-lg font-medium mb-3">Props</h3>
     <ResponsiveTable class="mb-6">
@@ -209,9 +222,22 @@ import sourceCode from '@patterns/dialog/Dialog.svelte?raw';
     </ResponsiveTable>
   </section>
 
+  <!-- Testing Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
+    <TestingDocs />
+    <div class="mt-6">
+      <CodeBlock
+        code={testCode}
+        lang="typescript"
+        title="Dialog.test.svelte.ts"
+      />
+    </div>
+  </section>
+
   <!-- Resources -->
   <section>
-    <h2 class="text-xl font-semibold mb-4">Resources</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
     <ul class="list-disc pl-6 space-y-2">
       <li>
         <ExternalLink

--- a/src/pages/patterns/dialog/vue/index.astro
+++ b/src/pages/patterns/dialog/vue/index.astro
@@ -6,10 +6,23 @@ import ExternalLink from '@/components/ui/ExternalLink.astro';
 import AccessibilityDocs from '@patterns/dialog/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/dialog/Dialog.vue?raw';
+import TestingDocs from '@patterns/dialog/TestingDocs.astro';
+import testCode from '@patterns/dialog/Dialog.test.vue.ts?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
 ---
 
-<PatternLayout title="Dialog - Vue" pattern="dialog" framework="vue">
+<PatternLayout title="Dialog - Vue" pattern="dialog" framework="vue" tocItems={tocItems}>
   <nav class="mb-6 text-sm">
     <a href="/patterns/" class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
@@ -28,7 +41,7 @@ import sourceCode from '@patterns/dialog/Dialog.vue?raw';
 
   <!-- Demo Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Demo</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
 
     <!-- Basic Dialog -->
     <div class="mb-8">
@@ -75,13 +88,13 @@ import sourceCode from '@patterns/dialog/Dialog.vue?raw';
 
   <!-- Accessibility Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Accessibility Features</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
     <AccessibilityDocs />
   </section>
 
   <!-- Source Code Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
     <CodeBlock
       code={sourceCode}
       lang="vue"
@@ -91,7 +104,7 @@ import sourceCode from '@patterns/dialog/Dialog.vue?raw';
 
   <!-- Usage Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Usage</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
     <CodeBlock
       code={`<template>
   <Dialog
@@ -120,7 +133,7 @@ function handleOpenChange(open) {
 
   <!-- API Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">API</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
 
     <h3 class="text-lg font-medium mb-3">Props</h3>
     <ResponsiveTable class="mb-6">
@@ -208,9 +221,22 @@ function handleOpenChange(open) {
     </ResponsiveTable>
   </section>
 
+  <!-- Testing Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
+    <TestingDocs />
+    <div class="mt-6">
+      <CodeBlock
+        code={testCode}
+        lang="typescript"
+        title="Dialog.test.vue.ts"
+      />
+    </div>
+  </section>
+
   <!-- Resources -->
   <section>
-    <h2 class="text-xl font-semibold mb-4">Resources</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
     <ul class="list-disc pl-6 space-y-2">
       <li>
         <ExternalLink

--- a/src/pages/patterns/switch/astro/index.astro
+++ b/src/pages/patterns/switch/astro/index.astro
@@ -6,11 +6,21 @@ import ExternalLink from '@/components/ui/ExternalLink.astro';
 import AccessibilityDocs from '@patterns/switch/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/switch/Switch.astro?raw';
 import { withBase } from '@/lib/utils';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'resources', text: 'Resources' },
+];
 ---
 
-<PatternLayout title="Switch - Astro" pattern="switch" framework="astro">
+<PatternLayout title="Switch - Astro" pattern="switch" framework="astro" tocItems={tocItems}>
   <nav class="mb-6 text-sm">
     <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
@@ -29,7 +39,7 @@ import { withBase } from '@/lib/utils';
 
   <!-- Demo Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Demo</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
     <div class="p-6 rounded-lg border border-border bg-background">
       <div class="flex flex-col items-start gap-4">
         <Switch>Wi-Fi</Switch>
@@ -41,13 +51,13 @@ import { withBase } from '@/lib/utils';
 
   <!-- Accessibility Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Accessibility Features</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
     <AccessibilityDocs />
   </section>
 
   <!-- Source Code Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
     <CodeBlock
       code={sourceCode}
       lang="astro"
@@ -57,7 +67,7 @@ import { withBase } from '@/lib/utils';
 
   <!-- Usage Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Usage</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
     <CodeBlock
       code={`---
 import Switch from './Switch.astro';
@@ -80,7 +90,7 @@ import Switch from './Switch.astro';
 
   <!-- API Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">API</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
     <ResponsiveTable>
       <table class="w-full border-collapse">
         <thead>
@@ -155,7 +165,7 @@ import Switch from './Switch.astro';
 
   <!-- Resources -->
   <section>
-    <h2 class="text-xl font-semibold mb-4">Resources</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
     <ul class="list-disc pl-6 space-y-2">
       <li>
         <ExternalLink

--- a/src/pages/patterns/switch/react/index.astro
+++ b/src/pages/patterns/switch/react/index.astro
@@ -6,12 +6,23 @@ import ExternalLink from '@/components/ui/ExternalLink.astro';
 import AccessibilityDocs from '@patterns/switch/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/switch/Switch.tsx?raw';
 import testCode from '@patterns/switch/Switch.test.tsx?raw';
 import { withBase } from '@/lib/utils';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
 ---
 
-<PatternLayout title="Switch - React" pattern="switch" framework="react">
+<PatternLayout title="Switch - React" pattern="switch" framework="react" tocItems={tocItems}>
   <nav class="mb-6 text-sm">
     <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
@@ -30,7 +41,7 @@ import { withBase } from '@/lib/utils';
 
   <!-- Demo Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Demo</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
     <div class="p-6 rounded-lg border border-border bg-background">
       <div class="flex flex-col items-start gap-4">
         <Switch client:load>Wi-Fi</Switch>
@@ -42,13 +53,13 @@ import { withBase } from '@/lib/utils';
 
   <!-- Accessibility Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Accessibility Features</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
     <AccessibilityDocs />
   </section>
 
   <!-- Source Code Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
     <CodeBlock
       code={sourceCode}
       lang="tsx"
@@ -58,7 +69,7 @@ import { withBase } from '@/lib/utils';
 
   <!-- Usage Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Usage</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
     <CodeBlock
       code={`import { Switch } from './Switch';
 
@@ -79,7 +90,7 @@ function App() {
 
   <!-- API Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">API</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
     <ResponsiveTable>
       <table class="w-full border-collapse">
         <thead>
@@ -125,7 +136,7 @@ function App() {
 
   <!-- Testing Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Testing</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
     <p class="text-muted-foreground mb-4">
       Tests cover APG compliance including keyboard interactions, ARIA attributes, and accessibility validation.
     </p>
@@ -140,7 +151,7 @@ function App() {
 
   <!-- Resources -->
   <section>
-    <h2 class="text-xl font-semibold mb-4">Resources</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
     <ul class="list-disc pl-6 space-y-2">
       <li>
         <ExternalLink

--- a/src/pages/patterns/switch/svelte/index.astro
+++ b/src/pages/patterns/switch/svelte/index.astro
@@ -6,12 +6,23 @@ import ExternalLink from '@/components/ui/ExternalLink.astro';
 import AccessibilityDocs from '@patterns/switch/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/switch/Switch.svelte?raw';
 import testCode from '@patterns/switch/Switch.test.svelte.ts?raw';
 import { withBase } from '@/lib/utils';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
 ---
 
-<PatternLayout title="Switch - Svelte" pattern="switch" framework="svelte">
+<PatternLayout title="Switch - Svelte" pattern="switch" framework="svelte" tocItems={tocItems}>
   <nav class="mb-6 text-sm">
     <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
@@ -30,7 +41,7 @@ import { withBase } from '@/lib/utils';
 
   <!-- Demo Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Demo</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
     <div class="p-6 rounded-lg border border-border bg-background">
       <div class="flex flex-col items-start gap-4">
         <Switch client:load>Wi-Fi</Switch>
@@ -42,13 +53,13 @@ import { withBase } from '@/lib/utils';
 
   <!-- Accessibility Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Accessibility Features</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
     <AccessibilityDocs />
   </section>
 
   <!-- Source Code Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
     <CodeBlock
       code={sourceCode}
       lang="svelte"
@@ -58,7 +69,7 @@ import { withBase } from '@/lib/utils';
 
   <!-- Usage Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Usage</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
     <CodeBlock
       code={`<script>
   import Switch from './Switch.svelte';
@@ -81,7 +92,7 @@ import { withBase } from '@/lib/utils';
 
   <!-- API Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">API</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
     <ResponsiveTable>
       <table class="w-full border-collapse">
         <thead>
@@ -127,7 +138,7 @@ import { withBase } from '@/lib/utils';
 
   <!-- Testing Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Testing</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
     <p class="text-muted-foreground mb-4">
       Tests cover APG compliance including keyboard interactions, ARIA attributes, and accessibility validation.
     </p>
@@ -142,7 +153,7 @@ import { withBase } from '@/lib/utils';
 
   <!-- Resources -->
   <section>
-    <h2 class="text-xl font-semibold mb-4">Resources</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
     <ul class="list-disc pl-6 space-y-2">
       <li>
         <ExternalLink

--- a/src/pages/patterns/switch/vue/index.astro
+++ b/src/pages/patterns/switch/vue/index.astro
@@ -6,12 +6,23 @@ import ExternalLink from '@/components/ui/ExternalLink.astro';
 import AccessibilityDocs from '@patterns/switch/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/switch/Switch.vue?raw';
 import testCode from '@patterns/switch/Switch.test.vue.ts?raw';
 import { withBase } from '@/lib/utils';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
 ---
 
-<PatternLayout title="Switch - Vue" pattern="switch" framework="vue">
+<PatternLayout title="Switch - Vue" pattern="switch" framework="vue" tocItems={tocItems}>
   <nav class="mb-6 text-sm">
     <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
@@ -30,7 +41,7 @@ import { withBase } from '@/lib/utils';
 
   <!-- Demo Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Demo</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
     <div class="p-6 rounded-lg border border-border bg-background">
       <div class="flex flex-col items-start gap-4">
         <Switch client:load>Wi-Fi</Switch>
@@ -42,13 +53,13 @@ import { withBase } from '@/lib/utils';
 
   <!-- Accessibility Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Accessibility Features</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
     <AccessibilityDocs />
   </section>
 
   <!-- Source Code Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
     <CodeBlock
       code={sourceCode}
       lang="vue"
@@ -58,7 +69,7 @@ import { withBase } from '@/lib/utils';
 
   <!-- Usage Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Usage</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
     <CodeBlock
       code={`<script setup>
 import Switch from './Switch.vue';
@@ -83,7 +94,7 @@ function handleChange(checked) {
 
   <!-- API Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">API</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
     <ResponsiveTable>
       <table class="w-full border-collapse">
         <thead>
@@ -152,7 +163,7 @@ function handleChange(checked) {
 
   <!-- Testing Section -->
   <section class="mb-12">
-    <h2 class="text-xl font-semibold mb-4">Testing</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
     <p class="text-muted-foreground mb-4">
       Tests cover APG compliance including keyboard interactions, ARIA attributes, and accessibility validation.
     </p>
@@ -167,7 +178,7 @@ function handleChange(checked) {
 
   <!-- Resources -->
   <section>
-    <h2 class="text-xl font-semibold mb-4">Resources</h2>
+    <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
     <ul class="list-disc pl-6 space-y-2">
       <li>
         <ExternalLink

--- a/src/pages/patterns/tabs/astro/index.astro
+++ b/src/pages/patterns/tabs/astro/index.astro
@@ -6,8 +6,18 @@ import ExternalLink from "@/components/ui/ExternalLink.astro";
 import AccessibilityDocs from "@patterns/tabs/AccessibilityDocs.astro";
 import FrameworkTabs from "@/components/ui/FrameworkTabs.astro";
 import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
 import sourceCode from "@patterns/tabs/Tabs.astro?raw";
 import { withBase } from "@/lib/utils";
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'resources', text: 'Resources' },
+];
 
 const demoTabs = [
   {
@@ -58,7 +68,7 @@ const verticalTabs = [
 ];
 ---
 
-<PatternLayout title="Tabs - Astro" pattern="tabs" framework="astro">
+<PatternLayout title="Tabs - Astro" pattern="tabs" framework="astro" tocItems={tocItems}>
   <nav class="mb-6 text-sm">
     <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
@@ -78,7 +88,7 @@ const verticalTabs = [
 
     <!-- Demo Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Demo</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
 
       <!-- Default (Automatic Activation) -->
       <div class="mb-8">
@@ -116,19 +126,19 @@ const verticalTabs = [
 
     <!-- Accessibility Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Accessibility Features</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
       <AccessibilityDocs />
     </section>
 
     <!-- Source Code Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
       <CodeBlock code={sourceCode} lang="astro" title="Tabs.astro" />
     </section>
 
     <!-- Usage Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Usage</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
       <CodeBlock
         code={`---
 import Tabs from './Tabs.astro';
@@ -158,7 +168,7 @@ const tabs = [
 
     <!-- API Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">API</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
 
       <h3 class="text-lg font-medium mb-3">Props</h3>
       <ResponsiveTable class="mb-6">
@@ -251,7 +261,7 @@ const tabs = [
 
     <!-- Resources -->
     <section>
-      <h2 class="text-xl font-semibold mb-4">Resources</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
       <ul class="list-disc pl-6 space-y-2">
         <li>
           <ExternalLink

--- a/src/pages/patterns/tabs/react/index.astro
+++ b/src/pages/patterns/tabs/react/index.astro
@@ -4,10 +4,23 @@ import Tabs from '@patterns/tabs/Tabs';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
 import AccessibilityDocs from '@patterns/tabs/AccessibilityDocs.astro';
+import TestingDocs from '@patterns/tabs/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/tabs/Tabs.tsx?raw';
+import testCode from '@patterns/tabs/Tabs.test.tsx?raw';
 import { withBase } from '@/lib/utils';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
 
 const demoTabs = [
   { id: 'tab1', label: 'Overview', content: 'This is the overview panel content. It provides a general introduction to the product or service.' },
@@ -28,7 +41,7 @@ const verticalTabs = [
 ];
 ---
 
-<PatternLayout title="Tabs - React" pattern="tabs" framework="react">
+<PatternLayout title="Tabs - React" pattern="tabs" framework="react" tocItems={tocItems}>
   <nav class="mb-6 text-sm">
     <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
@@ -47,7 +60,7 @@ const verticalTabs = [
 
     <!-- Demo Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Demo</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
 
       <!-- Default (Automatic Activation) -->
       <div class="mb-8">
@@ -99,13 +112,13 @@ const verticalTabs = [
 
     <!-- Accessibility Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Accessibility Features</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
       <AccessibilityDocs />
     </section>
 
     <!-- Source Code Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
       <CodeBlock
         code={sourceCode}
         lang="tsx"
@@ -115,7 +128,7 @@ const verticalTabs = [
 
     <!-- Usage Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Usage</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
       <CodeBlock
         code={`import { Tabs } from './Tabs';
 
@@ -141,7 +154,7 @@ function App() {
 
     <!-- API Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">API</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
 
       <h3 class="text-lg font-medium mb-3">Tabs Props</h3>
       <ResponsiveTable class="mb-6">
@@ -202,9 +215,22 @@ function App() {
       />
     </section>
 
+    <!-- Testing Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
+      <TestingDocs />
+      <div class="mt-6">
+        <CodeBlock
+          code={testCode}
+          lang="tsx"
+          title="Tabs.test.tsx"
+        />
+      </div>
+    </section>
+
     <!-- Resources -->
     <section>
-      <h2 class="text-xl font-semibold mb-4">Resources</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
       <ul class="list-disc pl-6 space-y-2">
         <li>
           <ExternalLink

--- a/src/pages/patterns/tabs/svelte/index.astro
+++ b/src/pages/patterns/tabs/svelte/index.astro
@@ -4,10 +4,23 @@ import Tabs from '@patterns/tabs/Tabs.svelte';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
 import AccessibilityDocs from '@patterns/tabs/AccessibilityDocs.astro';
+import TestingDocs from '@patterns/tabs/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/tabs/Tabs.svelte?raw';
+import testCode from '@patterns/tabs/Tabs.test.svelte.ts?raw';
 import { withBase } from '@/lib/utils';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
 
 const demoTabs = [
   { id: 'tab1', label: 'Overview', content: 'This is the overview panel content. It provides a general introduction to the product or service.' },
@@ -28,7 +41,7 @@ const verticalTabs = [
 ];
 ---
 
-<PatternLayout title="Tabs - Svelte" pattern="tabs" framework="svelte">
+<PatternLayout title="Tabs - Svelte" pattern="tabs" framework="svelte" tocItems={tocItems}>
   <nav class="mb-6 text-sm">
     <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
@@ -47,7 +60,7 @@ const verticalTabs = [
 
     <!-- Demo Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Demo</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
 
       <!-- Default (Automatic Activation) -->
       <div class="mb-8">
@@ -99,13 +112,13 @@ const verticalTabs = [
 
     <!-- Accessibility Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Accessibility Features</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
       <AccessibilityDocs />
     </section>
 
     <!-- Source Code Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
       <CodeBlock
         code={sourceCode}
         lang="svelte"
@@ -115,7 +128,7 @@ const verticalTabs = [
 
     <!-- Usage Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Usage</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
       <CodeBlock
         code={`<script>
   import Tabs from './Tabs.svelte';
@@ -143,7 +156,7 @@ const verticalTabs = [
 
     <!-- API Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">API</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
 
       <h3 class="text-lg font-medium mb-3">Props</h3>
       <ResponsiveTable class="mb-6">
@@ -224,9 +237,22 @@ const verticalTabs = [
       />
     </section>
 
+    <!-- Testing Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
+      <TestingDocs />
+      <div class="mt-6">
+        <CodeBlock
+          code={testCode}
+          lang="typescript"
+          title="Tabs.test.svelte.ts"
+        />
+      </div>
+    </section>
+
     <!-- Resources -->
     <section>
-      <h2 class="text-xl font-semibold mb-4">Resources</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
       <ul class="list-disc pl-6 space-y-2">
         <li>
           <ExternalLink

--- a/src/pages/patterns/tabs/vue/index.astro
+++ b/src/pages/patterns/tabs/vue/index.astro
@@ -4,10 +4,23 @@ import Tabs from '@patterns/tabs/Tabs.vue';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
 import AccessibilityDocs from '@patterns/tabs/AccessibilityDocs.astro';
+import TestingDocs from '@patterns/tabs/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/tabs/Tabs.vue?raw';
+import testCode from '@patterns/tabs/Tabs.test.vue.ts?raw';
 import { withBase } from '@/lib/utils';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
 
 const demoTabs = [
   { id: 'tab1', label: 'Overview', content: 'This is the overview panel content. It provides a general introduction to the product or service.' },
@@ -28,7 +41,7 @@ const verticalTabs = [
 ];
 ---
 
-<PatternLayout title="Tabs - Vue" pattern="tabs" framework="vue">
+<PatternLayout title="Tabs - Vue" pattern="tabs" framework="vue" tocItems={tocItems}>
   <nav class="mb-6 text-sm">
     <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
@@ -47,7 +60,7 @@ const verticalTabs = [
 
     <!-- Demo Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Demo</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
 
       <!-- Default (Automatic Activation) -->
       <div class="mb-8">
@@ -99,13 +112,13 @@ const verticalTabs = [
 
     <!-- Accessibility Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Accessibility Features</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
       <AccessibilityDocs />
     </section>
 
     <!-- Source Code Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
       <CodeBlock
         code={sourceCode}
         lang="vue"
@@ -115,7 +128,7 @@ const verticalTabs = [
 
     <!-- Usage Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Usage</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
       <CodeBlock
         code={`<script setup>
 import Tabs from './Tabs.vue';
@@ -141,7 +154,7 @@ const tabs = [
 
     <!-- API Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">API</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
 
       <h3 class="text-lg font-medium mb-3">Props</h3>
       <ResponsiveTable class="mb-6">
@@ -222,9 +235,22 @@ const tabs = [
       />
     </section>
 
+    <!-- Testing Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
+      <TestingDocs />
+      <div class="mt-6">
+        <CodeBlock
+          code={testCode}
+          lang="typescript"
+          title="Tabs.test.vue.ts"
+        />
+      </div>
+    </section>
+
     <!-- Resources -->
     <section>
-      <h2 class="text-xl font-semibold mb-4">Resources</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
       <ul class="list-disc pl-6 space-y-2">
         <li>
           <ExternalLink

--- a/src/pages/patterns/toolbar/astro/index.astro
+++ b/src/pages/patterns/toolbar/astro/index.astro
@@ -9,14 +9,24 @@ import ExternalLink from '@/components/ui/ExternalLink.astro';
 import AccessibilityDocs from '@patterns/toolbar/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
 import toolbarSource from '@patterns/toolbar/Toolbar.astro?raw';
 import buttonSource from '@patterns/toolbar/ToolbarButton.astro?raw';
 import toggleSource from '@patterns/toolbar/ToolbarToggleButton.astro?raw';
 import separatorSource from '@patterns/toolbar/ToolbarSeparator.astro?raw';
 import { withBase } from '@/lib/utils';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility', text: 'Accessibility' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'resources', text: 'Resources' },
+];
 ---
 
-<PatternLayout title="Toolbar - Astro" pattern="toolbar" framework="astro">
+<PatternLayout title="Toolbar - Astro" pattern="toolbar" framework="astro" tocItems={tocItems}>
   <nav class="mb-6 text-sm">
     <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
@@ -35,7 +45,7 @@ import { withBase } from '@/lib/utils';
 
     <!-- Demo Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Demo</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
 
       <!-- Text Formatting Toolbar -->
       <div class="mb-8">
@@ -162,13 +172,13 @@ import { withBase } from '@/lib/utils';
 
     <!-- Accessibility Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Accessibility</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Accessibility</Heading>
       <AccessibilityDocs />
     </section>
 
     <!-- Source Code Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
       <div class="space-y-4">
         <CodeBlock code={toolbarSource} lang="astro" title="Toolbar.astro" />
         <CodeBlock code={buttonSource} lang="astro" title="ToolbarButton.astro" />
@@ -179,7 +189,7 @@ import { withBase } from '@/lib/utils';
 
     <!-- Usage Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Usage</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
       <CodeBlock
         code={`---
 import Toolbar from '@patterns/toolbar/Toolbar.astro';
@@ -210,7 +220,7 @@ import ToolbarSeparator from '@patterns/toolbar/ToolbarSeparator.astro';
 
     <!-- API Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">API</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
 
       <h3 class="text-lg font-medium mb-3">Toolbar Props</h3>
       <ResponsiveTable class="mb-6">
@@ -342,7 +352,7 @@ import ToolbarSeparator from '@patterns/toolbar/ToolbarSeparator.astro';
 
     <!-- Resources Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Resources</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
       <ul class="list-disc list-inside space-y-2">
         <li>
           <ExternalLink href="https://www.w3.org/WAI/ARIA/apg/patterns/toolbar/" class="text-primary hover:underline">

--- a/src/pages/patterns/toolbar/react/index.astro
+++ b/src/pages/patterns/toolbar/react/index.astro
@@ -12,11 +12,24 @@ import ExternalLink from '@/components/ui/ExternalLink.astro';
 import AccessibilityDocs from '@patterns/toolbar/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/toolbar/Toolbar.tsx?raw';
+import TestingDocs from '@patterns/toolbar/TestingDocs.astro';
+import testCode from '@patterns/toolbar/Toolbar.test.tsx?raw';
 import { withBase } from '@/lib/utils';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility', text: 'Accessibility' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
 ---
 
-<PatternLayout title="Toolbar - React" pattern="toolbar" framework="react">
+<PatternLayout title="Toolbar - React" pattern="toolbar" framework="react" tocItems={tocItems}>
   <nav class="mb-6 text-sm">
     <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
@@ -35,7 +48,7 @@ import { withBase } from '@/lib/utils';
 
     <!-- Demo Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Demo</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
 
       <!-- Text Formatting Toolbar -->
       <div class="mb-8">
@@ -95,19 +108,19 @@ import { withBase } from '@/lib/utils';
 
     <!-- Accessibility Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Accessibility</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Accessibility</Heading>
       <AccessibilityDocs />
     </section>
 
     <!-- Source Code Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
       <CodeBlock code={sourceCode} lang="tsx" title="Toolbar.tsx" />
     </section>
 
     <!-- Usage Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Usage</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
       <CodeBlock
         code={`import {
   Toolbar,
@@ -149,7 +162,7 @@ const [isBold, setIsBold] = useState(false);
 
     <!-- API Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">API</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
 
       <h3 class="text-lg font-medium mb-3">Toolbar Props</h3>
       <ResponsiveTable class="mb-6">
@@ -254,9 +267,22 @@ const [isBold, setIsBold] = useState(false);
       </ResponsiveTable>
     </section>
 
+    <!-- Testing Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
+      <TestingDocs />
+      <div class="mt-6">
+        <CodeBlock
+          code={testCode}
+          lang="tsx"
+          title="Toolbar.test.tsx"
+        />
+      </div>
+    </section>
+
     <!-- Resources Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Resources</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
       <ul class="list-disc list-inside space-y-2">
         <li>
           <ExternalLink href="https://www.w3.org/WAI/ARIA/apg/patterns/toolbar/" class="text-primary hover:underline">

--- a/src/pages/patterns/toolbar/svelte/index.astro
+++ b/src/pages/patterns/toolbar/svelte/index.astro
@@ -10,14 +10,27 @@ import ExternalLink from '@/components/ui/ExternalLink.astro';
 import AccessibilityDocs from '@patterns/toolbar/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
 import toolbarSource from '@patterns/toolbar/Toolbar.svelte?raw';
 import buttonSource from '@patterns/toolbar/ToolbarButton.svelte?raw';
 import toggleSource from '@patterns/toolbar/ToolbarToggleButton.svelte?raw';
 import separatorSource from '@patterns/toolbar/ToolbarSeparator.svelte?raw';
+import TestingDocs from '@patterns/toolbar/TestingDocs.astro';
+import testCode from '@patterns/toolbar/Toolbar.test.svelte.ts?raw';
 import { withBase } from '@/lib/utils';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility', text: 'Accessibility' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
 ---
 
-<PatternLayout title="Toolbar - Svelte" pattern="toolbar" framework="svelte">
+<PatternLayout title="Toolbar - Svelte" pattern="toolbar" framework="svelte" tocItems={tocItems}>
   <nav class="mb-6 text-sm">
     <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
@@ -36,7 +49,7 @@ import { withBase } from '@/lib/utils';
 
     <!-- Demo Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Demo</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
 
       <!-- Text Formatting Toolbar -->
       <div class="mb-8">
@@ -96,13 +109,13 @@ import { withBase } from '@/lib/utils';
 
     <!-- Accessibility Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Accessibility</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Accessibility</Heading>
       <AccessibilityDocs />
     </section>
 
     <!-- Source Code Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
       <div class="space-y-4">
         <CodeBlock code={toolbarSource} lang="svelte" title="Toolbar.svelte" />
         <CodeBlock code={buttonSource} lang="svelte" title="ToolbarButton.svelte" />
@@ -113,7 +126,7 @@ import { withBase } from '@/lib/utils';
 
     <!-- Usage Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Usage</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
       <CodeBlock
         code={`<script>
   import Toolbar from '@patterns/toolbar/Toolbar.svelte';
@@ -135,7 +148,7 @@ import { withBase } from '@/lib/utils';
 
     <!-- API Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">API</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
 
       <h3 class="text-lg font-medium mb-3">Toolbar Props</h3>
       <ResponsiveTable class="mb-6">
@@ -194,9 +207,22 @@ import { withBase } from '@/lib/utils';
       </ResponsiveTable>
     </section>
 
+    <!-- Testing Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
+      <TestingDocs />
+      <div class="mt-6">
+        <CodeBlock
+          code={testCode}
+          lang="typescript"
+          title="Toolbar.test.svelte.ts"
+        />
+      </div>
+    </section>
+
     <!-- Resources Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Resources</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
       <ul class="list-disc list-inside space-y-2">
         <li>
           <ExternalLink href="https://www.w3.org/WAI/ARIA/apg/patterns/toolbar/" class="text-primary hover:underline">

--- a/src/pages/patterns/toolbar/vue/index.astro
+++ b/src/pages/patterns/toolbar/vue/index.astro
@@ -10,14 +10,27 @@ import ExternalLink from '@/components/ui/ExternalLink.astro';
 import AccessibilityDocs from '@patterns/toolbar/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
 import toolbarSource from '@patterns/toolbar/Toolbar.vue?raw';
 import buttonSource from '@patterns/toolbar/ToolbarButton.vue?raw';
 import toggleSource from '@patterns/toolbar/ToolbarToggleButton.vue?raw';
 import separatorSource from '@patterns/toolbar/ToolbarSeparator.vue?raw';
+import TestingDocs from '@patterns/toolbar/TestingDocs.astro';
+import testCode from '@patterns/toolbar/Toolbar.test.vue.ts?raw';
 import { withBase } from '@/lib/utils';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility', text: 'Accessibility' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
 ---
 
-<PatternLayout title="Toolbar - Vue" pattern="toolbar" framework="vue">
+<PatternLayout title="Toolbar - Vue" pattern="toolbar" framework="vue" tocItems={tocItems}>
   <nav class="mb-6 text-sm">
     <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
     <span class="mx-2 text-muted-foreground">/</span>
@@ -36,7 +49,7 @@ import { withBase } from '@/lib/utils';
 
     <!-- Demo Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Demo</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
 
       <!-- Text Formatting Toolbar -->
       <div class="mb-8">
@@ -96,13 +109,13 @@ import { withBase } from '@/lib/utils';
 
     <!-- Accessibility Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Accessibility</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Accessibility</Heading>
       <AccessibilityDocs />
     </section>
 
     <!-- Source Code Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Source Code</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
       <div class="space-y-4">
         <CodeBlock code={toolbarSource} lang="vue" title="Toolbar.vue" />
         <CodeBlock code={buttonSource} lang="vue" title="ToolbarButton.vue" />
@@ -113,7 +126,7 @@ import { withBase } from '@/lib/utils';
 
     <!-- Usage Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Usage</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
       <CodeBlock
         code={`<script setup>
 import Toolbar from '@patterns/toolbar/Toolbar.vue'
@@ -137,7 +150,7 @@ import ToolbarSeparator from '@patterns/toolbar/ToolbarSeparator.vue'
 
     <!-- API Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">API</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
 
       <h3 class="text-lg font-medium mb-3">Toolbar Props</h3>
       <ResponsiveTable class="mb-6">
@@ -187,9 +200,22 @@ import ToolbarSeparator from '@patterns/toolbar/ToolbarSeparator.vue'
       </ResponsiveTable>
     </section>
 
+    <!-- Testing Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
+      <TestingDocs />
+      <div class="mt-6">
+        <CodeBlock
+          code={testCode}
+          lang="typescript"
+          title="Toolbar.test.vue.ts"
+        />
+      </div>
+    </section>
+
     <!-- Resources Section -->
     <section class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Resources</h2>
+      <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
       <ul class="list-disc list-inside space-y-2">
         <li>
           <ExternalLink href="https://www.w3.org/WAI/ARIA/apg/patterns/toolbar/" class="text-primary hover:underline">

--- a/src/patterns/accordion/TestingDocs.astro
+++ b/src/patterns/accordion/TestingDocs.astro
@@ -1,0 +1,193 @@
+---
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+---
+
+<div class="prose dark:prose-invert max-w-none">
+  <p class="text-muted-foreground mb-4">
+    Tests verify APG compliance across keyboard interaction, ARIA attributes, and accessibility requirements.
+  </p>
+
+  <h3 class="text-lg font-medium mb-3">Test Categories</h3>
+
+  <h4 class="font-medium mb-2 flex items-center gap-2">
+    <span class="inline-block w-3 h-3 rounded-full bg-red-500"></span>
+    High Priority: APG Keyboard Interaction
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Test</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Enter key</code></td>
+          <td class="py-2">Expands/collapses the focused panel</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Space key</code></td>
+          <td class="py-2">Expands/collapses the focused panel</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>ArrowDown</code></td>
+          <td class="py-2">Moves focus to next header</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>ArrowUp</code></td>
+          <td class="py-2">Moves focus to previous header</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Home</code></td>
+          <td class="py-2">Moves focus to first header</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>End</code></td>
+          <td class="py-2">Moves focus to last header</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>No loop</code></td>
+          <td class="py-2">Focus stops at edges (no wrapping)</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Disabled skip</code></td>
+          <td class="py-2">Skips disabled headers during navigation</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="font-medium mb-2 flex items-center gap-2">
+    <span class="inline-block w-3 h-3 rounded-full bg-red-500"></span>
+    High Priority: APG ARIA Attributes
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Test</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>aria-expanded</code></td>
+          <td class="py-2">Header button reflects expand/collapse state</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>aria-controls</code></td>
+          <td class="py-2">Header references its panel via aria-controls</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>aria-labelledby</code></td>
+          <td class="py-2">Panel references its header via aria-labelledby</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>role="region"</code></td>
+          <td class="py-2">Panel has region role (6 or fewer panels)</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>No region (7+)</code></td>
+          <td class="py-2">Panel omits region role when 7+ panels</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>aria-disabled</code></td>
+          <td class="py-2">Disabled items have aria-disabled="true"</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="font-medium mb-2 flex items-center gap-2">
+    <span class="inline-block w-3 h-3 rounded-full bg-red-500"></span>
+    High Priority: Heading Structure
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Test</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>headingLevel prop</code></td>
+          <td class="py-2">Uses correct heading element (h2, h3, etc.)</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="font-medium mb-2 flex items-center gap-2">
+    <span class="inline-block w-3 h-3 rounded-full bg-yellow-500"></span>
+    Medium Priority: Accessibility
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Test</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>axe violations</code></td>
+          <td class="py-2">No WCAG 2.1 AA violations (via jest-axe)</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="font-medium mb-2 flex items-center gap-2">
+    <span class="inline-block w-3 h-3 rounded-full bg-green-500"></span>
+    Low Priority: Props & Behavior
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Test</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>allowMultiple</code></td>
+          <td class="py-2">Controls single vs. multiple expansion</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>defaultExpanded</code></td>
+          <td class="py-2">Sets initial expansion state</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>className</code></td>
+          <td class="py-2">Custom classes are applied</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h3 class="text-lg font-medium mb-3">Testing Tools</h3>
+  <ul class="list-disc pl-6 mb-6 space-y-2">
+    <li>
+      <ExternalLink href="https://vitest.dev/" class="text-primary hover:underline">Vitest</ExternalLink>
+      - Test runner
+    </li>
+    <li>
+      <ExternalLink href="https://testing-library.com/" class="text-primary hover:underline">Testing Library</ExternalLink>
+      - Framework-specific testing utilities
+    </li>
+    <li>
+      <ExternalLink href="https://github.com/nickcolley/jest-axe" class="text-primary hover:underline">jest-axe</ExternalLink>
+      - Automated accessibility testing
+    </li>
+  </ul>
+
+  <p class="text-sm text-muted-foreground">
+    See <ExternalLink href="https://github.com/masuP9/apg-patterns-examples/blob/main/.internal/testing-strategy.md" class="text-primary hover:underline">testing-strategy.md</ExternalLink> for full documentation.
+  </p>
+</div>

--- a/src/patterns/dialog/TestingDocs.astro
+++ b/src/patterns/dialog/TestingDocs.astro
@@ -1,0 +1,169 @@
+---
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+---
+
+<div class="prose dark:prose-invert max-w-none">
+  <p class="text-muted-foreground mb-4">
+    Tests verify APG compliance across keyboard interaction, ARIA attributes, and accessibility requirements.
+  </p>
+
+  <h3 class="text-lg font-medium mb-3">Test Categories</h3>
+
+  <h4 class="font-medium mb-2 flex items-center gap-2">
+    <span class="inline-block w-3 h-3 rounded-full bg-red-500"></span>
+    High Priority: APG Keyboard Interaction
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Test</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Escape key</code></td>
+          <td class="py-2">Closes the dialog</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="font-medium mb-2 flex items-center gap-2">
+    <span class="inline-block w-3 h-3 rounded-full bg-red-500"></span>
+    High Priority: APG ARIA Attributes
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Test</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>role="dialog"</code></td>
+          <td class="py-2">Dialog element has dialog role</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>aria-modal="true"</code></td>
+          <td class="py-2">Indicates modal behavior</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>aria-labelledby</code></td>
+          <td class="py-2">References the dialog title</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>aria-describedby</code></td>
+          <td class="py-2">References description (when provided)</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="font-medium mb-2 flex items-center gap-2">
+    <span class="inline-block w-3 h-3 rounded-full bg-red-500"></span>
+    High Priority: Focus Management
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Test</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Initial focus</code></td>
+          <td class="py-2">Focus moves to first focusable element on open</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Focus restore</code></td>
+          <td class="py-2">Focus returns to trigger on close</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Focus trap</code></td>
+          <td class="py-2">Tab cycling stays within dialog (via native dialog)</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="font-medium mb-2 flex items-center gap-2">
+    <span class="inline-block w-3 h-3 rounded-full bg-yellow-500"></span>
+    Medium Priority: Accessibility
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Test</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>axe violations</code></td>
+          <td class="py-2">No WCAG 2.1 AA violations (via jest-axe)</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="font-medium mb-2 flex items-center gap-2">
+    <span class="inline-block w-3 h-3 rounded-full bg-green-500"></span>
+    Low Priority: Props & Behavior
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Test</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>closeOnOverlayClick</code></td>
+          <td class="py-2">Controls overlay click behavior</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>defaultOpen</code></td>
+          <td class="py-2">Initial open state</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>onOpenChange</code></td>
+          <td class="py-2">Callback fires on open/close</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>className</code></td>
+          <td class="py-2">Custom classes are applied</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h3 class="text-lg font-medium mb-3">Testing Tools</h3>
+  <ul class="list-disc pl-6 mb-6 space-y-2">
+    <li>
+      <ExternalLink href="https://vitest.dev/" class="text-primary hover:underline">Vitest</ExternalLink>
+      - Test runner
+    </li>
+    <li>
+      <ExternalLink href="https://testing-library.com/" class="text-primary hover:underline">Testing Library</ExternalLink>
+      - Framework-specific testing utilities
+    </li>
+    <li>
+      <ExternalLink href="https://github.com/nickcolley/jest-axe" class="text-primary hover:underline">jest-axe</ExternalLink>
+      - Automated accessibility testing
+    </li>
+  </ul>
+
+  <p class="text-sm text-muted-foreground">
+    See <ExternalLink href="https://github.com/masuP9/apg-patterns-examples/blob/main/.internal/testing-strategy.md" class="text-primary hover:underline">testing-strategy.md</ExternalLink> for full documentation.
+  </p>
+</div>

--- a/src/patterns/switch/TestingDocs.astro
+++ b/src/patterns/switch/TestingDocs.astro
@@ -1,0 +1,164 @@
+---
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+---
+
+<div class="prose dark:prose-invert max-w-none">
+  <p class="text-muted-foreground mb-4">
+    Tests verify APG compliance across keyboard interaction, ARIA attributes, and accessibility requirements.
+  </p>
+
+  <h3 class="text-lg font-medium mb-3">Test Categories</h3>
+
+  <h4 class="font-medium mb-2 flex items-center gap-2">
+    <span class="inline-block w-3 h-3 rounded-full bg-red-500"></span>
+    High Priority: APG Keyboard Interaction
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Test</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Space key</code></td>
+          <td class="py-2">Toggles the switch state</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Enter key</code></td>
+          <td class="py-2">Toggles the switch state</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Tab navigation</code></td>
+          <td class="py-2">Tab moves focus between switches</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Disabled Tab skip</code></td>
+          <td class="py-2">Disabled switches are skipped in Tab order</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Disabled key ignore</code></td>
+          <td class="py-2">Disabled switches ignore key presses</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="font-medium mb-2 flex items-center gap-2">
+    <span class="inline-block w-3 h-3 rounded-full bg-red-500"></span>
+    High Priority: APG ARIA Attributes
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Test</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>role="switch"</code></td>
+          <td class="py-2">Element has switch role</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>aria-checked initial</code></td>
+          <td class="py-2">Initial state is <code>aria-checked="false"</code></td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>aria-checked toggle</code></td>
+          <td class="py-2">Click changes <code>aria-checked</code> value</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>type="button"</code></td>
+          <td class="py-2">Explicit button type prevents form submission</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>aria-disabled</code></td>
+          <td class="py-2">Disabled switches have aria-disabled="true"</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="font-medium mb-2 flex items-center gap-2">
+    <span class="inline-block w-3 h-3 rounded-full bg-yellow-500"></span>
+    Medium Priority: Accessibility
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Test</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>axe violations</code></td>
+          <td class="py-2">No WCAG 2.1 AA violations (via jest-axe)</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Accessible name (children)</code></td>
+          <td class="py-2">Switch has name from children content</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>aria-label</code></td>
+          <td class="py-2">Accessible name via aria-label</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>aria-labelledby</code></td>
+          <td class="py-2">Accessible name via external element</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="font-medium mb-2 flex items-center gap-2">
+    <span class="inline-block w-3 h-3 rounded-full bg-green-500"></span>
+    Low Priority: HTML Attribute Inheritance
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Test</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>className merge</code></td>
+          <td class="py-2">Custom classes are merged with component classes</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>data-* attributes</code></td>
+          <td class="py-2">Custom data attributes are passed through</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h3 class="text-lg font-medium mb-3">Testing Tools</h3>
+  <ul class="list-disc pl-6 mb-6 space-y-2">
+    <li>
+      <ExternalLink href="https://vitest.dev/" class="text-primary hover:underline">Vitest</ExternalLink>
+      - Test runner
+    </li>
+    <li>
+      <ExternalLink href="https://testing-library.com/" class="text-primary hover:underline">Testing Library</ExternalLink>
+      - Framework-specific testing utilities
+    </li>
+    <li>
+      <ExternalLink href="https://github.com/nickcolley/jest-axe" class="text-primary hover:underline">jest-axe</ExternalLink>
+      - Automated accessibility testing
+    </li>
+  </ul>
+
+  <p class="text-sm text-muted-foreground">
+    See <ExternalLink href="https://github.com/masuP9/apg-patterns-examples/blob/main/.internal/testing-strategy.md" class="text-primary hover:underline">testing-strategy.md</ExternalLink> for full documentation.
+  </p>
+</div>

--- a/src/patterns/tabs/TestingDocs.astro
+++ b/src/patterns/tabs/TestingDocs.astro
@@ -1,0 +1,176 @@
+---
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+---
+
+<div class="prose dark:prose-invert max-w-none">
+  <p class="text-muted-foreground mb-4">
+    Tests verify APG compliance across keyboard interaction, ARIA attributes, and accessibility requirements.
+  </p>
+
+  <h3 class="text-lg font-medium mb-3">Test Categories</h3>
+
+  <h4 class="font-medium mb-2 flex items-center gap-2">
+    <span class="inline-block w-3 h-3 rounded-full bg-red-500"></span>
+    High Priority: APG Keyboard Interaction
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Test</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>ArrowRight/Left</code></td>
+          <td class="py-2">Moves focus between tabs (horizontal)</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>ArrowDown/Up</code></td>
+          <td class="py-2">Moves focus between tabs (vertical orientation)</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Home/End</code></td>
+          <td class="py-2">Moves focus to first/last tab</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Loop navigation</code></td>
+          <td class="py-2">Arrow keys loop from last to first and vice versa</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Disabled skip</code></td>
+          <td class="py-2">Skips disabled tabs during navigation</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Automatic activation</code></td>
+          <td class="py-2">Tab panel changes on focus (default mode)</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Manual activation</code></td>
+          <td class="py-2">Enter/Space required to activate tab</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="font-medium mb-2 flex items-center gap-2">
+    <span class="inline-block w-3 h-3 rounded-full bg-red-500"></span>
+    High Priority: APG ARIA Attributes
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Test</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>role="tablist"</code></td>
+          <td class="py-2">Container has tablist role</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>role="tab"</code></td>
+          <td class="py-2">Each tab button has tab role</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>role="tabpanel"</code></td>
+          <td class="py-2">Content panel has tabpanel role</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>aria-selected</code></td>
+          <td class="py-2">Selected tab has <code>aria-selected="true"</code></td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>aria-controls</code></td>
+          <td class="py-2">Tab references its panel via aria-controls</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>aria-labelledby</code></td>
+          <td class="py-2">Panel references its tab via aria-labelledby</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>aria-orientation</code></td>
+          <td class="py-2">Reflects horizontal/vertical orientation</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="font-medium mb-2 flex items-center gap-2">
+    <span class="inline-block w-3 h-3 rounded-full bg-red-500"></span>
+    High Priority: Focus Management (Roving Tabindex)
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Test</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>tabIndex=0</code></td>
+          <td class="py-2">Selected tab has tabIndex=0</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>tabIndex=-1</code></td>
+          <td class="py-2">Non-selected tabs have tabIndex=-1</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Tab to panel</code></td>
+          <td class="py-2">Tab key moves focus from tablist to panel</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Panel focusable</code></td>
+          <td class="py-2">Panel has tabIndex=0 for focus</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="font-medium mb-2 flex items-center gap-2">
+    <span class="inline-block w-3 h-3 rounded-full bg-yellow-500"></span>
+    Medium Priority: Accessibility
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Test</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>axe violations</code></td>
+          <td class="py-2">No WCAG 2.1 AA violations (via jest-axe)</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h3 class="text-lg font-medium mb-3">Testing Tools</h3>
+  <ul class="list-disc pl-6 mb-6 space-y-2">
+    <li>
+      <ExternalLink href="https://vitest.dev/" class="text-primary hover:underline">Vitest</ExternalLink>
+      - Test runner
+    </li>
+    <li>
+      <ExternalLink href="https://testing-library.com/" class="text-primary hover:underline">Testing Library</ExternalLink>
+      - Framework-specific testing utilities
+    </li>
+    <li>
+      <ExternalLink href="https://github.com/nickcolley/jest-axe" class="text-primary hover:underline">jest-axe</ExternalLink>
+      - Automated accessibility testing
+    </li>
+  </ul>
+
+  <p class="text-sm text-muted-foreground">
+    See <ExternalLink href="https://github.com/masuP9/apg-patterns-examples/blob/main/.internal/testing-strategy.md" class="text-primary hover:underline">testing-strategy.md</ExternalLink> for full documentation.
+  </p>
+</div>

--- a/src/patterns/toolbar/TestingDocs.astro
+++ b/src/patterns/toolbar/TestingDocs.astro
@@ -1,0 +1,193 @@
+---
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+---
+
+<div class="prose dark:prose-invert max-w-none">
+  <p class="text-muted-foreground mb-4">
+    Tests verify APG compliance across keyboard interaction, ARIA attributes, and accessibility requirements.
+  </p>
+
+  <h3 class="text-lg font-medium mb-3">Test Categories</h3>
+
+  <h4 class="font-medium mb-2 flex items-center gap-2">
+    <span class="inline-block w-3 h-3 rounded-full bg-red-500"></span>
+    High Priority: APG Keyboard Interaction
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Test</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>ArrowRight/Left</code></td>
+          <td class="py-2">Moves focus between items (horizontal)</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>ArrowDown/Up</code></td>
+          <td class="py-2">Moves focus between items (vertical)</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Home</code></td>
+          <td class="py-2">Moves focus to first item</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>End</code></td>
+          <td class="py-2">Moves focus to last item</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>No wrap</code></td>
+          <td class="py-2">Focus stops at edges (no looping)</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Disabled skip</code></td>
+          <td class="py-2">Skips disabled items during navigation</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Enter/Space</code></td>
+          <td class="py-2">Activates button or toggles toggle button</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="font-medium mb-2 flex items-center gap-2">
+    <span class="inline-block w-3 h-3 rounded-full bg-red-500"></span>
+    High Priority: APG ARIA Attributes
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Test</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>role="toolbar"</code></td>
+          <td class="py-2">Container has toolbar role</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>aria-orientation</code></td>
+          <td class="py-2">Reflects horizontal/vertical orientation</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>aria-label/labelledby</code></td>
+          <td class="py-2">Toolbar has accessible name</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>aria-pressed</code></td>
+          <td class="py-2">Toggle buttons reflect pressed state</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>role="separator"</code></td>
+          <td class="py-2">Separator has correct role and orientation</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>type="button"</code></td>
+          <td class="py-2">Buttons have explicit type attribute</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="font-medium mb-2 flex items-center gap-2">
+    <span class="inline-block w-3 h-3 rounded-full bg-red-500"></span>
+    High Priority: Focus Management (Roving Tabindex)
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Test</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>tabIndex=0</code></td>
+          <td class="py-2">First enabled item has tabIndex=0</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>tabIndex=-1</code></td>
+          <td class="py-2">Other items have tabIndex=-1</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Click updates focus</code></td>
+          <td class="py-2">Clicking an item updates roving focus position</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="font-medium mb-2 flex items-center gap-2">
+    <span class="inline-block w-3 h-3 rounded-full bg-yellow-500"></span>
+    Medium Priority: Accessibility
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Test</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>axe violations</code></td>
+          <td class="py-2">No WCAG 2.1 AA violations (via jest-axe)</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>Vertical toolbar</code></td>
+          <td class="py-2">Vertical orientation also passes axe</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="font-medium mb-2 flex items-center gap-2">
+    <span class="inline-block w-3 h-3 rounded-full bg-green-500"></span>
+    Low Priority: HTML Attribute Inheritance
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Test</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>className</code></td>
+          <td class="py-2">Custom classes applied to all components</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h3 class="text-lg font-medium mb-3">Testing Tools</h3>
+  <ul class="list-disc pl-6 mb-6 space-y-2">
+    <li>
+      <ExternalLink href="https://vitest.dev/" class="text-primary hover:underline">Vitest</ExternalLink>
+      - Test runner
+    </li>
+    <li>
+      <ExternalLink href="https://testing-library.com/" class="text-primary hover:underline">Testing Library</ExternalLink>
+      - Framework-specific testing utilities
+    </li>
+    <li>
+      <ExternalLink href="https://github.com/nickcolley/jest-axe" class="text-primary hover:underline">jest-axe</ExternalLink>
+      - Automated accessibility testing
+    </li>
+  </ul>
+
+  <p class="text-sm text-muted-foreground">
+    See <ExternalLink href="https://github.com/masuP9/apg-patterns-examples/blob/main/.internal/testing-strategy.md" class="text-primary hover:underline">testing-strategy.md</ExternalLink> for full documentation.
+  </p>
+</div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -136,6 +136,12 @@
     font-family: system-ui, -apple-system, sans-serif;
     @apply bg-background text-foreground;
   }
+
+  /* Scroll margin for headings with anchors (prevents header overlap) */
+  h2[id],
+  h3[id] {
+    scroll-margin-top: 5rem;
+  }
 }
 
 /* Skip link for accessibility */


### PR DESCRIPTION
 ## Summary

  - Add Table of Contents (TOC) to pattern detail pages
  - Add Testing sections with TestingDocs to all pattern pages (except Astro)

  ## Changes

  ### Table of Contents
  - New `TableOfContents` component with scroll-based active section highlight
  - New `Heading` component with auto-generated slug IDs
  - Desktop (xl+): 3-column layout with sticky TOC on right
  - Mobile: TOC hidden (desktop only)
  - Both sidebars (pattern nav + TOC) now sticky on scroll

  ### Testing Sections
  - Add `TestingDocs.astro` for tabs, accordion, dialog, toolbar, switch patterns
  - Add Testing sections to all React/Vue/Svelte pattern pages
  - Astro pages excluded (no unit tests for Web Components)

  ### Layout Improvements
  - Increase gap between columns for better readability
  - Add `scroll-margin-top` to headings for header overlap prevention
  - Fix scroll listener duplication on page transitions
  - Add `aria-current` for active TOC link (accessibility)

  ## Test plan
  - [ ] Verify TOC appears on desktop (xl+)
  - [ ] Verify TOC highlights active section while scrolling
  - [ ] Verify clicking TOC links scrolls to correct heading
  - [ ] Verify sidebars are sticky on scroll
  - [ ] Verify Testing sections appear on React/Vue/Svelte pages
  - [ ] Run `npm run build` to ensure no build errors