### PR TITLE
feat: add PatternBreadcrumb component with dropdown navigation

### DIFF
--- a/src/components/ui/pattern-breadcrumb/PatternBreadcrumb.astro
+++ b/src/components/ui/pattern-breadcrumb/PatternBreadcrumb.astro
@@ -1,0 +1,114 @@
+---
+import {
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsibleContent,
+} from "@/components/ui/collapsible";
+import { type Framework } from "@/lib/frameworks";
+import { getAvailablePatterns, getPatternById } from "@/lib/patterns";
+import { withBase } from "@/lib/utils";
+import ChevronDownIcon from "lucide-static/icons/chevron-down.svg";
+
+interface Props {
+  pattern: string;
+  framework: Framework;
+}
+
+const { pattern, framework } = Astro.props;
+const availablePatterns = getAvailablePatterns();
+const currentPattern = getPatternById(pattern);
+---
+
+<nav aria-label="Breadcrumb" class="mb-6 text-sm">
+  <ol class="flex items-center">
+    <li class="relative">
+      <Collapsible class="inline-block">
+        <CollapsibleTrigger
+          class="inline-flex items-center gap-1 text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+          showChevron={false}
+        >
+          <span>Patterns</span>
+          <ChevronDownIcon class="size-4 translate-y-px transition-transform duration-200 group-open/collapsible:rotate-180" />
+        </CollapsibleTrigger>
+        <CollapsibleContent class="absolute left-0 z-10 mt-2 w-56 border border-border rounded-lg bg-background shadow-lg max-h-80 overflow-y-auto">
+          <a
+            href={withBase("/patterns/")}
+            class="flex items-center gap-2 px-4 py-2 text-sm rounded-t-lg hover:bg-muted/50 focus:bg-muted focus:ring-2 focus:ring-inset focus:ring-primary focus:outline-none transition-colors"
+          >
+            <span class="text-base" aria-hidden="true">📚</span>
+            <span>All patterns</span>
+          </a>
+          <hr class="border-border" />
+          <ul class="py-1">
+            {availablePatterns.map((p) => (
+              <li>
+                <a
+                  href={withBase(`/patterns/${p.id}/${framework}/`)}
+                  class:list={[
+                    "flex items-center gap-2 px-4 py-2 text-sm hover:bg-muted/50 focus:bg-muted focus:ring-2 focus:ring-inset focus:ring-primary focus:outline-none transition-colors",
+                    pattern === p.id && "bg-muted font-medium",
+                  ]}
+                  aria-current={pattern === p.id ? "page" : undefined}
+                >
+                  <span class="text-base" aria-hidden="true">{p.icon}</span>
+                  <span>{p.name}</span>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </CollapsibleContent>
+      </Collapsible>
+    </li>
+    <li aria-hidden="true" class="mx-2 text-muted-foreground">/</li>
+    <li aria-current="page">{currentPattern?.name}</li>
+  </ol>
+</nav>
+
+<script>
+  // Close dropdown when clicking outside
+  document.addEventListener("click", (e) => {
+    const details = document.querySelectorAll(
+      'nav[aria-label="Breadcrumb"] details[open]'
+    );
+    details.forEach((detail) => {
+      if (!detail.contains(e.target as Node)) {
+        detail.removeAttribute("open");
+      }
+    });
+  });
+
+  // Keyboard navigation for dropdown
+  document.addEventListener("keydown", (e) => {
+    const openDetails = document.querySelector(
+      'nav[aria-label="Breadcrumb"] details[open]'
+    );
+
+    // Close dropdown when pressing Escape
+    if (e.key === "Escape" && openDetails) {
+      openDetails.removeAttribute("open");
+      const summary = openDetails.querySelector("summary");
+      summary?.focus();
+      return;
+    }
+
+    // Arrow key navigation within dropdown
+    if ((e.key === "ArrowDown" || e.key === "ArrowUp") && openDetails) {
+      const links = Array.from(
+        openDetails.querySelectorAll<HTMLAnchorElement>("a")
+      );
+      if (links.length === 0) return;
+
+      const currentIndex = links.findIndex((link) => link === document.activeElement);
+
+      let nextIndex: number;
+      if (e.key === "ArrowDown") {
+        nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % links.length;
+      } else {
+        nextIndex = currentIndex < 0 ? links.length - 1 : (currentIndex - 1 + links.length) % links.length;
+      }
+
+      links[nextIndex]?.focus();
+      e.preventDefault();
+    }
+  });
+</script>

--- a/src/components/ui/pattern-breadcrumb/index.ts
+++ b/src/components/ui/pattern-breadcrumb/index.ts
@@ -1,0 +1,1 @@
+export { default as PatternBreadcrumb } from "./PatternBreadcrumb.astro";

--- a/src/layouts/PatternLayout.astro
+++ b/src/layouts/PatternLayout.astro
@@ -1,15 +1,9 @@
 ---
 import BaseLayout from "./BaseLayout.astro";
 import { PatternSidebar } from "@/components/ui/pattern-sidebar";
-import { FRAMEWORK_INFO, type Framework } from "@/lib/frameworks";
-import { getAvailablePatterns } from "@/lib/patterns";
-import {
-  Collapsible,
-  CollapsibleTrigger,
-  CollapsibleContent,
-} from "@/components/ui/collapsible";
+import { PatternBreadcrumb } from "@/components/ui/pattern-breadcrumb";
+import { type Framework } from "@/lib/frameworks";
 import { TableOfContents, type TocItem } from "@/components/ui/toc";
-import { withBase } from "@/lib/utils";
 
 interface Props {
   title: string;
@@ -20,9 +14,6 @@ interface Props {
 }
 
 const { title, description, pattern, framework, tocItems = [] } = Astro.props;
-const availablePatterns = getAvailablePatterns();
-const currentPatternData = availablePatterns.find((p) => p.id === pattern);
-const frameworkLabel = FRAMEWORK_INFO[framework].label;
 const hasToc = tocItems.length > 0;
 ---
 
@@ -43,39 +34,8 @@ const hasToc = tocItems.length > 0;
 
       <!-- Main content -->
       <div class="max-w-4xl min-w-0">
-        <!-- Mobile pattern navigation -->
-        <div class="lg:hidden mb-6">
-          <Collapsible class="border border-border rounded-lg">
-            <CollapsibleTrigger class="w-full px-4 py-3 text-left hover:bg-muted/50 rounded-lg">
-              <span class="text-base" aria-hidden="true">{currentPatternData?.icon}</span>
-              <span class="font-medium">{currentPatternData?.name}</span>
-              <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-primary/10 text-primary">
-                {frameworkLabel}
-              </span>
-            </CollapsibleTrigger>
-            <CollapsibleContent class="border-t border-border">
-              <nav aria-label="Pattern navigation" class="py-2">
-                <ul class="space-y-1">
-                  {availablePatterns.map((p) => (
-                    <li>
-                      <a
-                        href={withBase(`/patterns/${p.id}/${framework}/`)}
-                        class:list={[
-                          "flex items-center gap-2 px-4 py-2 text-sm hover:bg-muted/50 transition-colors",
-                          pattern === p.id && "bg-muted font-medium"
-                        ]}
-                        aria-current={pattern === p.id ? "page" : undefined}
-                      >
-                        <span class="text-base" aria-hidden="true">{p.icon}</span>
-                        <span>{p.name}</span>
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </nav>
-            </CollapsibleContent>
-          </Collapsible>
-        </div>
+        <!-- Pattern breadcrumb with dropdown -->
+        <PatternBreadcrumb pattern={pattern} framework={framework} />
 
         <slot />
       </div>

--- a/src/pages/patterns/accordion/astro/index.astro
+++ b/src/pages/patterns/accordion/astro/index.astro
@@ -8,7 +8,6 @@ import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/accordion/Accordion.astro?raw';
-import { withBase } from '@/lib/utils';
 
 const tocItems = [
   { id: 'demo', text: 'Demo' },
@@ -78,12 +77,6 @@ const disabledItems = [
 ---
 
 <PatternLayout title="Accordion - Astro" pattern="accordion" framework="astro" tocItems={tocItems}>
-    <nav class="mb-6 text-sm">
-      <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
-      <span class="mx-2 text-muted-foreground">/</span>
-      <span>Accordion</span>
-    </nav>
-
     <header class="mb-8">
       <h1 class="text-3xl font-bold mb-4">Accordion</h1>
       <p class="text-lg text-muted-foreground">

--- a/src/pages/patterns/accordion/react/index.astro
+++ b/src/pages/patterns/accordion/react/index.astro
@@ -10,7 +10,6 @@ import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/accordion/Accordion.tsx?raw';
 import testCode from '@patterns/accordion/Accordion.test.tsx?raw';
-import { withBase } from '@/lib/utils';
 
 const tocItems = [
   { id: 'demo', text: 'Demo' },
@@ -80,12 +79,6 @@ const disabledItems = [
 ---
 
 <PatternLayout title="Accordion - React" pattern="accordion" framework="react" tocItems={tocItems}>
-    <nav class="mb-6 text-sm">
-      <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
-      <span class="mx-2 text-muted-foreground">/</span>
-      <span>Accordion</span>
-    </nav>
-
     <header class="mb-8">
       <h1 class="text-3xl font-bold mb-4">Accordion</h1>
       <p class="text-lg text-muted-foreground">

--- a/src/pages/patterns/accordion/svelte/index.astro
+++ b/src/pages/patterns/accordion/svelte/index.astro
@@ -10,7 +10,6 @@ import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/accordion/Accordion.svelte?raw';
 import TestingDocs from '@patterns/accordion/TestingDocs.astro';
 import testCode from '@patterns/accordion/Accordion.test.svelte.ts?raw';
-import { withBase } from '@/lib/utils';
 
 const tocItems = [
   { id: 'demo', text: 'Demo' },
@@ -80,12 +79,6 @@ const disabledItems = [
 ---
 
 <PatternLayout title="Accordion - Svelte" pattern="accordion" framework="svelte" tocItems={tocItems}>
-    <nav class="mb-6 text-sm">
-      <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
-      <span class="mx-2 text-muted-foreground">/</span>
-      <span>Accordion</span>
-    </nav>
-
     <header class="mb-8">
       <h1 class="text-3xl font-bold mb-4">Accordion</h1>
       <p class="text-lg text-muted-foreground">

--- a/src/pages/patterns/accordion/vue/index.astro
+++ b/src/pages/patterns/accordion/vue/index.astro
@@ -10,7 +10,6 @@ import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/accordion/Accordion.vue?raw';
 import TestingDocs from '@patterns/accordion/TestingDocs.astro';
 import testCode from '@patterns/accordion/Accordion.test.vue.ts?raw';
-import { withBase } from '@/lib/utils';
 
 const tocItems = [
   { id: 'demo', text: 'Demo' },
@@ -80,12 +79,6 @@ const disabledItems = [
 ---
 
 <PatternLayout title="Accordion - Vue" pattern="accordion" framework="vue" tocItems={tocItems}>
-    <nav class="mb-6 text-sm">
-      <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
-      <span class="mx-2 text-muted-foreground">/</span>
-      <span>Accordion</span>
-    </nav>
-
     <header class="mb-8">
       <h1 class="text-3xl font-bold mb-4">Accordion</h1>
       <p class="text-lg text-muted-foreground">

--- a/src/pages/patterns/button/astro/index.astro
+++ b/src/pages/patterns/button/astro/index.astro
@@ -9,7 +9,6 @@ import AccessibilityDocs from "@patterns/button/AccessibilityDocs.astro";
 import FrameworkTabs from "@/components/ui/FrameworkTabs.astro";
 import { ResponsiveTable } from "@/components/ui/table";
 import sourceCode from "@patterns/button/ToggleButton.astro?raw";
-import { withBase } from "@/lib/utils";
 
 const tocItems = [
   { id: 'demo', text: 'Demo' },
@@ -22,12 +21,6 @@ const tocItems = [
 ---
 
 <PatternLayout title="Toggle Button - Astro" pattern="button" framework="astro" tocItems={tocItems}>
-  <nav class="mb-6 text-sm">
-    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
-    <span class="mx-2 text-muted-foreground">/</span>
-    <span>Toggle Button</span>
-  </nav>
-
     <header class="mb-8">
       <h1 class="text-3xl font-bold mb-4">Toggle Button</h1>
       <p class="text-lg text-muted-foreground">

--- a/src/pages/patterns/button/react/index.astro
+++ b/src/pages/patterns/button/react/index.astro
@@ -10,7 +10,6 @@ import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import sourceCode from '@patterns/button/ToggleButton.tsx?raw';
 import testCode from '@patterns/button/ToggleButton.test.tsx?raw';
-import { withBase } from '@/lib/utils';
 
 const tocItems = [
   { id: 'demo', text: 'Demo' },
@@ -24,12 +23,6 @@ const tocItems = [
 ---
 
 <PatternLayout title="Toggle Button - React" pattern="button" framework="react" tocItems={tocItems}>
-  <nav class="mb-6 text-sm">
-    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
-    <span class="mx-2 text-muted-foreground">/</span>
-    <span>Toggle Button</span>
-  </nav>
-
     <header class="mb-8">
       <h1 class="text-3xl font-bold mb-4">Toggle Button</h1>
       <p class="text-lg text-muted-foreground">

--- a/src/pages/patterns/button/svelte/index.astro
+++ b/src/pages/patterns/button/svelte/index.astro
@@ -10,7 +10,6 @@ import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import sourceCode from '@patterns/button/ToggleButton.svelte?raw';
 import testCode from '@patterns/button/ToggleButton.test.svelte.ts?raw';
-import { withBase } from '@/lib/utils';
 
 const tocItems = [
   { id: 'demo', text: 'Demo' },
@@ -24,12 +23,6 @@ const tocItems = [
 ---
 
 <PatternLayout title="Toggle Button - Svelte" pattern="button" framework="svelte" tocItems={tocItems}>
-  <nav class="mb-6 text-sm">
-    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
-    <span class="mx-2 text-muted-foreground">/</span>
-    <span>Toggle Button</span>
-  </nav>
-
     <header class="mb-8">
       <h1 class="text-3xl font-bold mb-4">Toggle Button</h1>
       <p class="text-lg text-muted-foreground">

--- a/src/pages/patterns/button/vue/index.astro
+++ b/src/pages/patterns/button/vue/index.astro
@@ -10,7 +10,6 @@ import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import sourceCode from '@patterns/button/ToggleButton.vue?raw';
 import testCode from '@patterns/button/ToggleButton.test.vue.ts?raw';
-import { withBase } from '@/lib/utils';
 
 const tocItems = [
   { id: 'demo', text: 'Demo' },
@@ -24,12 +23,6 @@ const tocItems = [
 ---
 
 <PatternLayout title="Toggle Button - Vue" pattern="button" framework="vue" tocItems={tocItems}>
-  <nav class="mb-6 text-sm">
-    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
-    <span class="mx-2 text-muted-foreground">/</span>
-    <span>Toggle Button</span>
-  </nav>
-
     <header class="mb-8">
       <h1 class="text-3xl font-bold mb-4">Toggle Button</h1>
       <p class="text-lg text-muted-foreground">

--- a/src/pages/patterns/dialog/astro/index.astro
+++ b/src/pages/patterns/dialog/astro/index.astro
@@ -20,12 +20,6 @@ const tocItems = [
 ---
 
 <PatternLayout title="Dialog - Astro" pattern="dialog" framework="astro" tocItems={tocItems}>
-  <nav class="mb-6 text-sm">
-    <a href="/patterns/" class="text-primary hover:underline">Patterns</a>
-    <span class="mx-2 text-muted-foreground">/</span>
-    <span>Dialog</span>
-  </nav>
-
   <header class="mb-8">
     <h1 class="text-3xl font-bold mb-4">Dialog (Modal)</h1>
     <p class="text-lg text-muted-foreground">

--- a/src/pages/patterns/dialog/react/index.astro
+++ b/src/pages/patterns/dialog/react/index.astro
@@ -23,12 +23,6 @@ const tocItems = [
 ---
 
 <PatternLayout title="Dialog - React" pattern="dialog" framework="react" tocItems={tocItems}>
-  <nav class="mb-6 text-sm">
-    <a href="/patterns/" class="text-primary hover:underline">Patterns</a>
-    <span class="mx-2 text-muted-foreground">/</span>
-    <span>Dialog</span>
-  </nav>
-
   <header class="mb-8">
     <h1 class="text-3xl font-bold mb-4">Dialog (Modal)</h1>
     <p class="text-lg text-muted-foreground">

--- a/src/pages/patterns/dialog/svelte/index.astro
+++ b/src/pages/patterns/dialog/svelte/index.astro
@@ -23,12 +23,6 @@ const tocItems = [
 ---
 
 <PatternLayout title="Dialog - Svelte" pattern="dialog" framework="svelte" tocItems={tocItems}>
-  <nav class="mb-6 text-sm">
-    <a href="/patterns/" class="text-primary hover:underline">Patterns</a>
-    <span class="mx-2 text-muted-foreground">/</span>
-    <span>Dialog</span>
-  </nav>
-
   <header class="mb-8">
     <h1 class="text-3xl font-bold mb-4">Dialog (Modal)</h1>
     <p class="text-lg text-muted-foreground">

--- a/src/pages/patterns/dialog/vue/index.astro
+++ b/src/pages/patterns/dialog/vue/index.astro
@@ -23,12 +23,6 @@ const tocItems = [
 ---
 
 <PatternLayout title="Dialog - Vue" pattern="dialog" framework="vue" tocItems={tocItems}>
-  <nav class="mb-6 text-sm">
-    <a href="/patterns/" class="text-primary hover:underline">Patterns</a>
-    <span class="mx-2 text-muted-foreground">/</span>
-    <span>Dialog</span>
-  </nav>
-
   <header class="mb-8">
     <h1 class="text-3xl font-bold mb-4">Dialog (Modal)</h1>
     <p class="text-lg text-muted-foreground">

--- a/src/pages/patterns/switch/astro/index.astro
+++ b/src/pages/patterns/switch/astro/index.astro
@@ -8,7 +8,6 @@ import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/switch/Switch.astro?raw';
-import { withBase } from '@/lib/utils';
 
 const tocItems = [
   { id: 'demo', text: 'Demo' },
@@ -21,12 +20,6 @@ const tocItems = [
 ---
 
 <PatternLayout title="Switch - Astro" pattern="switch" framework="astro" tocItems={tocItems}>
-  <nav class="mb-6 text-sm">
-    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
-    <span class="mx-2 text-muted-foreground">/</span>
-    <span>Switch</span>
-  </nav>
-
   <header class="mb-8">
     <h1 class="text-3xl font-bold mb-4">Switch</h1>
     <p class="text-lg text-muted-foreground">

--- a/src/pages/patterns/switch/react/index.astro
+++ b/src/pages/patterns/switch/react/index.astro
@@ -9,7 +9,6 @@ import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/switch/Switch.tsx?raw';
 import testCode from '@patterns/switch/Switch.test.tsx?raw';
-import { withBase } from '@/lib/utils';
 
 const tocItems = [
   { id: 'demo', text: 'Demo' },
@@ -23,12 +22,6 @@ const tocItems = [
 ---
 
 <PatternLayout title="Switch - React" pattern="switch" framework="react" tocItems={tocItems}>
-  <nav class="mb-6 text-sm">
-    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
-    <span class="mx-2 text-muted-foreground">/</span>
-    <span>Switch</span>
-  </nav>
-
   <header class="mb-8">
     <h1 class="text-3xl font-bold mb-4">Switch</h1>
     <p class="text-lg text-muted-foreground">

--- a/src/pages/patterns/switch/svelte/index.astro
+++ b/src/pages/patterns/switch/svelte/index.astro
@@ -9,7 +9,6 @@ import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/switch/Switch.svelte?raw';
 import testCode from '@patterns/switch/Switch.test.svelte.ts?raw';
-import { withBase } from '@/lib/utils';
 
 const tocItems = [
   { id: 'demo', text: 'Demo' },
@@ -23,12 +22,6 @@ const tocItems = [
 ---
 
 <PatternLayout title="Switch - Svelte" pattern="switch" framework="svelte" tocItems={tocItems}>
-  <nav class="mb-6 text-sm">
-    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
-    <span class="mx-2 text-muted-foreground">/</span>
-    <span>Switch</span>
-  </nav>
-
   <header class="mb-8">
     <h1 class="text-3xl font-bold mb-4">Switch</h1>
     <p class="text-lg text-muted-foreground">

--- a/src/pages/patterns/switch/vue/index.astro
+++ b/src/pages/patterns/switch/vue/index.astro
@@ -9,7 +9,6 @@ import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/switch/Switch.vue?raw';
 import testCode from '@patterns/switch/Switch.test.vue.ts?raw';
-import { withBase } from '@/lib/utils';
 
 const tocItems = [
   { id: 'demo', text: 'Demo' },
@@ -23,12 +22,6 @@ const tocItems = [
 ---
 
 <PatternLayout title="Switch - Vue" pattern="switch" framework="vue" tocItems={tocItems}>
-  <nav class="mb-6 text-sm">
-    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
-    <span class="mx-2 text-muted-foreground">/</span>
-    <span>Switch</span>
-  </nav>
-
   <header class="mb-8">
     <h1 class="text-3xl font-bold mb-4">Switch</h1>
     <p class="text-lg text-muted-foreground">

--- a/src/pages/patterns/tabs/astro/index.astro
+++ b/src/pages/patterns/tabs/astro/index.astro
@@ -8,7 +8,6 @@ import FrameworkTabs from "@/components/ui/FrameworkTabs.astro";
 import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
 import sourceCode from "@patterns/tabs/Tabs.astro?raw";
-import { withBase } from "@/lib/utils";
 
 const tocItems = [
   { id: 'demo', text: 'Demo' },
@@ -69,12 +68,6 @@ const verticalTabs = [
 ---
 
 <PatternLayout title="Tabs - Astro" pattern="tabs" framework="astro" tocItems={tocItems}>
-  <nav class="mb-6 text-sm">
-    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
-    <span class="mx-2 text-muted-foreground">/</span>
-    <span>Tabs</span>
-  </nav>
-
     <header class="mb-8">
       <h1 class="text-3xl font-bold mb-4">Tabs</h1>
       <p class="text-lg text-muted-foreground">

--- a/src/pages/patterns/tabs/react/index.astro
+++ b/src/pages/patterns/tabs/react/index.astro
@@ -10,7 +10,6 @@ import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/tabs/Tabs.tsx?raw';
 import testCode from '@patterns/tabs/Tabs.test.tsx?raw';
-import { withBase } from '@/lib/utils';
 
 const tocItems = [
   { id: 'demo', text: 'Demo' },
@@ -42,12 +41,6 @@ const verticalTabs = [
 ---
 
 <PatternLayout title="Tabs - React" pattern="tabs" framework="react" tocItems={tocItems}>
-  <nav class="mb-6 text-sm">
-    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
-    <span class="mx-2 text-muted-foreground">/</span>
-    <span>Tabs</span>
-  </nav>
-
     <header class="mb-8">
       <h1 class="text-3xl font-bold mb-4">Tabs</h1>
       <p class="text-lg text-muted-foreground">

--- a/src/pages/patterns/tabs/svelte/index.astro
+++ b/src/pages/patterns/tabs/svelte/index.astro
@@ -10,7 +10,6 @@ import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/tabs/Tabs.svelte?raw';
 import testCode from '@patterns/tabs/Tabs.test.svelte.ts?raw';
-import { withBase } from '@/lib/utils';
 
 const tocItems = [
   { id: 'demo', text: 'Demo' },
@@ -42,12 +41,6 @@ const verticalTabs = [
 ---
 
 <PatternLayout title="Tabs - Svelte" pattern="tabs" framework="svelte" tocItems={tocItems}>
-  <nav class="mb-6 text-sm">
-    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
-    <span class="mx-2 text-muted-foreground">/</span>
-    <span>Tabs</span>
-  </nav>
-
     <header class="mb-8">
       <h1 class="text-3xl font-bold mb-4">Tabs</h1>
       <p class="text-lg text-muted-foreground">

--- a/src/pages/patterns/tabs/vue/index.astro
+++ b/src/pages/patterns/tabs/vue/index.astro
@@ -10,7 +10,6 @@ import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/tabs/Tabs.vue?raw';
 import testCode from '@patterns/tabs/Tabs.test.vue.ts?raw';
-import { withBase } from '@/lib/utils';
 
 const tocItems = [
   { id: 'demo', text: 'Demo' },
@@ -42,12 +41,6 @@ const verticalTabs = [
 ---
 
 <PatternLayout title="Tabs - Vue" pattern="tabs" framework="vue" tocItems={tocItems}>
-  <nav class="mb-6 text-sm">
-    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
-    <span class="mx-2 text-muted-foreground">/</span>
-    <span>Tabs</span>
-  </nav>
-
     <header class="mb-8">
       <h1 class="text-3xl font-bold mb-4">Tabs</h1>
       <p class="text-lg text-muted-foreground">

--- a/src/pages/patterns/toolbar/astro/index.astro
+++ b/src/pages/patterns/toolbar/astro/index.astro
@@ -14,7 +14,6 @@ import toolbarSource from '@patterns/toolbar/Toolbar.astro?raw';
 import buttonSource from '@patterns/toolbar/ToolbarButton.astro?raw';
 import toggleSource from '@patterns/toolbar/ToolbarToggleButton.astro?raw';
 import separatorSource from '@patterns/toolbar/ToolbarSeparator.astro?raw';
-import { withBase } from '@/lib/utils';
 
 const tocItems = [
   { id: 'demo', text: 'Demo' },
@@ -27,12 +26,6 @@ const tocItems = [
 ---
 
 <PatternLayout title="Toolbar - Astro" pattern="toolbar" framework="astro" tocItems={tocItems}>
-  <nav class="mb-6 text-sm">
-    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
-    <span class="mx-2 text-muted-foreground">/</span>
-    <span>Toolbar</span>
-  </nav>
-
     <header class="mb-8">
       <h1 class="text-3xl font-bold mb-4">Toolbar</h1>
       <p class="text-lg text-muted-foreground">

--- a/src/pages/patterns/toolbar/react/index.astro
+++ b/src/pages/patterns/toolbar/react/index.astro
@@ -16,7 +16,6 @@ import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/toolbar/Toolbar.tsx?raw';
 import TestingDocs from '@patterns/toolbar/TestingDocs.astro';
 import testCode from '@patterns/toolbar/Toolbar.test.tsx?raw';
-import { withBase } from '@/lib/utils';
 
 const tocItems = [
   { id: 'demo', text: 'Demo' },
@@ -30,12 +29,6 @@ const tocItems = [
 ---
 
 <PatternLayout title="Toolbar - React" pattern="toolbar" framework="react" tocItems={tocItems}>
-  <nav class="mb-6 text-sm">
-    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
-    <span class="mx-2 text-muted-foreground">/</span>
-    <span>Toolbar</span>
-  </nav>
-
     <header class="mb-8">
       <h1 class="text-3xl font-bold mb-4">Toolbar</h1>
       <p class="text-lg text-muted-foreground">

--- a/src/pages/patterns/toolbar/svelte/index.astro
+++ b/src/pages/patterns/toolbar/svelte/index.astro
@@ -17,7 +17,6 @@ import toggleSource from '@patterns/toolbar/ToolbarToggleButton.svelte?raw';
 import separatorSource from '@patterns/toolbar/ToolbarSeparator.svelte?raw';
 import TestingDocs from '@patterns/toolbar/TestingDocs.astro';
 import testCode from '@patterns/toolbar/Toolbar.test.svelte.ts?raw';
-import { withBase } from '@/lib/utils';
 
 const tocItems = [
   { id: 'demo', text: 'Demo' },
@@ -31,12 +30,6 @@ const tocItems = [
 ---
 
 <PatternLayout title="Toolbar - Svelte" pattern="toolbar" framework="svelte" tocItems={tocItems}>
-  <nav class="mb-6 text-sm">
-    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
-    <span class="mx-2 text-muted-foreground">/</span>
-    <span>Toolbar</span>
-  </nav>
-
     <header class="mb-8">
       <h1 class="text-3xl font-bold mb-4">Toolbar</h1>
       <p class="text-lg text-muted-foreground">

--- a/src/pages/patterns/toolbar/vue/index.astro
+++ b/src/pages/patterns/toolbar/vue/index.astro
@@ -17,7 +17,6 @@ import toggleSource from '@patterns/toolbar/ToolbarToggleButton.vue?raw';
 import separatorSource from '@patterns/toolbar/ToolbarSeparator.vue?raw';
 import TestingDocs from '@patterns/toolbar/TestingDocs.astro';
 import testCode from '@patterns/toolbar/Toolbar.test.vue.ts?raw';
-import { withBase } from '@/lib/utils';
 
 const tocItems = [
   { id: 'demo', text: 'Demo' },
@@ -31,12 +30,6 @@ const tocItems = [
 ---
 
 <PatternLayout title="Toolbar - Vue" pattern="toolbar" framework="vue" tocItems={tocItems}>
-  <nav class="mb-6 text-sm">
-    <a href={withBase('/patterns/')} class="text-primary hover:underline">Patterns</a>
-    <span class="mx-2 text-muted-foreground">/</span>
-    <span>Toolbar</span>
-  </nav>
-
     <header class="mb-8">
       <h1 class="text-3xl font-bold mb-4">Toolbar</h1>
       <p class="text-lg text-muted-foreground">


### PR DESCRIPTION
## Summary

  - パンくずの「Patterns」部分をクリックするとドロップダウンでPattern一覧を表示するように変更
  - 24個のパターンページから個別のパンくずマークアップを削除し、`PatternBreadcrumb`コンポーネントに一元化
  - デスクトップ・モバイル共通のUIでシンプルな実装に

  ## Changes

  ### New Component
  - `src/components/ui/pattern-breadcrumb/PatternBreadcrumb.astro`
    - パンくず構造: `Patterns ▼ / {ComponentName}`
    - 「Patterns」クリックでドロップダウン表示
    - 「All patterns」リンクで `/patterns/` へ遷移可能
    - 現在のパターンを `aria-current="page"` でマーク

  ### Accessibility Features
  - キーボードナビゲーション: ArrowUp/Down でドロップダウン内のリンク間移動
  - Escape でドロップダウンを閉じてトリガーにフォーカス
  - 内側リング（`ring-inset`）によるフォーカススタイル
  - 適切な `aria-label="Breadcrumb"` と `aria-current` 属性

  ### Removed
  - 24個のパターンページから個別のパンくず `<nav>` を削除
  - `PatternLayout.astro` から旧モバイルパターンナビゲーション（Collapsible）を削除

  ## Test plan

  - [ ] パンくずの「Patterns」をクリックしてドロップダウンが開くことを確認
  - [ ] ドロップダウン内のリンクをクリックして遷移できることを確認
  - [ ] ArrowUp/Down でドロップダウン内のフォーカス移動を確認
  - [ ] Escape でドロップダウンが閉じることを確認
  - [ ] 外側クリックでドロップダウンが閉じることを確認
  - [ ] 現在のパターンにフォーカスした際、内側リングが表示されることを確認
  - [ ] スクリーンリーダーで適切に読み上げられることを確認