### PR TITLE
feat: implement Tooltip APG pattern with SSR-safe design

### DIFF
--- a/src/lib/patterns.ts
+++ b/src/lib/patterns.ts
@@ -81,6 +81,15 @@ export const PATTERNS: Pattern[] = [
     status: "available",
   },
   {
+    id: "tooltip",
+    name: "Tooltip",
+    description:
+      "A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.",
+    icon: "💡",
+    complexity: "Low",
+    status: "available",
+  },
+  {
     id: "menu-button",
     name: "Menu Button",
     description: "A button that opens a menu of actions or options.",

--- a/src/pages/patterns/[pattern]/index.astro
+++ b/src/pages/patterns/[pattern]/index.astro
@@ -7,7 +7,7 @@ import { withBase } from "@/lib/utils";
 
 export function getStaticPaths() {
   // Add new patterns here as they are implemented
-  const patterns = ["button", "tabs", "accordion", "dialog", "switch"];
+  const patterns = ["button", "tabs", "accordion", "dialog", "toolbar", "switch", "tooltip"];
   return patterns.map((pattern) => ({ params: { pattern } }));
 }
 

--- a/src/pages/patterns/tooltip/astro/index.astro
+++ b/src/pages/patterns/tooltip/astro/index.astro
@@ -1,0 +1,174 @@
+---
+import PatternLayout from '../../../../layouts/PatternLayout.astro';
+import Tooltip from '@patterns/tooltip/Tooltip.astro';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AccessibilityDocs from '@patterns/tooltip/AccessibilityDocs.astro';
+import TestingDocs from '@patterns/tooltip/TestingDocs.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/tooltip/Tooltip.astro?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'resources', text: 'Resources' },
+];
+---
+
+<PatternLayout title="Tooltip - Astro" pattern="tooltip" framework="astro" tocItems={tocItems}>
+  <header class="mb-8">
+    <h1 class="text-3xl font-bold mb-4">Tooltip</h1>
+    <p class="text-lg text-muted-foreground">
+      A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.
+    </p>
+  </header>
+
+  <!-- Framework Selector -->
+  <FrameworkTabs pattern="tooltip" currentFramework="astro" />
+
+  <!-- Demo Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
+    <div class="p-6 rounded-lg border border-border bg-background">
+      <div class="flex flex-wrap items-center gap-8">
+        <Tooltip content="Save your changes">
+          <button class="px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90">
+            Save
+          </button>
+        </Tooltip>
+
+        <Tooltip content="This appears on the right" placement="right">
+          <button class="px-4 py-2 bg-secondary text-secondary-foreground rounded-md hover:bg-secondary/90">
+            Right tooltip
+          </button>
+        </Tooltip>
+
+        <Tooltip content="This appears below" placement="bottom">
+          <button class="px-4 py-2 bg-secondary text-secondary-foreground rounded-md hover:bg-secondary/90">
+            Bottom tooltip
+          </button>
+        </Tooltip>
+
+        <Tooltip content="This tooltip is disabled" disabled>
+          <button class="px-4 py-2 bg-muted text-muted-foreground rounded-md">
+            Disabled tooltip
+          </button>
+        </Tooltip>
+      </div>
+    </div>
+  </section>
+
+  <!-- Accessibility Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
+    <AccessibilityDocs />
+  </section>
+
+  <!-- Source Code Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
+    <CodeBlock
+      code={sourceCode}
+      lang="astro"
+      title="Tooltip.astro"
+    />
+  </section>
+
+  <!-- Usage Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
+    <CodeBlock
+      code={`---
+import Tooltip from './Tooltip.astro';
+---
+
+<Tooltip
+  content="Save your changes"
+  placement="top"
+  delay={300}
+>
+  <button>Save</button>
+</Tooltip>`}
+      lang="astro"
+      title="Example"
+    />
+  </section>
+
+  <!-- API Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
+    <ResponsiveTable>
+      <table class="w-full border-collapse">
+        <thead>
+          <tr class="border-b border-border">
+            <th class="text-left py-2 pr-4">Prop</th>
+            <th class="text-left py-2 pr-4">Type</th>
+            <th class="text-left py-2 pr-4">Default</th>
+            <th class="text-left py-2">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>content</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">string</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Tooltip content (required)</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>defaultOpen</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+            <td class="py-2 pr-4 text-muted-foreground">false</td>
+            <td class="py-2">Default open state</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>delay</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">number</td>
+            <td class="py-2 pr-4 text-muted-foreground">300</td>
+            <td class="py-2">Delay before showing (ms)</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>placement</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">'top' | 'bottom' | 'left' | 'right'</td>
+            <td class="py-2 pr-4 text-muted-foreground">'top'</td>
+            <td class="py-2">Tooltip position</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>id</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">string</td>
+            <td class="py-2 pr-4 text-muted-foreground">auto-generated</td>
+            <td class="py-2">Custom ID</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>disabled</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+            <td class="py-2 pr-4 text-muted-foreground">false</td>
+            <td class="py-2">Disable the tooltip</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+    <p class="mt-4 text-sm text-muted-foreground">
+      This implementation uses a Web Component (<code>&lt;apg-tooltip&gt;</code>) for client-side interactivity.
+    </p>
+  </section>
+
+  <!-- Resources -->
+  <section>
+    <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
+    <ul class="list-disc pl-6 space-y-2">
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Tooltip Pattern
+        </ExternalLink>
+      </li>
+    </ul>
+  </section>
+</PatternLayout>

--- a/src/pages/patterns/tooltip/react/index.astro
+++ b/src/pages/patterns/tooltip/react/index.astro
@@ -1,0 +1,206 @@
+---
+import PatternLayout from '../../../../layouts/PatternLayout.astro';
+import { Tooltip } from '@patterns/tooltip/Tooltip';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AccessibilityDocs from '@patterns/tooltip/AccessibilityDocs.astro';
+import TestingDocs from '@patterns/tooltip/TestingDocs.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/tooltip/Tooltip.tsx?raw';
+import testCode from '@patterns/tooltip/Tooltip.test.tsx?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
+---
+
+<PatternLayout title="Tooltip - React" pattern="tooltip" framework="react" tocItems={tocItems}>
+  <header class="mb-8">
+    <h1 class="text-3xl font-bold mb-4">Tooltip</h1>
+    <p class="text-lg text-muted-foreground">
+      A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.
+    </p>
+  </header>
+
+  <!-- Framework Selector -->
+  <FrameworkTabs pattern="tooltip" currentFramework="react" />
+
+  <!-- Demo Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
+    <div class="p-6 rounded-lg border border-border bg-background">
+      <div class="flex flex-wrap items-center gap-8">
+        <Tooltip content="Save your changes" client:load>
+          <button class="px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90">
+            Save
+          </button>
+        </Tooltip>
+
+        <Tooltip content="This appears on the right" placement="right" client:load>
+          <button class="px-4 py-2 bg-secondary text-secondary-foreground rounded-md hover:bg-secondary/90">
+            Right tooltip
+          </button>
+        </Tooltip>
+
+        <Tooltip content="This appears below" placement="bottom" client:load>
+          <button class="px-4 py-2 bg-secondary text-secondary-foreground rounded-md hover:bg-secondary/90">
+            Bottom tooltip
+          </button>
+        </Tooltip>
+
+        <Tooltip content="This tooltip is disabled" disabled client:load>
+          <button class="px-4 py-2 bg-muted text-muted-foreground rounded-md">
+            Disabled tooltip
+          </button>
+        </Tooltip>
+      </div>
+    </div>
+  </section>
+
+  <!-- Accessibility Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
+    <AccessibilityDocs />
+  </section>
+
+  <!-- Source Code Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
+    <CodeBlock
+      code={sourceCode}
+      lang="tsx"
+      title="Tooltip.tsx"
+    />
+  </section>
+
+  <!-- Usage Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
+    <CodeBlock
+      code={`import { Tooltip } from './Tooltip';
+
+function App() {
+  return (
+    <Tooltip
+      content="Save your changes"
+      placement="top"
+      delay={300}
+    >
+      <button>Save</button>
+    </Tooltip>
+  );
+}`}
+      lang="tsx"
+      title="Example"
+    />
+  </section>
+
+  <!-- API Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
+    <ResponsiveTable>
+      <table class="w-full border-collapse">
+        <thead>
+          <tr class="border-b border-border">
+            <th class="text-left py-2 pr-4">Prop</th>
+            <th class="text-left py-2 pr-4">Type</th>
+            <th class="text-left py-2 pr-4">Default</th>
+            <th class="text-left py-2">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>content</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">ReactNode</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Tooltip content (required)</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>children</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">ReactNode</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Trigger element (required)</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>open</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Controlled open state</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>defaultOpen</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+            <td class="py-2 pr-4 text-muted-foreground">false</td>
+            <td class="py-2">Default open state (uncontrolled)</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>onOpenChange</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">(open: boolean) =&gt; void</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Callback when open state changes</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>delay</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">number</td>
+            <td class="py-2 pr-4 text-muted-foreground">300</td>
+            <td class="py-2">Delay before showing (ms)</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>placement</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">'top' | 'bottom' | 'left' | 'right'</td>
+            <td class="py-2 pr-4 text-muted-foreground">'top'</td>
+            <td class="py-2">Tooltip position relative to trigger</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>id</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">string</td>
+            <td class="py-2 pr-4 text-muted-foreground">auto-generated</td>
+            <td class="py-2">Custom ID for SSR</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>disabled</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+            <td class="py-2 pr-4 text-muted-foreground">false</td>
+            <td class="py-2">Disable the tooltip</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </section>
+
+  <!-- Testing Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
+    <TestingDocs />
+    <div class="mt-6">
+      <CodeBlock
+        code={testCode}
+        lang="tsx"
+        title="Tooltip.test.tsx"
+      />
+    </div>
+  </section>
+
+  <!-- Resources -->
+  <section>
+    <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
+    <ul class="list-disc pl-6 space-y-2">
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Tooltip Pattern
+        </ExternalLink>
+      </li>
+    </ul>
+  </section>
+</PatternLayout>

