### PR TITLE
fix: add Astro to framework list in site copy

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -16,7 +16,7 @@ import { Tile, TileContent, TileTitle, TileDescription } from '@/components/ui/t
       <h2 class="text-2xl font-semibold mb-4">What is this project?</h2>
       <p class="text-muted-foreground mb-4">
         APG Patterns Examples provides production-ready implementations of WAI-ARIA design patterns
-        in React, Vue, and Svelte. Each pattern follows the official
+        in React, Vue, Svelte, and Astro. Each pattern follows the official
         <a href="https://www.w3.org/WAI/ARIA/apg/" target="_blank" rel="noopener noreferrer" class="text-primary hover:underline">
           WAI-ARIA Authoring Practices Guide (APG)
         </a> specifications.
@@ -34,7 +34,7 @@ import { Tile, TileContent, TileTitle, TileDescription } from '@/components/ui/t
           <TileContent>
             <TileTitle>Multi-Framework</TileTitle>
             <TileDescription>
-              Each pattern is implemented in React, Vue, and Svelte with framework-specific best practices.
+              Each pattern is implemented in React, Vue, Svelte, and Astro with framework-specific best practices.
             </TileDescription>
           </TileContent>
         </Tile>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,7 +11,7 @@ const availablePatterns = getAvailablePatterns();
   <div class="text-center">
     <h1 class="mb-4 text-4xl font-bold">APG Patterns Examples</h1>
     <p class="mb-8 text-lg text-muted-foreground">
-      Accessible component patterns for React, Vue, and Svelte
+      Accessible component patterns for React, Vue, Svelte, and Astro
     </p>
 
     <div class="grid gap-6 md:grid-cols-3">


### PR DESCRIPTION
Update homepage and about page descriptions to include Astro alongside React, Vue, and Svelte.

# Pull Request

## 概要
<!-- このPRで実装・修正する内容を簡潔に説明してください -->

## 変更内容
<!-- 具体的な変更点をリストアップしてください -->
- [ ] 新機能追加
- [ ] バグ修正  
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] テスト追加/修正

## APGパターン準拠チェック
<!-- アクセシビリティ関連の変更がある場合はチェックしてください -->
- [ ] ARIA属性の適切な使用
- [ ] キーボードナビゲーション対応
- [ ] スクリーンリーダー対応
- [ ] フォーカス管理の実装
- [ ] 色・コントラストの考慮

## テスト
<!-- テスト方法や確認項目を記載してください -->
- [ ] 手動テスト完了
- [ ] 自動テスト追加/更新
- [ ] アクセシビリティテスト実施
- [ ] 複数ブラウザでの動作確認

## 破壊的変更
- [ ] 破壊的変更あり（詳細を下記に記載）
- [ ] 破壊的変更なし

## その他
<!-- レビュー時の注意点や補足情報があれば記載してください -->

## 関連Issue/TODO
<!-- 関連するIssueやTODOがあれば記載してください -->
- Closes #
- Related to #