### PR TITLE
fix: improve pattern navigation UX and maintainability

### DIFF
--- a/src/components/ui/pattern-sidebar/PatternSidebar.astro
+++ b/src/components/ui/pattern-sidebar/PatternSidebar.astro
@@ -36,8 +36,10 @@ const frameworkLabel = FRAMEWORK_INFO[currentFramework].label;
             href={withBase(`/patterns/${pattern.id}/${currentFramework}/`)}
             active={currentPattern === pattern.id}
             aria-current={currentPattern === pattern.id ? "page" : undefined}
+            size="sm"
+            class="text-sm"
           >
-            <span class="text-base" aria-hidden="true">
+            <span class="text-xs" aria-hidden="true">
               {pattern.icon}
             </span>
             <span>{pattern.name}</span>
@@ -55,13 +57,13 @@ const frameworkLabel = FRAMEWORK_INFO[currentFramework].label;
             Planned
           </h3>
         </div>
-        <ul class="flex w-full min-w-0 flex-col gap-1">
+        <ul class="flex w-full min-w-0 flex-col gap-1 pb-8">
           {plannedPatterns.map((pattern) => (
             <li class="group/menu-item relative">
               <span
-                class="flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm text-muted-foreground opacity-60 cursor-default"
+                class="flex h-7 w-full items-center gap-2 overflow-hidden rounded-md px-2 text-left text-sm text-muted-foreground opacity-60 cursor-default"
               >
-                <span class="text-base" aria-hidden="true">
+                <span class="text-xs" aria-hidden="true">
                   {pattern.icon}
                 </span>
                 <span class="truncate">{pattern.name}</span>

--- a/src/components/ui/sidebar/sidebar-menu-button.astro
+++ b/src/components/ui/sidebar/sidebar-menu-button.astro
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const variants = cva(
-  "hover:bg-accent hover:text-accent-foreground active:bg-accent active:text-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 disabled:pointer-events-none disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "hover:bg-accent hover:text-accent-foreground active:bg-accent active:text-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/src/layouts/PatternLayout.astro
+++ b/src/layouts/PatternLayout.astro
@@ -27,7 +27,7 @@ const hasToc = tocItems.length > 0;
     ]}>
       <!-- Sidebar (desktop only) -->
       <aside class="hidden lg:block">
-        <div class="sticky top-20">
+        <div class="sticky top-20 max-h-[calc(100vh-5rem)] overflow-y-auto">
           <PatternSidebar currentPattern={pattern} currentFramework={framework} />
         </div>
       </aside>

--- a/src/lib/patterns.ts
+++ b/src/lib/patterns.ts
@@ -147,8 +147,8 @@ export const PATTERNS: Pattern[] = [
     description:
       "An input widget with an associated popup that enables users to select a value from a collection.",
     icon: "🔽",
-    complexity: "Low",
-    status: "available",
+    complexity: "High",
+    status: "planned",
   },
   {
     id: "menu-button",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,45 +2,9 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { Tile, TileContent, TileTitle, TileDescription } from '@/components/ui/tile';
 import { withBase } from '@/lib/utils';
+import { getAvailablePatterns } from '@/lib/patterns';
 
-const patterns = [
-  {
-    name: 'Toggle Button',
-    description: 'Button with pressed state',
-    href: withBase('/patterns/button/react/'),
-    icon: '🔘',
-  },
-  {
-    name: 'Tabs',
-    description: 'Tabbed interface with keyboard navigation',
-    href: withBase('/patterns/tabs/react/'),
-    icon: '📑',
-  },
-  {
-    name: 'Accordion',
-    description: 'Collapsible content sections',
-    href: withBase('/patterns/accordion/react/'),
-    icon: '📋',
-  },
-  {
-    name: 'Dialog',
-    description: 'Modal dialog with focus management',
-    href: withBase('/patterns/dialog/react/'),
-    icon: '💬',
-  },
-  {
-    name: 'Toolbar',
-    description: 'Grouped controls with keyboard navigation',
-    href: withBase('/patterns/toolbar/react/'),
-    icon: '🛠️',
-  },
-  {
-    name: 'Switch',
-    description: 'Toggle between on and off states',
-    href: withBase('/patterns/switch/react/'),
-    icon: '🔛',
-  },
-];
+const availablePatterns = getAvailablePatterns();
 ---
 
 <BaseLayout title="Home">
@@ -82,8 +46,8 @@ const patterns = [
     <section class="mt-16">
       <h2 class="mb-6 text-2xl font-bold">Available Patterns</h2>
       <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        {patterns.map((pattern) => (
-          <Tile variant="floating" href={pattern.href}>
+        {availablePatterns.map((pattern) => (
+          <Tile variant="floating" href={withBase(`/patterns/${pattern.id}/react/`)}>
             <TileContent class="flex flex-row items-center gap-4 text-left">
               <div class="flex h-12 w-12 items-center justify-center rounded-full bg-muted text-2xl shrink-0">
                 {pattern.icon}


### PR DESCRIPTION
## Summary

   - Make pattern sidebar scrollable when content exceeds viewport height
   - Reduce navigation link height for a more compact design
   - Use inset focus ring style to prevent clipping
   - Generate home page "Available Patterns" from `patterns.ts` for single source of
   truth
   - Move Combobox back to planned status (not yet implemented)

   ## Test plan

   - [ ] Verify sidebar scrolls when pattern list exceeds viewport
   - [ ] Verify focus ring is fully visible when navigating with keyboard
   - [ ] Verify home page displays all available patterns from `patterns.ts`
   - [ ] Verify Combobox appears in the Planned section