--- a/src/pages/patterns/tooltip/svelte/index.astro
+++ b/src/pages/patterns/tooltip/svelte/index.astro
@@ -1,0 +1,196 @@
+---
+import PatternLayout from '../../../../layouts/PatternLayout.astro';
+import TooltipDemo from '@patterns/tooltip/TooltipDemo.svelte';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AccessibilityDocs from '@patterns/tooltip/AccessibilityDocs.astro';
+import TestingDocs from '@patterns/tooltip/TestingDocs.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/tooltip/Tooltip.svelte?raw';
+import testCode from '@patterns/tooltip/Tooltip.test.svelte.ts?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
+---
+
+<PatternLayout title="Tooltip - Svelte" pattern="tooltip" framework="svelte" tocItems={tocItems}>
+  <header class="mb-8">
+    <h1 class="text-3xl font-bold mb-4">Tooltip</h1>
+    <p class="text-lg text-muted-foreground">
+      A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.
+    </p>
+  </header>
+
+  <!-- Framework Selector -->
+  <FrameworkTabs pattern="tooltip" currentFramework="svelte" />
+
+  <!-- Demo Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
+    <div class="p-6 rounded-lg border border-border bg-background">
+      <TooltipDemo client:only="svelte" />
+    </div>
+  </section>
+
+  <!-- Accessibility Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
+    <AccessibilityDocs />
+  </section>
+
+  <!-- Source Code Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
+    <CodeBlock
+      code={sourceCode}
+      lang="svelte"
+      title="Tooltip.svelte"
+    />
+  </section>
+
+  <!-- Usage Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
+    <CodeBlock
+      code={`<script>
+  import Tooltip from './Tooltip.svelte';
+</script>
+
+<!-- Basic usage with render props for aria-describedby -->
+<Tooltip
+  id="tooltip-save"
+  content="Save your changes"
+  placement="top"
+  delay={300}
+>
+  {#snippet children({ describedBy })}
+    <button aria-describedby={describedBy}>Save</button>
+  {/snippet}
+</Tooltip>
+
+<!-- Rich content using Snippet -->
+<Tooltip id="tooltip-shortcut">
+  {#snippet content()}
+    <span class="flex items-center gap-1">
+      <kbd>Ctrl</kbd>+<kbd>S</kbd>
+    </span>
+  {/snippet}
+  {#snippet children({ describedBy })}
+    <button aria-describedby={describedBy}>Keyboard shortcut</button>
+  {/snippet}
+</Tooltip>`}
+      lang="svelte"
+      title="Example"
+    />
+  </section>
+
+  <!-- API Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
+    <ResponsiveTable>
+      <table class="w-full border-collapse">
+        <thead>
+          <tr class="border-b border-border">
+            <th class="text-left py-2 pr-4">Prop</th>
+            <th class="text-left py-2 pr-4">Type</th>
+            <th class="text-left py-2 pr-4">Default</th>
+            <th class="text-left py-2">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>id</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">string</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Unique ID for the tooltip (required for SSR/hydration consistency)</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>content</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">string | Snippet</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Tooltip content (required)</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>children</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">Snippet&lt;[&#123; describedBy &#125;]&gt;</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Render props pattern - receives describedBy for aria-describedby</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>open</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Controlled open state</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>defaultOpen</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+            <td class="py-2 pr-4 text-muted-foreground">false</td>
+            <td class="py-2">Default open state (uncontrolled)</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>onOpenChange</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">(open: boolean) =&gt; void</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Callback when open state changes</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>delay</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">number</td>
+            <td class="py-2 pr-4 text-muted-foreground">300</td>
+            <td class="py-2">Delay before showing (ms)</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>placement</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">'top' | 'bottom' | 'left' | 'right'</td>
+            <td class="py-2 pr-4 text-muted-foreground">'top'</td>
+            <td class="py-2">Tooltip position</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>disabled</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+            <td class="py-2 pr-4 text-muted-foreground">false</td>
+            <td class="py-2">Disable the tooltip</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </section>
+
+  <!-- Testing Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
+    <TestingDocs />
+    <div class="mt-6">
+      <CodeBlock
+        code={testCode}
+        lang="typescript"
+        title="Tooltip.test.svelte.ts"
+      />
+    </div>
+  </section>
+
+  <!-- Resources -->
+  <section>
+    <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
+    <ul class="list-disc pl-6 space-y-2">
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Tooltip Pattern
+        </ExternalLink>
+      </li>
+    </ul>
+  </section>
+</PatternLayout>

--- a/src/pages/patterns/tooltip/vue/index.astro
+++ b/src/pages/patterns/tooltip/vue/index.astro
@@ -1,0 +1,194 @@
+---
+import PatternLayout from '../../../../layouts/PatternLayout.astro';
+import Tooltip from '@patterns/tooltip/Tooltip.vue';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AccessibilityDocs from '@patterns/tooltip/AccessibilityDocs.astro';
+import TestingDocs from '@patterns/tooltip/TestingDocs.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/tooltip/Tooltip.vue?raw';
+import testCode from '@patterns/tooltip/Tooltip.test.vue.ts?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
+---
+
+<PatternLayout title="Tooltip - Vue" pattern="tooltip" framework="vue" tocItems={tocItems}>
+  <header class="mb-8">
+    <h1 class="text-3xl font-bold mb-4">Tooltip</h1>
+    <p class="text-lg text-muted-foreground">
+      A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.
+    </p>
+  </header>
+
+  <!-- Framework Selector -->
+  <FrameworkTabs pattern="tooltip" currentFramework="vue" />
+
+  <!-- Demo Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
+    <div class="p-6 rounded-lg border border-border bg-background">
+      <div class="flex flex-wrap items-center gap-8">
+        <Tooltip content="Save your changes" client:load>
+          <button class="px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90">
+            Save
+          </button>
+        </Tooltip>
+
+        <Tooltip content="This appears on the right" placement="right" client:load>
+          <button class="px-4 py-2 bg-secondary text-secondary-foreground rounded-md hover:bg-secondary/90">
+            Right tooltip
+          </button>
+        </Tooltip>
+
+        <Tooltip content="This appears below" placement="bottom" client:load>
+          <button class="px-4 py-2 bg-secondary text-secondary-foreground rounded-md hover:bg-secondary/90">
+            Bottom tooltip
+          </button>
+        </Tooltip>
+
+        <Tooltip content="This tooltip is disabled" disabled={true} client:load>
+          <button class="px-4 py-2 bg-muted text-muted-foreground rounded-md">
+            Disabled tooltip
+          </button>
+        </Tooltip>
+      </div>
+    </div>
+  </section>
+
+  <!-- Accessibility Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
+    <AccessibilityDocs />
+  </section>
+
+  <!-- Source Code Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
+    <CodeBlock
+      code={sourceCode}
+      lang="vue"
+      title="Tooltip.vue"
+    />
+  </section>
+
+  <!-- Usage Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
+    <CodeBlock
+      code={`<script setup>
+import Tooltip from './Tooltip.vue';
+</script>
+
+<template>
+  <Tooltip
+    content="Save your changes"
+    placement="top"
+    :delay="300"
+  >
+    <button>Save</button>
+  </Tooltip>
+</template>`}
+      lang="vue"
+      title="Example"
+    />
+  </section>
+
+  <!-- API Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
+    <ResponsiveTable>
+      <table class="w-full border-collapse">
+        <thead>
+          <tr class="border-b border-border">
+            <th class="text-left py-2 pr-4">Prop</th>
+            <th class="text-left py-2 pr-4">Type</th>
+            <th class="text-left py-2 pr-4">Default</th>
+            <th class="text-left py-2">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>content</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">string</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Tooltip content (required)</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>open</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Controlled open state (v-model:open)</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>defaultOpen</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+            <td class="py-2 pr-4 text-muted-foreground">false</td>
+            <td class="py-2">Default open state (uncontrolled)</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>delay</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">number</td>
+            <td class="py-2 pr-4 text-muted-foreground">300</td>
+            <td class="py-2">Delay before showing (ms)</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>placement</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">'top' | 'bottom' | 'left' | 'right'</td>
+            <td class="py-2 pr-4 text-muted-foreground">'top'</td>
+            <td class="py-2">Tooltip position</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>id</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">string</td>
+            <td class="py-2 pr-4 text-muted-foreground">auto-generated</td>
+            <td class="py-2">Custom ID</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>disabled</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+            <td class="py-2 pr-4 text-muted-foreground">false</td>
+            <td class="py-2">Disable the tooltip</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </section>
+
+  <!-- Testing Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
+    <TestingDocs />
+    <div class="mt-6">
+      <CodeBlock
+        code={testCode}
+        lang="typescript"
+        title="Tooltip.test.vue.ts"
+      />
+    </div>
+  </section>
+
+  <!-- Resources -->
+  <section>
+    <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
+    <ul class="list-disc pl-6 space-y-2">
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Tooltip Pattern
+        </ExternalLink>
+      </li>
+    </ul>
+  </section>
+</PatternLayout>

--- a/src/patterns/tooltip/AccessibilityDocs.astro
+++ b/src/patterns/tooltip/AccessibilityDocs.astro
@@ -1,0 +1,148 @@
+---
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+---
+
+<div class="prose dark:prose-invert max-w-none">
+  <h3 class="text-lg font-medium mb-3">WAI-ARIA Roles</h3>
+  <ul class="list-disc pl-6 mb-6 space-y-2">
+    <li>
+      <code>tooltip</code> - A contextual popup that displays a description for an element<br />
+      <ExternalLink href="https://w3c.github.io/aria/#tooltip" class="text-sm text-primary hover:underline">
+        WAI-ARIA tooltip role
+      </ExternalLink>
+    </li>
+  </ul>
+
+  <h3 class="text-lg font-medium mb-3">WAI-ARIA States &amp; Properties</h3>
+  <div class="mb-6">
+    <h4 class="font-medium mb-2"><code>aria-describedby</code></h4>
+    <p class="text-muted-foreground mb-3">References the tooltip element to provide an accessible description for the trigger element.</p>
+    <ResponsiveTable class="mb-2">
+      <table class="w-full border-collapse">
+        <tbody>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4 font-medium w-32">Applied to</td>
+            <td class="py-2">Trigger element (wrapper)</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4 font-medium">When</td>
+            <td class="py-2">Only when tooltip is visible</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4 font-medium">Reference</td>
+            <td class="py-2">
+              <ExternalLink href="https://w3c.github.io/aria/#aria-describedby" class="text-primary hover:underline">
+                aria-describedby
+              </ExternalLink>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </div>
+
+  <div class="mb-6">
+    <h4 class="font-medium mb-2"><code>aria-hidden</code></h4>
+    <p class="text-muted-foreground mb-3">Indicates whether the tooltip is hidden from assistive technology.</p>
+    <ResponsiveTable class="mb-2">
+      <table class="w-full border-collapse">
+        <tbody>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4 font-medium w-32">Values</td>
+            <td class="py-2">
+              <code>true</code> (hidden) | <code>false</code> (visible)
+            </td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4 font-medium">Default</td>
+            <td class="py-2"><code>true</code></td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4 font-medium">Reference</td>
+            <td class="py-2">
+              <ExternalLink href="https://w3c.github.io/aria/#aria-hidden" class="text-primary hover:underline">
+                aria-hidden
+              </ExternalLink>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </div>
+
+  <h3 class="text-lg font-medium mb-3">Keyboard Support</h3>
+  <ResponsiveTable class="mb-4">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Key</th>
+          <th class="text-left py-2">Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><kbd class="px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded">Escape</kbd></td>
+          <td class="py-2">Closes the tooltip</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><kbd class="px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded">Tab</kbd></td>
+          <td class="py-2">Standard focus navigation; tooltip shows when trigger receives focus</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h3 class="text-lg font-medium mb-3">Focus Management</h3>
+  <ul class="list-disc pl-6 mb-6 space-y-2">
+    <li>
+      <strong>Tooltip never receives focus</strong> - Per APG, tooltips must not be focusable. If interactive content is needed, use a Dialog or Popover pattern instead.
+    </li>
+    <li>
+      <strong>Focus triggers display</strong> - When the trigger element receives focus, the tooltip appears after the configured delay.
+    </li>
+    <li>
+      <strong>Blur hides tooltip</strong> - When focus leaves the trigger element, the tooltip is hidden.
+    </li>
+  </ul>
+
+  <h3 class="text-lg font-medium mb-3">Mouse/Pointer Behavior</h3>
+  <ul class="list-disc pl-6 mb-6 space-y-2">
+    <li>
+      <strong>Hover triggers display</strong> - Moving the pointer over the trigger shows the tooltip after the delay.
+    </li>
+    <li>
+      <strong>Pointer leave hides</strong> - Moving the pointer away from the trigger hides the tooltip.
+    </li>
+  </ul>
+
+  <h3 class="text-lg font-medium mb-3">Important Notes</h3>
+  <div class="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-4 mb-6">
+    <p class="text-amber-800 dark:text-amber-200 text-sm">
+      <strong>Note:</strong> The APG Tooltip pattern is currently marked as "work in progress" by the WAI.
+      This implementation follows the documented guidelines, but the specification may evolve.
+      <ExternalLink href="https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/" class="text-amber-700 dark:text-amber-300 hover:underline ml-1">
+        View APG Tooltip Pattern
+      </ExternalLink>
+    </p>
+  </div>
+
+  <h3 class="text-lg font-medium mb-3">Visual Design</h3>
+  <p class="text-muted-foreground mb-3">
+    This implementation follows best practices for tooltip visibility:
+  </p>
+  <ul class="list-disc pl-6 mb-6 space-y-2">
+    <li>
+      <strong>High contrast</strong> - Dark background with light text ensures readability
+    </li>
+    <li>
+      <strong>Dark mode support</strong> - Colors invert appropriately in dark mode
+    </li>
+    <li>
+      <strong>Positioned near trigger</strong> - Tooltip appears adjacent to the triggering element
+    </li>
+    <li>
+      <strong>Configurable delay</strong> - Prevents accidental activation during cursor movement
+    </li>
+  </ul>
+</div>

--- a/src/patterns/tooltip/TestingDocs.astro
+++ b/src/patterns/tooltip/TestingDocs.astro
@@ -1,0 +1,142 @@
+---
+import { ResponsiveTable } from '@/components/ui/table';
+---
+
+<div class="prose dark:prose-invert max-w-none">
+  <h3 class="text-lg font-medium mb-3">Testing Overview</h3>
+  <p class="text-muted-foreground mb-4">
+    The Tooltip component tests are organized into priority levels based on APG compliance requirements.
+  </p>
+
+  <h3 class="text-lg font-medium mb-3">Test Categories</h3>
+
+  <div class="mb-6">
+    <h4 class="font-medium mb-2 flex items-center gap-2">
+      <span class="inline-block w-3 h-3 rounded-full bg-red-500"></span>
+      High Priority: APG Core Compliance
+    </h4>
+    <ResponsiveTable>
+      <table class="w-full border-collapse text-sm">
+        <thead>
+          <tr class="border-b border-border">
+            <th class="text-left py-2 pr-4">Test</th>
+            <th class="text-left py-2">APG Requirement</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">role="tooltip" exists</td>
+            <td class="py-2">Tooltip container must have tooltip role</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">aria-hidden when closed</td>
+            <td class="py-2">Hidden tooltips must not be read by AT</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">aria-describedby when visible</td>
+            <td class="py-2">Trigger must reference tooltip only when visible</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">Escape key closes tooltip</td>
+            <td class="py-2">Keyboard dismissal support</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">Focus shows tooltip</td>
+            <td class="py-2">Keyboard accessibility</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">Blur hides tooltip</td>
+            <td class="py-2">Focus management</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </div>
+
+  <div class="mb-6">
+    <h4 class="font-medium mb-2 flex items-center gap-2">
+      <span class="inline-block w-3 h-3 rounded-full bg-yellow-500"></span>
+      Medium Priority: Accessibility Validation
+    </h4>
+    <ResponsiveTable>
+      <table class="w-full border-collapse text-sm">
+        <thead>
+          <tr class="border-b border-border">
+            <th class="text-left py-2 pr-4">Test</th>
+            <th class="text-left py-2">WCAG Requirement</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">No axe violations (hidden state)</td>
+            <td class="py-2">WCAG 2.1 AA compliance</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">No axe violations (visible state)</td>
+            <td class="py-2">WCAG 2.1 AA compliance</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">Tooltip is not focusable</td>
+            <td class="py-2">APG: tooltips must not receive focus</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </div>
+
+  <div class="mb-6">
+    <h4 class="font-medium mb-2 flex items-center gap-2">
+      <span class="inline-block w-3 h-3 rounded-full bg-green-500"></span>
+      Low Priority: Props &amp; Extensibility
+    </h4>
+    <ResponsiveTable>
+      <table class="w-full border-collapse text-sm">
+        <thead>
+          <tr class="border-b border-border">
+            <th class="text-left py-2 pr-4">Test</th>
+            <th class="text-left py-2">Feature</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">placement prop changes position</td>
+            <td class="py-2">Positioning customization</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">disabled prop prevents display</td>
+            <td class="py-2">Disable functionality</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">delay prop controls timing</td>
+            <td class="py-2">Delay customization</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">id prop sets custom ID</td>
+            <td class="py-2">SSR/custom ID support</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">controlled open state</td>
+            <td class="py-2">External state control</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">onOpenChange callback</td>
+            <td class="py-2">State change notification</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">className inheritance</td>
+            <td class="py-2">Style customization</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </div>
+
+  <h3 class="text-lg font-medium mb-3">Running Tests</h3>
+  <pre class="bg-gray-100 dark:bg-gray-800 p-4 rounded-lg text-sm overflow-x-auto"><code># Run all Tooltip tests
+npm run test -- tooltip
+
+# Run tests for specific framework
+npm run test -- Tooltip.test.tsx    # React
+npm run test -- Tooltip.test.vue    # Vue
+npm run test -- Tooltip.test.svelte # Svelte</code></pre>
+</div>

--- a/src/patterns/tooltip/Tooltip.astro
+++ b/src/patterns/tooltip/Tooltip.astro
@@ -1,0 +1,172 @@
+---
+export type TooltipPlacement = "top" | "bottom" | "left" | "right";
+
+export interface Props {
+  /** Tooltip content */
+  content: string;
+  /** Default open state */
+  defaultOpen?: boolean;
+  /** Delay before showing tooltip (ms) */
+  delay?: number;
+  /** Tooltip placement */
+  placement?: TooltipPlacement;
+  /** Custom tooltip ID */
+  id?: string;
+  /** Whether the tooltip is disabled */
+  disabled?: boolean;
+  /** Additional class name for the wrapper */
+  class?: string;
+  /** Additional class name for the tooltip content */
+  tooltipClass?: string;
+}
+
+const {
+  content,
+  defaultOpen = false,
+  delay = 300,
+  placement = "top",
+  id,
+  disabled = false,
+  class: className = "",
+  tooltipClass = "",
+} = Astro.props;
+
+const tooltipId = id ?? `tooltip-${crypto.randomUUID().slice(0, 8)}`;
+
+const placementClasses: Record<TooltipPlacement, string> = {
+  top: "bottom-full left-1/2 -translate-x-1/2 mb-2",
+  bottom: "top-full left-1/2 -translate-x-1/2 mt-2",
+  left: "right-full top-1/2 -translate-y-1/2 mr-2",
+  right: "left-full top-1/2 -translate-y-1/2 ml-2",
+};
+---
+
+<apg-tooltip
+  class:list={["apg-tooltip-trigger", "relative inline-block", className]}
+  data-delay={delay}
+  data-disabled={disabled ? "true" : undefined}
+  data-tooltip-id={tooltipId}
+  data-default-open={defaultOpen ? "true" : undefined}
+>
+  <slot />
+  <span
+    id={tooltipId}
+    role="tooltip"
+    aria-hidden="true"
+    class:list={[
+      "apg-tooltip",
+      "absolute z-50 px-3 py-1.5 text-sm",
+      "bg-gray-900 text-white rounded-md shadow-lg",
+      "dark:bg-gray-100 dark:text-gray-900",
+      "pointer-events-none whitespace-nowrap",
+      "transition-opacity duration-150",
+      placementClasses[placement],
+      "opacity-0 invisible",
+      tooltipClass,
+    ]}
+  >
+    {content}
+  </span>
+</apg-tooltip>
+
+<script>
+  class ApgTooltip extends HTMLElement {
+    private timeout: ReturnType<typeof setTimeout> | null = null;
+    private isOpen = false;
+    private tooltipEl: HTMLElement | null = null;
+    private delay: number;
+    private disabled: boolean;
+    private tooltipId: string;
+
+    constructor() {
+      super();
+      this.delay = 300;
+      this.disabled = false;
+      this.tooltipId = "";
+    }
+
+    connectedCallback() {
+      this.delay = parseInt(this.dataset.delay ?? "300", 10);
+      this.disabled = this.dataset.disabled === "true";
+      this.tooltipId = this.dataset.tooltipId ?? "";
+      this.tooltipEl = this.querySelector(`#${this.tooltipId}`);
+
+      if (this.dataset.defaultOpen === "true") {
+        this.showTooltip();
+      }
+
+      this.addEventListener("mouseenter", this.handleMouseEnter);
+      this.addEventListener("mouseleave", this.handleMouseLeave);
+      this.addEventListener("focusin", this.handleFocusIn);
+      this.addEventListener("focusout", this.handleFocusOut);
+      document.addEventListener("keydown", this.handleKeyDown);
+    }
+
+    disconnectedCallback() {
+      if (this.timeout) {
+        clearTimeout(this.timeout);
+      }
+      this.removeEventListener("mouseenter", this.handleMouseEnter);
+      this.removeEventListener("mouseleave", this.handleMouseLeave);
+      this.removeEventListener("focusin", this.handleFocusIn);
+      this.removeEventListener("focusout", this.handleFocusOut);
+      document.removeEventListener("keydown", this.handleKeyDown);
+    }
+
+    private handleMouseEnter = () => {
+      this.scheduleShow();
+    };
+
+    private handleMouseLeave = () => {
+      this.hideTooltip();
+    };
+
+    private handleFocusIn = () => {
+      this.scheduleShow();
+    };
+
+    private handleFocusOut = () => {
+      this.hideTooltip();
+    };
+
+    private handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && this.isOpen) {
+        this.hideTooltip();
+      }
+    };
+
+    private scheduleShow() {
+      if (this.disabled) return;
+      if (this.timeout) {
+        clearTimeout(this.timeout);
+      }
+      this.timeout = setTimeout(() => {
+        this.showTooltip();
+      }, this.delay);
+    }
+
+    private showTooltip() {
+      if (this.disabled || !this.tooltipEl) return;
+      this.isOpen = true;
+      this.tooltipEl.setAttribute("aria-hidden", "false");
+      this.tooltipEl.classList.remove("opacity-0", "invisible");
+      this.tooltipEl.classList.add("opacity-100", "visible");
+      this.setAttribute("aria-describedby", this.tooltipId);
+    }
+
+    private hideTooltip() {
+      if (this.timeout) {
+        clearTimeout(this.timeout);
+        this.timeout = null;
+      }
+      if (!this.tooltipEl) return;
+      this.isOpen = false;
+      this.tooltipEl.setAttribute("aria-hidden", "true");
+      this.tooltipEl.classList.remove("opacity-100", "visible");
+      this.tooltipEl.classList.add("opacity-0", "invisible");
+      this.removeAttribute("aria-describedby");
+    }
+  }
+
+  customElements.define("apg-tooltip", ApgTooltip);
+</script>

--- a/src/patterns/tooltip/Tooltip.svelte
+++ b/src/patterns/tooltip/Tooltip.svelte
@@ -1,0 +1,155 @@
+<script lang="ts" module>
+  import type { Snippet } from "svelte";
+
+  export type TooltipPlacement = "top" | "bottom" | "left" | "right";
+
+  export interface TooltipProps {
+    /** Tooltip content - can be string or Snippet for rich content */
+    content: string | Snippet;
+    /** Trigger element - must be a focusable element for keyboard accessibility */
+    children?: Snippet<[{ describedBy: string | undefined }]>;
+    /** Controlled open state */
+    open?: boolean;
+    /** Default open state (uncontrolled) */
+    defaultOpen?: boolean;
+    /** Delay before showing tooltip (ms) */
+    delay?: number;
+    /** Tooltip placement */
+    placement?: TooltipPlacement;
+    /**
+     * Tooltip ID - Required for SSR/hydration consistency.
+     * Must be unique and stable across server and client renders.
+     */
+    id: string;
+    /** Whether the tooltip is disabled */
+    disabled?: boolean;
+    /** Additional class name for the wrapper */
+    class?: string;
+    /** Additional class name for the tooltip content */
+    tooltipClass?: string;
+  }
+</script>
+
+<script lang="ts">
+  import { cn } from "@/lib/utils";
+  import { onDestroy } from "svelte";
+
+  let {
+    content,
+    children,
+    open: controlledOpen = undefined,
+    defaultOpen = false,
+    delay = 300,
+    placement = "top",
+    id,
+    disabled = false,
+    class: className = "",
+    tooltipClass = "",
+    onOpenChange,
+  }: TooltipProps & { onOpenChange?: (open: boolean) => void } = $props();
+
+  // Use provided id directly - required for SSR/hydration consistency
+  const tooltipId = $derived(id);
+
+  let internalOpen = $state(defaultOpen);
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+
+  let isControlled = $derived(controlledOpen !== undefined);
+  let isOpen = $derived(isControlled ? controlledOpen : internalOpen);
+
+  // aria-describedby should always be set when not disabled for screen reader accessibility
+  // This ensures SR users know the element has a description even before tooltip is visible
+  let describedBy = $derived(!disabled ? tooltipId : undefined);
+
+  function setOpen(value: boolean) {
+    if (controlledOpen === undefined) {
+      internalOpen = value;
+    }
+    onOpenChange?.(value);
+  }
+
+  function handleKeyDown(event: KeyboardEvent) {
+    if (event.key === "Escape") {
+      hideTooltip();
+    }
+  }
+
+  function showTooltip() {
+    if (disabled) return;
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    timeout = setTimeout(() => {
+      setOpen(true);
+    }, delay);
+  }
+
+  function hideTooltip() {
+    if (timeout) {
+      clearTimeout(timeout);
+      timeout = null;
+    }
+    setOpen(false);
+  }
+
+  // Manage keydown listener based on isOpen state
+  // This handles both controlled and uncontrolled modes
+  $effect(() => {
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+    } else {
+      document.removeEventListener("keydown", handleKeyDown);
+    }
+  });
+
+  // Cleanup on destroy - fix for memory leak
+  onDestroy(() => {
+    if (timeout) {
+      clearTimeout(timeout);
+      timeout = null;
+    }
+    document.removeEventListener("keydown", handleKeyDown);
+  });
+
+  const placementClasses: Record<TooltipPlacement, string> = {
+    top: "bottom-full left-1/2 -translate-x-1/2 mb-2",
+    bottom: "top-full left-1/2 -translate-x-1/2 mt-2",
+    left: "right-full top-1/2 -translate-y-1/2 mr-2",
+    right: "left-full top-1/2 -translate-y-1/2 ml-2",
+  };
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<span
+  class={cn("apg-tooltip-trigger", "relative inline-block", className)}
+  onmouseenter={showTooltip}
+  onmouseleave={hideTooltip}
+  onfocusin={showTooltip}
+  onfocusout={hideTooltip}
+>
+  {#if children}
+    {@render children({ describedBy })}
+  {/if}
+  <span
+    id={tooltipId}
+    role="tooltip"
+    aria-hidden={!isOpen}
+    class={cn(
+      "apg-tooltip",
+      "absolute z-50 px-3 py-1.5 text-sm",
+      "bg-gray-900 text-white rounded-md shadow-lg",
+      "dark:bg-gray-100 dark:text-gray-900",
+      "pointer-events-none whitespace-nowrap",
+      "transition-opacity duration-150",
+      placementClasses[placement],
+      isOpen ? "opacity-100 visible" : "opacity-0 invisible",
+      tooltipClass
+    )}
+  >
+    {#if typeof content === "string"}
+      {content}
+    {:else}
+      {@render content()}
+    {/if}
+  </span>
+</span>

--- a/src/patterns/tooltip/Tooltip.test.svelte.ts
+++ b/src/patterns/tooltip/Tooltip.test.svelte.ts
@@ -1,0 +1,125 @@
+import { render, screen, waitFor } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import { axe } from "jest-axe";
+import { describe, expect, it, vi } from "vitest";
+import TooltipTestWrapper from "./test-wrappers/TooltipTestWrapper.svelte";
+
+describe("Tooltip (Svelte)", () => {
+  describe("APG: ARIA 属性", () => {
+    it('role="tooltip" を持つ', () => {
+      render(TooltipTestWrapper, { props: { content: "This is a tooltip" } });
+      expect(screen.getByRole("tooltip", { hidden: true })).toBeInTheDocument();
+    });
+
+    it("非表示時は aria-hidden が true", () => {
+      render(TooltipTestWrapper, { props: { content: "This is a tooltip" } });
+      const tooltip = screen.getByRole("tooltip", { hidden: true });
+      expect(tooltip).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("表示時は aria-hidden が false", async () => {
+      const user = userEvent.setup();
+      render(TooltipTestWrapper, { props: { content: "This is a tooltip", delay: 0 } });
+      const trigger = screen.getByRole("button");
+
+      await user.hover(trigger);
+      await waitFor(() => {
+        const tooltip = screen.getByRole("tooltip");
+        expect(tooltip).toHaveAttribute("aria-hidden", "false");
+      });
+    });
+  });
+
+  describe("APG: キーボード操作", () => {
+    it("Escape キーで閉じる", async () => {
+      const user = userEvent.setup();
+      render(TooltipTestWrapper, { props: { content: "This is a tooltip", delay: 0 } });
+      const trigger = screen.getByRole("button");
+
+      await user.hover(trigger);
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip")).toHaveAttribute("aria-hidden", "false");
+      });
+
+      await user.keyboard("{Escape}");
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip", { hidden: true })).toHaveAttribute("aria-hidden", "true");
+      });
+    });
+
+    it("フォーカスで表示される", async () => {
+      const user = userEvent.setup();
+      render(TooltipTestWrapper, { props: { content: "This is a tooltip", delay: 0 } });
+
+      await user.tab();
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip")).toHaveAttribute("aria-hidden", "false");
+      });
+    });
+  });
+
+  describe("ホバー操作", () => {
+    it("ホバーで表示される", async () => {
+      const user = userEvent.setup();
+      render(TooltipTestWrapper, { props: { content: "This is a tooltip", delay: 0 } });
+
+      await user.hover(screen.getByRole("button"));
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip")).toHaveAttribute("aria-hidden", "false");
+      });
+    });
+
+    it("ホバー解除で閉じる", async () => {
+      const user = userEvent.setup();
+      render(TooltipTestWrapper, { props: { content: "This is a tooltip", delay: 0 } });
+      const trigger = screen.getByRole("button");
+
+      await user.hover(trigger);
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip")).toHaveAttribute("aria-hidden", "false");
+      });
+
+      await user.unhover(trigger);
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip", { hidden: true })).toHaveAttribute("aria-hidden", "true");
+      });
+    });
+  });
+
+  describe("アクセシビリティ", () => {
+    it("axe による WCAG 2.1 AA 違反がない", async () => {
+      const { container } = render(TooltipTestWrapper, { props: { content: "This is a tooltip" } });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("tooltip がフォーカスを受け取らない", () => {
+      render(TooltipTestWrapper, { props: { content: "This is a tooltip" } });
+      const tooltip = screen.getByRole("tooltip", { hidden: true });
+      expect(tooltip).not.toHaveAttribute("tabindex");
+    });
+  });
+
+  describe("Props", () => {
+    it("placement prop で位置を変更できる", () => {
+      render(TooltipTestWrapper, { props: { content: "Tooltip", placement: "bottom" } });
+      const tooltip = screen.getByRole("tooltip", { hidden: true });
+      expect(tooltip).toHaveClass("top-full");
+    });
+
+    it("disabled の場合、tooltip が表示されない", async () => {
+      const user = userEvent.setup();
+      render(TooltipTestWrapper, { props: { content: "Tooltip", delay: 0, disabled: true } });
+
+      await user.hover(screen.getByRole("button"));
+      await new Promise((r) => setTimeout(r, 50));
+      expect(screen.getByRole("tooltip", { hidden: true })).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("id prop でカスタム ID を設定できる", () => {
+      render(TooltipTestWrapper, { props: { content: "Tooltip", id: "custom-tooltip-id" } });
+      const tooltip = screen.getByRole("tooltip", { hidden: true });
+      expect(tooltip).toHaveAttribute("id", "custom-tooltip-id");
+    });
+  });
+});

--- a/src/patterns/tooltip/Tooltip.test.tsx
+++ b/src/patterns/tooltip/Tooltip.test.tsx
@@ -1,0 +1,373 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "jest-axe";
+import { describe, expect, it, vi } from "vitest";
+import { Tooltip } from "./Tooltip";
+
+describe("Tooltip", () => {
+  // 🔴 High Priority: APG 準拠の核心
+  describe("APG: ARIA 属性", () => {
+    it('role="tooltip" を持つ', () => {
+      render(
+        <Tooltip content="This is a tooltip">
+          <button>Hover me</button>
+        </Tooltip>
+      );
+      expect(screen.getByRole("tooltip", { hidden: true })).toBeInTheDocument();
+    });
+
+    it("非表示時は aria-hidden が true", () => {
+      render(
+        <Tooltip content="This is a tooltip">
+          <button>Hover me</button>
+        </Tooltip>
+      );
+      const tooltip = screen.getByRole("tooltip", { hidden: true });
+      expect(tooltip).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("表示時は aria-hidden が false", async () => {
+      const user = userEvent.setup();
+      render(
+        <Tooltip content="This is a tooltip" delay={0}>
+          <button>Hover me</button>
+        </Tooltip>
+      );
+      const trigger = screen.getByRole("button");
+
+      await user.hover(trigger);
+      await waitFor(() => {
+        const tooltip = screen.getByRole("tooltip");
+        expect(tooltip).toHaveAttribute("aria-hidden", "false");
+      });
+    });
+
+    it("表示時のみ aria-describedby が設定される", async () => {
+      const user = userEvent.setup();
+      render(
+        <Tooltip content="This is a tooltip" delay={0}>
+          <button>Hover me</button>
+        </Tooltip>
+      );
+      const trigger = screen.getByRole("button");
+      const wrapper = trigger.parentElement;
+
+      // 非表示時は aria-describedby がない
+      expect(wrapper).not.toHaveAttribute("aria-describedby");
+
+      await user.hover(trigger);
+      await waitFor(() => {
+        expect(wrapper).toHaveAttribute("aria-describedby");
+      });
+
+      const tooltipId = wrapper?.getAttribute("aria-describedby");
+      const tooltip = screen.getByRole("tooltip");
+      expect(tooltip).toHaveAttribute("id", tooltipId);
+    });
+  });
+
+  describe("APG: キーボード操作", () => {
+    it("Escape キーで閉じる", async () => {
+      const user = userEvent.setup();
+      render(
+        <Tooltip content="This is a tooltip" delay={0}>
+          <button>Hover me</button>
+        </Tooltip>
+      );
+      const trigger = screen.getByRole("button");
+
+      await user.hover(trigger);
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip")).toHaveAttribute(
+          "aria-hidden",
+          "false"
+        );
+      });
+
+      await user.keyboard("{Escape}");
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip", { hidden: true })).toHaveAttribute(
+          "aria-hidden",
+          "true"
+        );
+      });
+    });
+
+    it("フォーカスで表示される", async () => {
+      const user = userEvent.setup();
+      render(
+        <Tooltip content="This is a tooltip" delay={0}>
+          <button>Hover me</button>
+        </Tooltip>
+      );
+
+      await user.tab();
+      expect(screen.getByRole("button")).toHaveFocus();
+
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip")).toHaveAttribute(
+          "aria-hidden",
+          "false"
+        );
+      });
+    });
+
+    it("フォーカスアウトで閉じる", async () => {
+      const user = userEvent.setup();
+      render(
+        <>
+          <Tooltip content="This is a tooltip" delay={0}>
+            <button>First</button>
+          </Tooltip>
+          <button>Second</button>
+        </>
+      );
+
+      await user.tab();
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip")).toHaveAttribute(
+          "aria-hidden",
+          "false"
+        );
+      });
+
+      await user.tab();
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip", { hidden: true })).toHaveAttribute(
+          "aria-hidden",
+          "true"
+        );
+      });
+    });
+  });
+
+  describe("ホバー操作", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("ホバーで表示される", async () => {
+      const user = userEvent.setup();
+      render(
+        <Tooltip content="This is a tooltip" delay={0}>
+          <button>Hover me</button>
+        </Tooltip>
+      );
+      const trigger = screen.getByRole("button");
+
+      await user.hover(trigger);
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip")).toHaveAttribute(
+          "aria-hidden",
+          "false"
+        );
+      });
+    });
+
+    it("ホバー解除で閉じる", async () => {
+      const user = userEvent.setup();
+      render(
+        <Tooltip content="This is a tooltip" delay={0}>
+          <button>Hover me</button>
+        </Tooltip>
+      );
+      const trigger = screen.getByRole("button");
+
+      await user.hover(trigger);
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip")).toHaveAttribute(
+          "aria-hidden",
+          "false"
+        );
+      });
+
+      await user.unhover(trigger);
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip", { hidden: true })).toHaveAttribute(
+          "aria-hidden",
+          "true"
+        );
+      });
+    });
+
+    it("delay 後に表示される", async () => {
+      const user = userEvent.setup();
+      render(
+        <Tooltip content="This is a tooltip" delay={100}>
+          <button>Hover me</button>
+        </Tooltip>
+      );
+      const trigger = screen.getByRole("button");
+
+      await user.hover(trigger);
+
+      // delay 前は非表示（直後）
+      expect(screen.getByRole("tooltip", { hidden: true })).toHaveAttribute(
+        "aria-hidden",
+        "true"
+      );
+
+      // delay 後は表示
+      await waitFor(
+        () => {
+          expect(screen.getByRole("tooltip")).toHaveAttribute(
+            "aria-hidden",
+            "false"
+          );
+        },
+        { timeout: 200 }
+      );
+    });
+  });
+
+  // 🟡 Medium Priority: アクセシビリティ検証
+  describe("アクセシビリティ", () => {
+    it("axe による WCAG 2.1 AA 違反がない（非表示状態）", async () => {
+      const { container } = render(
+        <Tooltip content="This is a tooltip">
+          <button>Hover me</button>
+        </Tooltip>
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("axe による WCAG 2.1 AA 違反がない（表示状態）", async () => {
+      const user = userEvent.setup();
+      const { container } = render(
+        <Tooltip content="This is a tooltip" delay={0}>
+          <button>Hover me</button>
+        </Tooltip>
+      );
+
+      await user.hover(screen.getByRole("button"));
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip")).toHaveAttribute(
+          "aria-hidden",
+          "false"
+        );
+      });
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("tooltip がフォーカスを受け取らない", () => {
+      render(
+        <Tooltip content="This is a tooltip">
+          <button>Hover me</button>
+        </Tooltip>
+      );
+      const tooltip = screen.getByRole("tooltip", { hidden: true });
+      expect(tooltip).not.toHaveAttribute("tabindex");
+    });
+  });
+
+  describe("Props", () => {
+    it("placement prop で位置を変更できる", () => {
+      render(
+        <Tooltip content="Tooltip" placement="bottom">
+          <button>Hover me</button>
+        </Tooltip>
+      );
+      const tooltip = screen.getByRole("tooltip", { hidden: true });
+      expect(tooltip).toHaveClass("top-full");
+    });
+
+    it("disabled の場合、tooltip が表示されない", async () => {
+      const user = userEvent.setup();
+      render(
+        <Tooltip content="Tooltip" delay={0} disabled>
+          <button>Hover me</button>
+        </Tooltip>
+      );
+      const trigger = screen.getByRole("button");
+
+      await user.hover(trigger);
+      // disabled なので表示されない (delay=0 なので即時)
+      expect(screen.getByRole("tooltip", { hidden: true })).toHaveAttribute(
+        "aria-hidden",
+        "true"
+      );
+    });
+
+    it("id prop でカスタム ID を設定できる", () => {
+      render(
+        <Tooltip content="Tooltip" id="custom-tooltip-id">
+          <button>Hover me</button>
+        </Tooltip>
+      );
+      const tooltip = screen.getByRole("tooltip", { hidden: true });
+      expect(tooltip).toHaveAttribute("id", "custom-tooltip-id");
+    });
+
+    it("onOpenChange が状態変化時に呼び出される", async () => {
+      const handleOpenChange = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <Tooltip content="Tooltip" delay={0} onOpenChange={handleOpenChange}>
+          <button>Hover me</button>
+        </Tooltip>
+      );
+      const trigger = screen.getByRole("button");
+
+      await user.hover(trigger);
+      await waitFor(() => {
+        expect(handleOpenChange).toHaveBeenCalledWith(true);
+      });
+
+      await user.unhover(trigger);
+      await waitFor(() => {
+        expect(handleOpenChange).toHaveBeenCalledWith(false);
+      });
+    });
+
+    it("controlled open prop で制御できる", () => {
+      const { rerender } = render(
+        <Tooltip content="Tooltip" open={false}>
+          <button>Hover me</button>
+        </Tooltip>
+      );
+
+      expect(screen.getByRole("tooltip", { hidden: true })).toHaveAttribute(
+        "aria-hidden",
+        "true"
+      );
+
+      rerender(
+        <Tooltip content="Tooltip" open={true}>
+          <button>Hover me</button>
+        </Tooltip>
+      );
+
+      expect(screen.getByRole("tooltip")).toHaveAttribute(
+        "aria-hidden",
+        "false"
+      );
+    });
+  });
+
+  // 🟢 Low Priority: 拡張性
+  describe("HTML 属性継承", () => {
+    it("className が正しくマージされる", () => {
+      render(
+        <Tooltip content="Tooltip" className="custom-class">
+          <button>Hover me</button>
+        </Tooltip>
+      );
+      const wrapper = screen.getByRole("button").parentElement;
+      expect(wrapper).toHaveClass("custom-class");
+      expect(wrapper).toHaveClass("apg-tooltip-trigger");
+    });
+
+    it("tooltipClassName が適用される", () => {
+      render(
+        <Tooltip content="Tooltip" tooltipClassName="custom-tooltip">
+          <button>Hover me</button>
+        </Tooltip>
+      );
+      const tooltip = screen.getByRole("tooltip", { hidden: true });
+      expect(tooltip).toHaveClass("custom-tooltip");
+    });
+  });
+});

--- a/src/patterns/tooltip/Tooltip.test.vue.ts
+++ b/src/patterns/tooltip/Tooltip.test.vue.ts
@@ -1,0 +1,161 @@
+import { render, screen, waitFor } from "@testing-library/vue";
+import userEvent from "@testing-library/user-event";
+import { axe } from "jest-axe";
+import { describe, expect, it, vi } from "vitest";
+import Tooltip from "./Tooltip.vue";
+
+describe("Tooltip (Vue)", () => {
+  describe("APG: ARIA 属性", () => {
+    it('role="tooltip" を持つ', () => {
+      render(Tooltip, {
+        props: { content: "This is a tooltip" },
+        slots: { default: "<button>Hover me</button>" },
+      });
+      expect(screen.getByRole("tooltip", { hidden: true })).toBeInTheDocument();
+    });
+
+    it("非表示時は aria-hidden が true", () => {
+      render(Tooltip, {
+        props: { content: "This is a tooltip" },
+        slots: { default: "<button>Hover me</button>" },
+      });
+      const tooltip = screen.getByRole("tooltip", { hidden: true });
+      expect(tooltip).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("表示時は aria-hidden が false", async () => {
+      const user = userEvent.setup();
+      render(Tooltip, {
+        props: { content: "This is a tooltip", delay: 0 },
+        slots: { default: "<button>Hover me</button>" },
+      });
+      const trigger = screen.getByRole("button");
+
+      await user.hover(trigger);
+      await waitFor(() => {
+        const tooltip = screen.getByRole("tooltip");
+        expect(tooltip).toHaveAttribute("aria-hidden", "false");
+      });
+    });
+  });
+
+  describe("APG: キーボード操作", () => {
+    it("Escape キーで閉じる", async () => {
+      const user = userEvent.setup();
+      render(Tooltip, {
+        props: { content: "This is a tooltip", delay: 0 },
+        slots: { default: "<button>Hover me</button>" },
+      });
+      const trigger = screen.getByRole("button");
+
+      await user.hover(trigger);
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip")).toHaveAttribute("aria-hidden", "false");
+      });
+
+      await user.keyboard("{Escape}");
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip", { hidden: true })).toHaveAttribute("aria-hidden", "true");
+      });
+    });
+
+    it("フォーカスで表示される", async () => {
+      const user = userEvent.setup();
+      render(Tooltip, {
+        props: { content: "This is a tooltip", delay: 0 },
+        slots: { default: "<button>Hover me</button>" },
+      });
+
+      await user.tab();
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip")).toHaveAttribute("aria-hidden", "false");
+      });
+    });
+  });
+
+  describe("ホバー操作", () => {
+    it("ホバーで表示される", async () => {
+      const user = userEvent.setup();
+      render(Tooltip, {
+        props: { content: "This is a tooltip", delay: 0 },
+        slots: { default: "<button>Hover me</button>" },
+      });
+
+      await user.hover(screen.getByRole("button"));
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip")).toHaveAttribute("aria-hidden", "false");
+      });
+    });
+
+    it("ホバー解除で閉じる", async () => {
+      const user = userEvent.setup();
+      render(Tooltip, {
+        props: { content: "This is a tooltip", delay: 0 },
+        slots: { default: "<button>Hover me</button>" },
+      });
+      const trigger = screen.getByRole("button");
+
+      await user.hover(trigger);
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip")).toHaveAttribute("aria-hidden", "false");
+      });
+
+      await user.unhover(trigger);
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip", { hidden: true })).toHaveAttribute("aria-hidden", "true");
+      });
+    });
+  });
+
+  describe("アクセシビリティ", () => {
+    it("axe による WCAG 2.1 AA 違反がない", async () => {
+      const { container } = render(Tooltip, {
+        props: { content: "This is a tooltip" },
+        slots: { default: "<button>Hover me</button>" },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("tooltip がフォーカスを受け取らない", () => {
+      render(Tooltip, {
+        props: { content: "This is a tooltip" },
+        slots: { default: "<button>Hover me</button>" },
+      });
+      const tooltip = screen.getByRole("tooltip", { hidden: true });
+      expect(tooltip).not.toHaveAttribute("tabindex");
+    });
+  });
+
+  describe("Props", () => {
+    it("placement prop で位置を変更できる", () => {
+      render(Tooltip, {
+        props: { content: "Tooltip", placement: "bottom" },
+        slots: { default: "<button>Hover me</button>" },
+      });
+      const tooltip = screen.getByRole("tooltip", { hidden: true });
+      expect(tooltip).toHaveClass("top-full");
+    });
+
+    it("disabled の場合、tooltip が表示されない", async () => {
+      const user = userEvent.setup();
+      render(Tooltip, {
+        props: { content: "Tooltip", delay: 0, disabled: true },
+        slots: { default: "<button>Hover me</button>" },
+      });
+
+      await user.hover(screen.getByRole("button"));
+      await new Promise((r) => setTimeout(r, 50));
+      expect(screen.getByRole("tooltip", { hidden: true })).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("id prop でカスタム ID を設定できる", () => {
+      render(Tooltip, {
+        props: { content: "Tooltip", id: "custom-tooltip-id" },
+        slots: { default: "<button>Hover me</button>" },
+      });
+      const tooltip = screen.getByRole("tooltip", { hidden: true });
+      expect(tooltip).toHaveAttribute("id", "custom-tooltip-id");
+    });
+  });
+});

--- a/src/patterns/tooltip/Tooltip.tsx
+++ b/src/patterns/tooltip/Tooltip.tsx
@@ -1,0 +1,156 @@
+import { cn } from "@/lib/utils";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type TooltipPlacement = "top" | "bottom" | "left" | "right";
+
+export interface TooltipProps {
+  /** Tooltip content */
+  content: ReactNode;
+  /** Trigger element */
+  children: ReactNode;
+  /** Controlled open state */
+  open?: boolean;
+  /** Default open state (uncontrolled) */
+  defaultOpen?: boolean;
+  /** Callback when open state changes */
+  onOpenChange?: (open: boolean) => void;
+  /** Delay before showing tooltip (ms) */
+  delay?: number;
+  /** Tooltip placement */
+  placement?: TooltipPlacement;
+  /** Custom tooltip ID for SSR */
+  id?: string;
+  /** Whether the tooltip is disabled */
+  disabled?: boolean;
+  /** Additional class name for the wrapper */
+  className?: string;
+  /** Additional class name for the tooltip content */
+  tooltipClassName?: string;
+}
+
+export const Tooltip: React.FC<TooltipProps> = ({
+  content,
+  children,
+  open: controlledOpen,
+  defaultOpen = false,
+  onOpenChange,
+  delay = 300,
+  placement = "top",
+  id: providedId,
+  disabled = false,
+  className,
+  tooltipClassName,
+}) => {
+  const generatedId = useId();
+  const tooltipId = providedId ?? `tooltip-${generatedId}`;
+
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const isControlled = controlledOpen !== undefined;
+  const isOpen = isControlled ? controlledOpen : internalOpen;
+
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+
+  const setOpen = useCallback(
+    (value: boolean) => {
+      if (!isControlled) {
+        setInternalOpen(value);
+      }
+      onOpenChange?.(value);
+    },
+    [isControlled, onOpenChange]
+  );
+
+  const showTooltip = useCallback(() => {
+    if (disabled) return;
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    timeoutRef.current = setTimeout(() => {
+      setOpen(true);
+    }, delay);
+  }, [delay, disabled, setOpen]);
+
+  const hideTooltip = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    setOpen(false);
+  }, [setOpen]);
+
+  // Handle Escape key
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        hideTooltip();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, hideTooltip]);
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const placementClasses: Record<TooltipPlacement, string> = {
+    top: "bottom-full left-1/2 -translate-x-1/2 mb-2",
+    bottom: "top-full left-1/2 -translate-x-1/2 mt-2",
+    left: "right-full top-1/2 -translate-y-1/2 mr-2",
+    right: "left-full top-1/2 -translate-y-1/2 ml-2",
+  };
+
+  return (
+    <span
+      ref={triggerRef}
+      className={cn("apg-tooltip-trigger", "relative inline-block", className)}
+      onMouseEnter={showTooltip}
+      onMouseLeave={hideTooltip}
+      onFocus={showTooltip}
+      onBlur={hideTooltip}
+      aria-describedby={isOpen && !disabled ? tooltipId : undefined}
+    >
+      {children}
+      <span
+        ref={tooltipRef}
+        id={tooltipId}
+        role="tooltip"
+        aria-hidden={!isOpen}
+        className={cn(
+          "apg-tooltip",
+          "absolute z-50 px-3 py-1.5 text-sm",
+          "bg-gray-900 text-white rounded-md shadow-lg",
+          "dark:bg-gray-100 dark:text-gray-900",
+          "pointer-events-none whitespace-nowrap",
+          "transition-opacity duration-150",
+          placementClasses[placement],
+          isOpen ? "opacity-100 visible" : "opacity-0 invisible",
+          tooltipClassName
+        )}
+      >
+        {content}
+      </span>
+    </span>
+  );
+};
+
+export default Tooltip;

--- a/src/patterns/tooltip/Tooltip.vue
+++ b/src/patterns/tooltip/Tooltip.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted, watch } from "vue";
+import { cn } from "@/lib/utils";
+
+export type TooltipPlacement = "top" | "bottom" | "left" | "right";
+
+export interface TooltipProps {
+  /** Tooltip content */
+  content: string;
+  /** Controlled open state */
+  open?: boolean;
+  /** Default open state (uncontrolled) */
+  defaultOpen?: boolean;
+  /** Delay before showing tooltip (ms) */
+  delay?: number;
+  /** Tooltip placement */
+  placement?: TooltipPlacement;
+  /** Custom tooltip ID for SSR */
+  id?: string;
+  /** Whether the tooltip is disabled */
+  disabled?: boolean;
+  /** Additional class name for the wrapper */
+  class?: string;
+  /** Additional class name for the tooltip content */
+  tooltipClass?: string;
+}
+
+const props = withDefaults(defineProps<TooltipProps>(), {
+  open: undefined,
+  defaultOpen: false,
+  delay: 300,
+  placement: "top",
+  id: undefined,
+  disabled: false,
+  class: "",
+  tooltipClass: "",
+});
+
+const emit = defineEmits<{
+  "update:open": [value: boolean];
+}>();
+
+// Generate unique ID
+let uid = "";
+onMounted(() => {
+  uid = props.id ?? `tooltip-${crypto.randomUUID().slice(0, 8)}`;
+  tooltipId.value = uid;
+});
+
+const tooltipId = ref(props.id ?? "");
+
+const internalOpen = ref(props.defaultOpen);
+const isControlled = computed(() => props.open !== undefined);
+const isOpen = computed(() =>
+  isControlled.value ? props.open : internalOpen.value
+);
+
+let timeout: ReturnType<typeof setTimeout> | null = null;
+
+const setOpen = (value: boolean) => {
+  if (!isControlled.value) {
+    internalOpen.value = value;
+  }
+  emit("update:open", value);
+};
+
+const showTooltip = () => {
+  if (props.disabled) return;
+  if (timeout) {
+    clearTimeout(timeout);
+  }
+  timeout = setTimeout(() => {
+    setOpen(true);
+  }, props.delay);
+};
+
+const hideTooltip = () => {
+  if (timeout) {
+    clearTimeout(timeout);
+    timeout = null;
+  }
+  setOpen(false);
+};
+
+const handleKeyDown = (event: KeyboardEvent) => {
+  if (event.key === "Escape" && isOpen.value) {
+    hideTooltip();
+  }
+};
+
+watch(isOpen, (newValue) => {
+  if (newValue) {
+    document.addEventListener("keydown", handleKeyDown);
+  } else {
+    document.removeEventListener("keydown", handleKeyDown);
+  }
+});
+
+onUnmounted(() => {
+  if (timeout) {
+    clearTimeout(timeout);
+  }
+  document.removeEventListener("keydown", handleKeyDown);
+});
+
+const placementClasses: Record<TooltipPlacement, string> = {
+  top: "bottom-full left-1/2 -translate-x-1/2 mb-2",
+  bottom: "top-full left-1/2 -translate-x-1/2 mt-2",
+  left: "right-full top-1/2 -translate-y-1/2 mr-2",
+  right: "left-full top-1/2 -translate-y-1/2 ml-2",
+};
+</script>
+
+<template>
+  <span
+    :class="cn('apg-tooltip-trigger', 'relative inline-block', props.class)"
+    @mouseenter="showTooltip"
+    @mouseleave="hideTooltip"
+    @focusin="showTooltip"
+    @focusout="hideTooltip"
+    :aria-describedby="isOpen && !disabled ? tooltipId : undefined"
+  >
+    <slot />
+    <span
+      :id="tooltipId"
+      role="tooltip"
+      :aria-hidden="!isOpen"
+      :class="
+        cn(
+          'apg-tooltip',
+          'absolute z-50 px-3 py-1.5 text-sm',
+          'bg-gray-900 text-white rounded-md shadow-lg',
+          'dark:bg-gray-100 dark:text-gray-900',
+          'pointer-events-none whitespace-nowrap',
+          'transition-opacity duration-150',
+          placementClasses[placement],
+          isOpen ? 'opacity-100 visible' : 'opacity-0 invisible',
+          props.tooltipClass
+        )
+      "
+    >
+      {{ content }}
+    </span>
+  </span>
+</template>

--- a/src/patterns/tooltip/TooltipDemo.svelte
+++ b/src/patterns/tooltip/TooltipDemo.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import Tooltip from "./Tooltip.svelte";
+</script>
+
+<div class="flex flex-wrap items-center gap-8">
+  <Tooltip id="tooltip-save" content="Save your changes">
+    {#snippet children({ describedBy })}
+      <button
+        class="px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90"
+        aria-describedby={describedBy}
+      >
+        Save
+      </button>
+    {/snippet}
+  </Tooltip>
+
+  <Tooltip id="tooltip-right" content="This appears on the right" placement="right">
+    {#snippet children({ describedBy })}
+      <button
+        class="px-4 py-2 bg-secondary text-secondary-foreground rounded-md hover:bg-secondary/90"
+        aria-describedby={describedBy}
+      >
+        Right tooltip
+      </button>
+    {/snippet}
+  </Tooltip>
+
+  <Tooltip id="tooltip-bottom" content="This appears below" placement="bottom">
+    {#snippet children({ describedBy })}
+      <button
+        class="px-4 py-2 bg-secondary text-secondary-foreground rounded-md hover:bg-secondary/90"
+        aria-describedby={describedBy}
+      >
+        Bottom tooltip
+      </button>
+    {/snippet}
+  </Tooltip>
+
+  <Tooltip id="tooltip-disabled" content="This tooltip is disabled" disabled={true}>
+    {#snippet children({ describedBy })}
+      <button
+        class="px-4 py-2 bg-muted text-muted-foreground rounded-md"
+        aria-describedby={describedBy}
+      >
+        Disabled tooltip
+      </button>
+    {/snippet}
+  </Tooltip>
+</div>

--- a/src/patterns/tooltip/test-wrappers/TooltipTestWrapper.svelte
+++ b/src/patterns/tooltip/test-wrappers/TooltipTestWrapper.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import Tooltip from "../Tooltip.svelte";
+  import type { TooltipPlacement } from "../Tooltip.svelte";
+
+  interface Props {
+    content?: string;
+    delay?: number;
+    placement?: TooltipPlacement;
+    disabled?: boolean;
+    id?: string;
+  }
+
+  let {
+    content = "Tooltip",
+    delay = 300,
+    placement = "top",
+    disabled = false,
+    id = "test-tooltip",
+  }: Props = $props();
+</script>
+
+<Tooltip {content} {delay} {placement} {disabled} {id}>
+  {#snippet children({ describedBy })}
+    <button type="button" aria-describedby={describedBy}>Hover me</button>
+  {/snippet}
+</Tooltip>


### PR DESCRIPTION
## Summary

   - WAI-ARIA APG Tooltip パターンを React, Vue, Svelte, Astro
   の4フレームワークで実装
   - Codex によるコードレビューを経て、Svelte 版は
   SSR/ハイドレーション対応のベストプラクティスに準拠

   ## Changes

   ### 新規ファイル
   - `src/patterns/tooltip/` - 4フレームワークのTooltip実装とテスト
   - `src/pages/patterns/tooltip/` - 各フレームワークのデモページ

   ### Svelte 版の特徴（Codex レビュー反映）

   | 課題 | 対応 |
   |------|------|
   | SSRでのID生成問題 | `id` を必須 props に変更 |
   | クリーンアップ処理の欠如 | `onDestroy` で timeout/listener 破棄 |
   | aria-describedby の付与先 | render props パターンで子要素に渡す |
   | 外部制御時の Escape 対応 | `$effect` で `isOpen` を監視 |

   ### アクセシビリティ
   - `role="tooltip"` と `aria-describedby` による関連付け
   - Escape キーでツールチップを閉じる
   - フォーカス/ホバーで表示、フォーカスアウト/マウスリーブで非表示

   ## Test plan
   - [x] `npm run test` - 全478テストがパス
   - [x] `npm run build` - ビルド成功
   - [x] 各フレームワークのデモページでツールチップの動作確認
   - [x] キーボード操作（Tab, Escape）の確認
   - [ ] スクリーンリーダーでの読み上げ確認