### PR TITLE
feat: implement Alert APG pattern with SSR-safe design

### DIFF
--- a/src/lib/patterns.ts
+++ b/src/lib/patterns.ts
@@ -93,9 +93,6 @@ export const PATTERNS: Pattern[] = [
     complexity: "Medium",
     status: "available",
   },
-  // ============================================
-  // Planned patterns (not yet implemented)
-  // ============================================
   {
     id: "alert",
     name: "Alert",
@@ -103,8 +100,11 @@ export const PATTERNS: Pattern[] = [
       "An element that displays a brief, important message in a way that attracts the user's attention without interrupting the user's task.",
     icon: "⚠️",
     complexity: "Low",
-    status: "planned",
+    status: "available",
   },
+  // ============================================
+  // Planned patterns (not yet implemented)
+  // ============================================
   {
     id: "alert-dialog",
     name: "Alert Dialog",

--- a/src/pages/patterns/[pattern]/index.astro
+++ b/src/pages/patterns/[pattern]/index.astro
@@ -7,7 +7,7 @@ import { withBase } from "@/lib/utils";
 
 export function getStaticPaths() {
   // Add new patterns here as they are implemented
-  const patterns = ["button", "tabs", "accordion", "dialog", "toolbar", "switch", "tooltip"];
+  const patterns = ["alert", "button", "tabs", "accordion", "dialog", "toolbar", "switch", "tooltip"];
   return patterns.map((pattern) => ({ params: { pattern } }));
 }
 

--- a/src/pages/patterns/alert/astro/index.astro
+++ b/src/pages/patterns/alert/astro/index.astro
@@ -1,0 +1,239 @@
+---
+import PatternLayout from '../../../../layouts/PatternLayout.astro';
+import Alert from '@patterns/alert/Alert.astro';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AccessibilityDocs from '@patterns/alert/AccessibilityDocs.astro';
+import TestingDocs from '@patterns/alert/TestingDocs.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/alert/Alert.astro?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
+---
+
+<PatternLayout title="Alert - Astro" pattern="alert" framework="astro" tocItems={tocItems}>
+  <header class="mb-8">
+    <h1 class="text-3xl font-bold mb-4">Alert</h1>
+    <p class="text-lg text-muted-foreground">
+      An element that displays a brief, important message in a way that attracts the user's attention without interrupting the user's task.
+    </p>
+  </header>
+
+  <!-- Framework Selector -->
+  <FrameworkTabs pattern="alert" currentFramework="astro" />
+
+  <!-- Demo Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
+    <p class="text-muted-foreground mb-4">
+      The Astro implementation uses a Web Component that provides a <code>setMessage()</code> method for updating alert content.
+      The live region container exists in the DOM from page load - only the content changes.
+    </p>
+    <div class="p-6 rounded-lg border border-border bg-background">
+      <div class="space-y-4">
+        <Alert id="demo-alert" variant="info" dismissible />
+        <div class="flex flex-wrap gap-2">
+          <button
+            type="button"
+            class="px-4 py-2 text-sm font-medium text-blue-700 bg-blue-100 rounded-md hover:bg-blue-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            onclick="document.querySelector('apg-alert').setMessage('This is an informational message.', 'info')"
+          >
+            Info
+          </button>
+          <button
+            type="button"
+            class="px-4 py-2 text-sm font-medium text-green-700 bg-green-100 rounded-md hover:bg-green-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+            onclick="document.querySelector('apg-alert').setMessage('Operation completed successfully!', 'success')"
+          >
+            Success
+          </button>
+          <button
+            type="button"
+            class="px-4 py-2 text-sm font-medium text-amber-700 bg-amber-100 rounded-md hover:bg-amber-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-500"
+            onclick="document.querySelector('apg-alert').setMessage('Please review your input before proceeding.', 'warning')"
+          >
+            Warning
+          </button>
+          <button
+            type="button"
+            class="px-4 py-2 text-sm font-medium text-red-700 bg-red-100 rounded-md hover:bg-red-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+            onclick="document.querySelector('apg-alert').setMessage('An error occurred. Please try again.', 'error')"
+          >
+            Error
+          </button>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Accessibility Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
+    <AccessibilityDocs />
+  </section>
+
+  <!-- Source Code Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
+    <CodeBlock
+      code={sourceCode}
+      lang="astro"
+      title="Alert.astro"
+    />
+  </section>
+
+  <!-- Usage Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
+    <CodeBlock
+      code={`---
+import Alert from './Alert.astro';
+---
+
+<!-- IMPORTANT: Alert container is always in DOM -->
+<Alert
+  id="my-alert"
+  variant="info"
+  dismissible
+/>
+
+<button onclick="document.querySelector('apg-alert').setMessage('Hello!')">
+  Show Alert
+</button>
+
+<script>
+  // Listen for dismiss events
+  document.querySelector('apg-alert')?.addEventListener('dismiss', () => {
+    console.log('Alert dismissed');
+  });
+</script>`}
+      lang="astro"
+      title="Example"
+    />
+  </section>
+
+  <!-- API Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
+    <h3 class="text-lg font-medium mb-3">Props</h3>
+    <ResponsiveTable>
+      <table class="w-full border-collapse">
+        <thead>
+          <tr class="border-b border-border">
+            <th class="text-left py-2 pr-4">Prop</th>
+            <th class="text-left py-2 pr-4">Type</th>
+            <th class="text-left py-2 pr-4">Default</th>
+            <th class="text-left py-2">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>message</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">string</td>
+            <td class="py-2 pr-4 text-muted-foreground">''</td>
+            <td class="py-2">Initial alert message</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>variant</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">'info' | 'success' | 'warning' | 'error'</td>
+            <td class="py-2 pr-4 text-muted-foreground">'info'</td>
+            <td class="py-2">Visual style variant</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>dismissible</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+            <td class="py-2 pr-4 text-muted-foreground">false</td>
+            <td class="py-2">Show dismiss button</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>id</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">string</td>
+            <td class="py-2 pr-4 text-muted-foreground">auto-generated</td>
+            <td class="py-2">Custom ID</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>class</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">string</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Additional CSS classes</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+
+    <h3 class="text-lg font-medium mb-3 mt-6">Methods</h3>
+    <ResponsiveTable>
+      <table class="w-full border-collapse">
+        <thead>
+          <tr class="border-b border-border">
+            <th class="text-left py-2 pr-4">Method</th>
+            <th class="text-left py-2">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>setMessage(message, variant?)</code></td>
+            <td class="py-2">Update alert message programmatically. The container remains in DOM.</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+
+    <h3 class="text-lg font-medium mb-3 mt-6">Events</h3>
+    <ResponsiveTable>
+      <table class="w-full border-collapse">
+        <thead>
+          <tr class="border-b border-border">
+            <th class="text-left py-2 pr-4">Event</th>
+            <th class="text-left py-2">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>dismiss</code></td>
+            <td class="py-2">Fired when dismiss button is clicked</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </section>
+
+  <!-- Testing Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
+    <TestingDocs />
+  </section>
+
+  <!-- Resources -->
+  <section>
+    <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
+    <ul class="list-disc pl-6 space-y-2">
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/alert/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Alert Pattern
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Alert Dialog Pattern
+        </ExternalLink>
+      </li>
+    </ul>
+  </section>
+</PatternLayout>

--- a/src/pages/patterns/alert/react/index.astro
+++ b/src/pages/patterns/alert/react/index.astro
@@ -1,0 +1,191 @@
+---
+import PatternLayout from '../../../../layouts/PatternLayout.astro';
+import { AlertDemo } from '@patterns/alert/AlertDemo';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AccessibilityDocs from '@patterns/alert/AccessibilityDocs.astro';
+import TestingDocs from '@patterns/alert/TestingDocs.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/alert/Alert.tsx?raw';
+import testCode from '@patterns/alert/Alert.test.tsx?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
+---
+
+<PatternLayout title="Alert - React" pattern="alert" framework="react" tocItems={tocItems}>
+  <header class="mb-8">
+    <h1 class="text-3xl font-bold mb-4">Alert</h1>
+    <p class="text-lg text-muted-foreground">
+      An element that displays a brief, important message in a way that attracts the user's attention without interrupting the user's task.
+    </p>
+  </header>
+
+  <!-- Framework Selector -->
+  <FrameworkTabs pattern="alert" currentFramework="react" />
+
+  <!-- Demo Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
+    <p class="text-muted-foreground mb-4">
+      Click the buttons below to show alerts with different variants.
+      The live region container exists in the DOM from page load - only the content changes.
+    </p>
+    <div class="p-6 rounded-lg border border-border bg-background">
+      <AlertDemo client:load />
+    </div>
+  </section>
+
+  <!-- Accessibility Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
+    <AccessibilityDocs />
+  </section>
+
+  <!-- Source Code Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
+    <CodeBlock
+      code={sourceCode}
+      lang="tsx"
+      title="Alert.tsx"
+    />
+  </section>
+
+  <!-- Usage Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
+    <CodeBlock
+      code={`import { useState } from 'react';
+import { Alert } from './Alert';
+
+function App() {
+  const [message, setMessage] = useState('');
+
+  return (
+    <div>
+      {/* IMPORTANT: Alert container is always in DOM */}
+      <Alert
+        message={message}
+        variant="info"
+        dismissible
+        onDismiss={() => setMessage('')}
+      />
+
+      <button onClick={() => setMessage('Operation completed!')}>
+        Show Alert
+      </button>
+    </div>
+  );
+}`}
+      lang="tsx"
+      title="Example"
+    />
+  </section>
+
+  <!-- API Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
+    <ResponsiveTable>
+      <table class="w-full border-collapse">
+        <thead>
+          <tr class="border-b border-border">
+            <th class="text-left py-2 pr-4">Prop</th>
+            <th class="text-left py-2 pr-4">Type</th>
+            <th class="text-left py-2 pr-4">Default</th>
+            <th class="text-left py-2">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>message</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">string</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Alert message content</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>children</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">ReactNode</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Complex content (alternative to message)</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>variant</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">'info' | 'success' | 'warning' | 'error'</td>
+            <td class="py-2 pr-4 text-muted-foreground">'info'</td>
+            <td class="py-2">Visual style variant</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>dismissible</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+            <td class="py-2 pr-4 text-muted-foreground">false</td>
+            <td class="py-2">Show dismiss button</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>onDismiss</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">() =&gt; void</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Callback when dismissed</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>id</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">string</td>
+            <td class="py-2 pr-4 text-muted-foreground">auto-generated</td>
+            <td class="py-2">Custom ID for SSR</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>className</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">string</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Additional CSS classes</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </section>
+
+  <!-- Testing Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
+    <TestingDocs />
+    <div class="mt-6">
+      <CodeBlock
+        code={testCode}
+        lang="tsx"
+        title="Alert.test.tsx"
+      />
+    </div>
+  </section>
+
+  <!-- Resources -->
+  <section>
+    <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
+    <ul class="list-disc pl-6 space-y-2">
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/alert/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Alert Pattern
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Alert Dialog Pattern
+        </ExternalLink>
+      </li>
+    </ul>
+  </section>
+</PatternLayout>

--- a/src/pages/patterns/alert/svelte/index.astro
+++ b/src/pages/patterns/alert/svelte/index.astro
@@ -1,0 +1,188 @@
+---
+import PatternLayout from '../../../../layouts/PatternLayout.astro';
+import AlertDemo from '@patterns/alert/AlertDemo.svelte';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AccessibilityDocs from '@patterns/alert/AccessibilityDocs.astro';
+import TestingDocs from '@patterns/alert/TestingDocs.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/alert/Alert.svelte?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
+---
+
+<PatternLayout title="Alert - Svelte" pattern="alert" framework="svelte" tocItems={tocItems}>
+  <header class="mb-8">
+    <h1 class="text-3xl font-bold mb-4">Alert</h1>
+    <p class="text-lg text-muted-foreground">
+      An element that displays a brief, important message in a way that attracts the user's attention without interrupting the user's task.
+    </p>
+  </header>
+
+  <!-- Framework Selector -->
+  <FrameworkTabs pattern="alert" currentFramework="svelte" />
+
+  <!-- Demo Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
+    <p class="text-muted-foreground mb-4">
+      Click the buttons below to show alerts with different variants.
+      The live region container exists in the DOM from page load - only the content changes.
+    </p>
+    <div class="p-6 rounded-lg border border-border bg-background">
+      <AlertDemo client:load />
+    </div>
+  </section>
+
+  <!-- Accessibility Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
+    <AccessibilityDocs />
+  </section>
+
+  <!-- Source Code Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
+    <CodeBlock
+      code={sourceCode}
+      lang="svelte"
+      title="Alert.svelte"
+    />
+  </section>
+
+  <!-- Usage Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
+    <CodeBlock
+      code={`<script lang="ts">
+  import Alert from './Alert.svelte';
+
+  let message = $state('');
+
+  function showAlert() {
+    message = 'Operation completed!';
+  }
+
+  function clearAlert() {
+    message = '';
+  }
+</script>
+
+<!-- IMPORTANT: Alert container is always in DOM -->
+<Alert
+  id="my-alert"
+  {message}
+  variant="info"
+  dismissible
+  onDismiss={clearAlert}
+/>
+
+<button onclick={showAlert}>
+  Show Alert
+</button>`}
+      lang="svelte"
+      title="Example"
+    />
+  </section>
+
+  <!-- API Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
+    <h3 class="text-lg font-medium mb-3">Props</h3>
+    <ResponsiveTable>
+      <table class="w-full border-collapse">
+        <thead>
+          <tr class="border-b border-border">
+            <th class="text-left py-2 pr-4">Prop</th>
+            <th class="text-left py-2 pr-4">Type</th>
+            <th class="text-left py-2 pr-4">Default</th>
+            <th class="text-left py-2">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>id</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">string</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Required ID for SSR consistency</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>message</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">string</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Alert message content</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>children</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">Snippet</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Complex content (alternative to message)</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>variant</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">'info' | 'success' | 'warning' | 'error'</td>
+            <td class="py-2 pr-4 text-muted-foreground">'info'</td>
+            <td class="py-2">Visual style variant</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>dismissible</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+            <td class="py-2 pr-4 text-muted-foreground">false</td>
+            <td class="py-2">Show dismiss button</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>onDismiss</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">() =&gt; void</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Callback when dismissed</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>class</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">string</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Additional CSS classes</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </section>
+
+  <!-- Testing Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
+    <TestingDocs />
+  </section>
+
+  <!-- Resources -->
+  <section>
+    <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
+    <ul class="list-disc pl-6 space-y-2">
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/alert/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Alert Pattern
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Alert Dialog Pattern
+        </ExternalLink>
+      </li>
+    </ul>
+  </section>
+</PatternLayout>

--- a/src/pages/patterns/alert/vue/index.astro
+++ b/src/pages/patterns/alert/vue/index.astro
@@ -1,0 +1,214 @@
+---
+import PatternLayout from '../../../../layouts/PatternLayout.astro';
+import AlertDemo from '@patterns/alert/AlertDemo.vue';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AccessibilityDocs from '@patterns/alert/AccessibilityDocs.astro';
+import TestingDocs from '@patterns/alert/TestingDocs.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/alert/Alert.vue?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
+---
+
+<PatternLayout title="Alert - Vue" pattern="alert" framework="vue" tocItems={tocItems}>
+  <header class="mb-8">
+    <h1 class="text-3xl font-bold mb-4">Alert</h1>
+    <p class="text-lg text-muted-foreground">
+      An element that displays a brief, important message in a way that attracts the user's attention without interrupting the user's task.
+    </p>
+  </header>
+
+  <!-- Framework Selector -->
+  <FrameworkTabs pattern="alert" currentFramework="vue" />
+
+  <!-- Demo Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
+    <p class="text-muted-foreground mb-4">
+      Click the buttons below to show alerts with different variants.
+      The live region container exists in the DOM from page load - only the content changes.
+    </p>
+    <div class="p-6 rounded-lg border border-border bg-background">
+      <AlertDemo client:load />
+    </div>
+  </section>
+
+  <!-- Accessibility Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
+    <AccessibilityDocs />
+  </section>
+
+  <!-- Source Code Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
+    <CodeBlock
+      code={sourceCode}
+      lang="vue"
+      title="Alert.vue"
+    />
+  </section>
+
+  <!-- Usage Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
+    <CodeBlock
+      code={`<script setup>
+import { ref } from 'vue';
+import Alert from './Alert.vue';
+
+const message = ref('');
+
+function showAlert() {
+  message.value = 'Operation completed!';
+}
+
+function clearAlert() {
+  message.value = '';
+}
+</script>
+
+<template>
+  <!-- IMPORTANT: Alert container is always in DOM -->
+  <Alert
+    :message="message"
+    variant="info"
+    :dismissible="true"
+    @dismiss="clearAlert"
+  />
+
+  <button @click="showAlert">
+    Show Alert
+  </button>
+</template>`}
+      lang="vue"
+      title="Example"
+    />
+  </section>
+
+  <!-- API Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
+    <h3 class="text-lg font-medium mb-3">Props</h3>
+    <ResponsiveTable>
+      <table class="w-full border-collapse">
+        <thead>
+          <tr class="border-b border-border">
+            <th class="text-left py-2 pr-4">Prop</th>
+            <th class="text-left py-2 pr-4">Type</th>
+            <th class="text-left py-2 pr-4">Default</th>
+            <th class="text-left py-2">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>message</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">string</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Alert message content</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>variant</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">'info' | 'success' | 'warning' | 'error'</td>
+            <td class="py-2 pr-4 text-muted-foreground">'info'</td>
+            <td class="py-2">Visual style variant</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>dismissible</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+            <td class="py-2 pr-4 text-muted-foreground">false</td>
+            <td class="py-2">Show dismiss button</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>id</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">string</td>
+            <td class="py-2 pr-4 text-muted-foreground">auto-generated</td>
+            <td class="py-2">Custom ID</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>class</code></td>
+            <td class="py-2 pr-4 text-muted-foreground">string</td>
+            <td class="py-2 pr-4 text-muted-foreground">-</td>
+            <td class="py-2">Additional CSS classes</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+
+    <h3 class="text-lg font-medium mb-3 mt-6">Events</h3>
+    <ResponsiveTable>
+      <table class="w-full border-collapse">
+        <thead>
+          <tr class="border-b border-border">
+            <th class="text-left py-2 pr-4">Event</th>
+            <th class="text-left py-2">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>@dismiss</code></td>
+            <td class="py-2">Emitted when dismiss button is clicked</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+
+    <h3 class="text-lg font-medium mb-3 mt-6">Slots</h3>
+    <ResponsiveTable>
+      <table class="w-full border-collapse">
+        <thead>
+          <tr class="border-b border-border">
+            <th class="text-left py-2 pr-4">Slot</th>
+            <th class="text-left py-2">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4"><code>default</code></td>
+            <td class="py-2">Complex content (alternative to message prop)</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </section>
+
+  <!-- Testing Section -->
+  <section class="mb-12">
+    <Heading level={2} class="text-xl font-semibold mb-4">Testing</Heading>
+    <TestingDocs />
+  </section>
+
+  <!-- Resources -->
+  <section>
+    <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
+    <ul class="list-disc pl-6 space-y-2">
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/alert/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Alert Pattern
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Alert Dialog Pattern
+        </ExternalLink>
+      </li>
+    </ul>
+  </section>
+</PatternLayout>

--- a/src/pages/patterns/tooltip/astro/index.astro
+++ b/src/pages/patterns/tooltip/astro/index.astro
@@ -4,7 +4,6 @@ import Tooltip from '@patterns/tooltip/Tooltip.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
 import AccessibilityDocs from '@patterns/tooltip/AccessibilityDocs.astro';
-import TestingDocs from '@patterns/tooltip/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';

--- a/src/patterns/alert/AccessibilityDocs.astro
+++ b/src/patterns/alert/AccessibilityDocs.astro
@@ -1,0 +1,196 @@
+---
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+---
+
+<div class="prose dark:prose-invert max-w-none">
+  <div class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 mb-6">
+    <h3 class="text-lg font-semibold text-red-800 dark:text-red-200 mt-0 mb-2">Critical Implementation Note</h3>
+    <p class="text-red-800 dark:text-red-200 text-sm mb-2">
+      <strong>The live region container (<code>role="alert"</code>) must exist in the DOM from page load.</strong>
+      Do NOT dynamically add/remove the container itself. Only the content inside the container should change dynamically.
+    </p>
+    <div class="text-red-700 dark:text-red-300 text-sm">
+      <pre class="bg-red-100 dark:bg-red-900/40 p-3 rounded-md overflow-x-auto mb-2"><code>{`// Incorrect: Dynamically adding live region
+{showAlert && <div role="alert">Message</div>}
+
+// Correct: Live region always exists, content changes
+<div role="alert">
+  {message && <span>{message}</span>}
+</div>`}</code></pre>
+      <p class="mt-2">
+        Screen readers detect changes to live regions by observing DOM mutations inside them.
+        If the live region itself is added dynamically, some screen readers may not announce the content reliably.
+      </p>
+    </div>
+  </div>
+
+  <h3 class="text-lg font-medium mb-3">WAI-ARIA Roles</h3>
+  <ul class="list-disc pl-6 mb-6 space-y-2">
+    <li>
+      <code>alert</code> - An element that displays a brief, important message that attracts the user's attention without interrupting their task<br />
+      <ExternalLink href="https://w3c.github.io/aria/#alert" class="text-sm text-primary hover:underline">
+        WAI-ARIA alert role
+      </ExternalLink>
+    </li>
+  </ul>
+
+  <h3 class="text-lg font-medium mb-3">Implicit ARIA Properties</h3>
+  <p class="text-muted-foreground mb-4">
+    The <code>role="alert"</code> implicitly sets the following ARIA properties. You do NOT need to add these manually:
+  </p>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Property</th>
+          <th class="text-left py-2 pr-4">Implicit Value</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>aria-live</code></td>
+          <td class="py-2 pr-4"><code>assertive</code></td>
+          <td class="py-2">Interrupts screen reader to announce immediately</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>aria-atomic</code></td>
+          <td class="py-2 pr-4"><code>true</code></td>
+          <td class="py-2">Announces entire alert content, not just changed parts</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h3 class="text-lg font-medium mb-3">Keyboard Support</h3>
+  <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4 mb-6">
+    <p class="text-blue-800 dark:text-blue-200 text-sm">
+      <strong>Alerts require no keyboard interaction.</strong> They are designed to inform users without interrupting their workflow.
+      The alert content is automatically announced by screen readers when it changes.
+    </p>
+  </div>
+
+  <p class="text-muted-foreground mb-4">
+    If the alert includes a dismiss button, the button follows standard button keyboard interaction:
+  </p>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Key</th>
+          <th class="text-left py-2">Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><kbd class="px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded">Enter</kbd></td>
+          <td class="py-2">Activates the dismiss button</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><kbd class="px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded">Space</kbd></td>
+          <td class="py-2">Activates the dismiss button</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h3 class="text-lg font-medium mb-3">Focus Management</h3>
+  <ul class="list-disc pl-6 mb-6 space-y-2">
+    <li>
+      <strong>Alert must NOT move focus</strong> - Alerts are non-modal and should not interrupt user workflow by stealing focus.
+    </li>
+    <li>
+      <strong>Alert container is not focusable</strong> - The alert element should not have <code>tabindex</code> or receive keyboard focus.
+    </li>
+    <li>
+      <strong>Dismiss button is focusable</strong> - If present, the dismiss button can be reached via Tab navigation.
+    </li>
+  </ul>
+
+  <h3 class="text-lg font-medium mb-3">Important Guidelines</h3>
+
+  <div class="mb-4">
+    <h4 class="font-medium mb-2">No Auto-Dismissal</h4>
+    <p class="text-muted-foreground mb-2">
+      Alerts should NOT disappear automatically. Per
+      <ExternalLink href="https://www.w3.org/WAI/WCAG21/Understanding/no-timing.html" class="text-primary hover:underline">
+        WCAG 2.2.3 No Timing
+      </ExternalLink>,
+      users need sufficient time to read content. If auto-dismissal is required:
+    </p>
+    <ul class="list-disc pl-6 text-muted-foreground">
+      <li>Provide user control to pause/extend the display time</li>
+      <li>Ensure sufficient display duration (minimum 5 seconds + reading time)</li>
+      <li>Consider if the content is truly non-essential</li>
+    </ul>
+  </div>
+
+  <div class="mb-4">
+    <h4 class="font-medium mb-2">Alert Frequency</h4>
+    <p class="text-muted-foreground mb-2">
+      Excessive alerts can inhibit usability, especially for users with visual or cognitive disabilities
+      (<ExternalLink href="https://www.w3.org/WAI/WCAG21/Understanding/interruptions.html" class="text-primary hover:underline">
+        WCAG 2.2.4 Interruptions
+      </ExternalLink>). Use alerts sparingly for truly important messages.
+    </p>
+  </div>
+
+  <div class="mb-6">
+    <h4 class="font-medium mb-2">Alert vs Alert Dialog</h4>
+    <p class="text-muted-foreground mb-2">
+      Use <strong>Alert</strong> when:
+    </p>
+    <ul class="list-disc pl-6 text-muted-foreground mb-2">
+      <li>The message is informational and doesn't require user action</li>
+      <li>User workflow should NOT be interrupted</li>
+      <li>Focus should remain on the current task</li>
+    </ul>
+    <p class="text-muted-foreground mb-2">
+      Use <strong>Alert Dialog</strong> (<code>role="alertdialog"</code>) when:
+    </p>
+    <ul class="list-disc pl-6 text-muted-foreground">
+      <li>The message requires immediate user response</li>
+      <li>User must acknowledge or take action before continuing</li>
+      <li>Focus should move to the dialog (modal behavior)</li>
+    </ul>
+    <div class="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3 mt-2">
+      <p class="text-amber-800 dark:text-amber-200 text-sm">
+        <strong>Note:</strong> <code>role="alertdialog"</code> requires focus management and keyboard handling (Escape to close, focus trapping).
+        Only use it when modal interruption is appropriate.
+      </p>
+    </div>
+  </div>
+
+  <h3 class="text-lg font-medium mb-3">Screen Reader Behavior</h3>
+  <ul class="list-disc pl-6 mb-6 space-y-2">
+    <li>
+      <strong>Immediate announcement</strong> - When alert content changes, screen readers interrupt current reading to announce the alert (<code>aria-live="assertive"</code>).
+    </li>
+    <li>
+      <strong>Full content announced</strong> - The entire alert content is read, not just the changed portion (<code>aria-atomic="true"</code>).
+    </li>
+    <li>
+      <strong>Initial content not announced</strong> - Alerts that exist when the page loads are NOT automatically announced. Only dynamic changes trigger announcements.
+    </li>
+  </ul>
+
+  <h3 class="text-lg font-medium mb-3">References</h3>
+  <ul class="list-disc pl-6 space-y-2">
+    <li>
+      <ExternalLink href="https://www.w3.org/WAI/ARIA/apg/patterns/alert/" class="text-primary hover:underline">
+        WAI-ARIA APG: Alert Pattern
+      </ExternalLink>
+    </li>
+    <li>
+      <ExternalLink href="https://w3c.github.io/aria/#alert" class="text-primary hover:underline">
+        WAI-ARIA: alert role
+      </ExternalLink>
+    </li>
+    <li>
+      <ExternalLink href="https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/" class="text-primary hover:underline">
+        WAI-ARIA APG: Alert Dialog Pattern
+      </ExternalLink>
+    </li>
+  </ul>
+</div>

--- a/src/patterns/alert/Alert.astro
+++ b/src/patterns/alert/Alert.astro
@@ -1,0 +1,221 @@
+---
+import InfoIcon from "lucide-static/icons/info.svg";
+import CircleCheckIcon from "lucide-static/icons/circle-check.svg";
+import AlertTriangleIcon from "lucide-static/icons/triangle-alert.svg";
+import OctagonAlertIcon from "lucide-static/icons/octagon-alert.svg";
+import XIcon from "lucide-static/icons/x.svg";
+import { type AlertVariant, variantStyles as sharedVariantStyles } from "./alert-config";
+
+export type { AlertVariant };
+
+export interface Props {
+  /**
+   * Alert message content.
+   * Changes to this prop trigger screen reader announcements.
+   */
+  message?: string;
+  /**
+   * Alert variant for visual styling.
+   * Does NOT affect ARIA - all variants use role="alert"
+   */
+  variant?: AlertVariant;
+  /**
+   * Custom ID for the alert container.
+   * Useful for SSR/hydration consistency.
+   */
+  id?: string;
+  /**
+   * Whether to show dismiss button.
+   * Note: Manual dismiss only - NO auto-dismiss per WCAG 2.2.3
+   */
+  dismissible?: boolean;
+  /**
+   * Additional class name for the alert container
+   */
+  class?: string;
+}
+
+const {
+  message = "",
+  variant = "info",
+  id,
+  dismissible = false,
+  class: className = "",
+} = Astro.props;
+
+const alertId = id ?? `alert-${crypto.randomUUID().slice(0, 8)}`;
+
+const variantIcons = {
+  info: InfoIcon,
+  success: CircleCheckIcon,
+  warning: AlertTriangleIcon,
+  error: OctagonAlertIcon,
+};
+
+const IconComponent = variantIcons[variant];
+const hasContent = Boolean(message);
+---
+
+<apg-alert
+  class:list={[
+    "apg-alert",
+    hasContent && [
+      "relative flex items-start gap-3 px-4 py-3 rounded-lg border",
+      "transition-colors duration-150",
+      sharedVariantStyles[variant],
+    ],
+    !hasContent && "contents",
+    className,
+  ]}
+  data-alert-id={alertId}
+  data-dismissible={dismissible ? "true" : undefined}
+  data-variant={variant}
+>
+  {/* Live region - contains only content for screen reader announcement */}
+  <div id={alertId} role="alert" class:list={[
+    hasContent && "flex-1 flex items-start gap-3",
+    !hasContent && "contents"
+  ]}>
+    {
+      hasContent && (
+        <>
+          <span class="apg-alert-icon flex-shrink-0 mt-0.5" aria-hidden="true">
+            <IconComponent class="size-5" />
+          </span>
+          <span class="apg-alert-content flex-1">{message}</span>
+        </>
+      )
+    }
+  </div>
+  {/* Dismiss button - outside live region to avoid SR announcing it as part of alert */}
+  {
+    hasContent && dismissible && (
+      <button
+        type="button"
+        class:list={[
+          "apg-alert-dismiss",
+          "flex-shrink-0 min-w-11 min-h-11 p-2 -m-2 rounded",
+          "flex items-center justify-center",
+          "hover:bg-black/10 dark:hover:bg-white/10",
+          "focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-current",
+        ]}
+        aria-label="Dismiss alert"
+      >
+        <XIcon class="size-5" aria-hidden="true" />
+      </button>
+    )
+  }
+</apg-alert>
+
+<script>
+  import {
+    variantStyles,
+    variantIconSvgs,
+    dismissIconSvg,
+  } from "./alert-config";
+
+  class ApgAlert extends HTMLElement {
+    private alertId: string = "";
+
+    connectedCallback() {
+      this.alertId = this.dataset.alertId ?? "";
+      const dismissBtn = this.querySelector(".apg-alert-dismiss");
+
+      if (dismissBtn) {
+        dismissBtn.addEventListener("click", this.handleDismiss);
+      }
+    }
+
+    disconnectedCallback() {
+      const dismissBtn = this.querySelector(".apg-alert-dismiss");
+      if (dismissBtn) {
+        dismissBtn.removeEventListener("click", this.handleDismiss);
+      }
+    }
+
+    private handleDismiss = () => {
+      // Clear content but keep the alert container (live region)
+      const alertEl = this.querySelector(`#${this.alertId}`);
+      if (alertEl) {
+        alertEl.replaceChildren();
+        // Update live region classes
+        alertEl.classList.remove("flex-1", "flex", "items-start", "gap-3");
+        alertEl.classList.add("contents");
+      }
+      // Update custom element display
+      this.className = "apg-alert contents";
+      // Remove dismiss button
+      const existingDismissBtn = this.querySelector(".apg-alert-dismiss");
+      if (existingDismissBtn) {
+        existingDismissBtn.remove();
+      }
+
+      // Dispatch custom event
+      this.dispatchEvent(new CustomEvent("dismiss", { bubbles: true }));
+    };
+
+    /**
+     * Method to update alert message programmatically.
+     * The live region container remains in DOM - only content changes.
+     */
+    setMessage(message: string, variant?: string) {
+      const alertEl = this.querySelector(`#${this.alertId}`);
+      if (!alertEl) return;
+
+      const currentVariant = (variant ?? this.dataset.variant ?? "info") as keyof typeof variantStyles;
+
+      if (message) {
+        // Update live region classes
+        alertEl.classList.remove("contents");
+        alertEl.classList.add("flex-1", "flex", "items-start", "gap-3");
+        // Update custom element styles
+        this.classList.remove("contents");
+        this.className = `apg-alert relative flex items-start gap-3 px-4 py-3 rounded-lg border transition-colors duration-150 ${variantStyles[currentVariant]}`;
+
+        // Build DOM nodes safely (avoid innerHTML for user content)
+        const iconSpan = document.createElement("span");
+        iconSpan.className = "apg-alert-icon flex-shrink-0 mt-0.5";
+        iconSpan.setAttribute("aria-hidden", "true");
+        iconSpan.innerHTML = variantIconSvgs[currentVariant]; // Safe: hardcoded SVG
+
+        const contentSpan = document.createElement("span");
+        contentSpan.className = "apg-alert-content flex-1";
+        contentSpan.textContent = message; // Safe: uses textContent
+
+        // Update live region content (icon + message only)
+        alertEl.replaceChildren(iconSpan, contentSpan);
+
+        // Remove existing dismiss button if any
+        const existingDismissBtn = this.querySelector(".apg-alert-dismiss");
+        if (existingDismissBtn) {
+          existingDismissBtn.remove();
+        }
+
+        // Add dismiss button outside live region
+        if (this.dataset.dismissible === "true") {
+          const dismissBtn = document.createElement("button");
+          dismissBtn.type = "button";
+          dismissBtn.className = "apg-alert-dismiss flex-shrink-0 min-w-11 min-h-11 p-2 -m-2 rounded flex items-center justify-center hover:bg-black/10 dark:hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-current";
+          dismissBtn.setAttribute("aria-label", "Dismiss alert");
+          dismissBtn.innerHTML = dismissIconSvg; // Safe: hardcoded SVG
+          dismissBtn.addEventListener("click", this.handleDismiss);
+          this.appendChild(dismissBtn);
+        }
+      } else {
+        alertEl.replaceChildren();
+        // Update live region classes
+        alertEl.classList.remove("flex-1", "flex", "items-start", "gap-3");
+        alertEl.classList.add("contents");
+        // Update custom element display
+        this.className = "apg-alert contents";
+        // Remove dismiss button
+        const existingDismissBtn = this.querySelector(".apg-alert-dismiss");
+        if (existingDismissBtn) {
+          existingDismissBtn.remove();
+        }
+      }
+    }
+  }
+
+  customElements.define("apg-alert", ApgAlert);
+</script>

--- a/src/patterns/alert/Alert.svelte
+++ b/src/patterns/alert/Alert.svelte
@@ -1,0 +1,129 @@
+<script lang="ts" module>
+  import type { Snippet } from "svelte";
+  import type { AlertVariant } from "./alert-config";
+
+  export type { AlertVariant };
+
+  // Module-level counter for generating unique IDs
+  let idCounter = 0;
+  function generateId() {
+    return `alert-${++idCounter}`;
+  }
+
+  export interface AlertProps {
+    /**
+     * Alert message content.
+     * Changes to this prop trigger screen reader announcements.
+     */
+    message?: string;
+    /**
+     * Optional children for complex content.
+     * Use message prop for simple text alerts.
+     */
+    children?: Snippet;
+    /**
+     * Alert variant for visual styling.
+     * Does NOT affect ARIA - all variants use role="alert"
+     */
+    variant?: AlertVariant;
+    /**
+     * Custom ID for the alert container.
+     * Auto-generated if not provided.
+     */
+    id?: string;
+    /**
+     * Whether to show dismiss button.
+     * Note: Manual dismiss only - NO auto-dismiss per WCAG 2.2.3
+     */
+    dismissible?: boolean;
+    /**
+     * Additional class name for the alert container
+     */
+    class?: string;
+  }
+</script>
+
+<script lang="ts">
+  import { cn } from "@/lib/utils";
+  import { Info, CircleCheck, AlertTriangle, OctagonAlert, X } from "lucide-svelte";
+  import { variantStyles } from "./alert-config";
+
+  let {
+    message,
+    children,
+    variant = "info",
+    id: providedId,
+    dismissible = false,
+    class: className = "",
+    onDismiss,
+  }: AlertProps & { onDismiss?: () => void } = $props();
+
+  // Generate stable ID - use provided or generate once
+  const generatedId = generateId();
+  let alertId = $derived(providedId ?? generatedId);
+
+  let hasContent = $derived(Boolean(message) || Boolean(children));
+  let IconComponent = $derived(
+    variant === "success" ? CircleCheck :
+    variant === "warning" ? AlertTriangle :
+    variant === "error" ? OctagonAlert :
+    Info
+  );
+
+  function handleDismiss() {
+    onDismiss?.();
+  }
+</script>
+
+<div
+  class={cn(
+    "apg-alert",
+    hasContent && [
+      "relative flex items-start gap-3 px-4 py-3 rounded-lg border",
+      "transition-colors duration-150",
+      variantStyles[variant],
+    ],
+    !hasContent && "contents",
+    className
+  )}
+>
+  <!-- Live region - contains only content for screen reader announcement -->
+  <div
+    id={alertId}
+    role="alert"
+    class={cn(
+      hasContent && "flex-1 flex items-start gap-3",
+      !hasContent && "contents"
+    )}
+  >
+    {#if hasContent}
+      <span class="apg-alert-icon flex-shrink-0 mt-0.5" aria-hidden="true">
+        <IconComponent class="size-5" />
+      </span>
+      <span class="apg-alert-content flex-1">
+        {#if message}
+          {message}
+        {:else if children}
+          {@render children()}
+        {/if}
+      </span>
+    {/if}
+  </div>
+  <!-- Dismiss button - outside live region to avoid SR announcing it as part of alert -->
+  {#if hasContent && dismissible}
+    <button
+      type="button"
+      class={cn(
+        "apg-alert-dismiss",
+        "flex-shrink-0 min-w-11 min-h-11 p-2 -m-2 rounded",
+        "flex items-center justify-center",
+        "hover:bg-black/10 dark:hover:bg-white/10",
+        "focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-current"
+      )}
+      aria-label="Dismiss alert"
+      onclick={handleDismiss}
+    >
+      <X class="size-5" aria-hidden="true" />
+    </button>
+  {/if}
+</div>

--- a/src/patterns/alert/Alert.test.tsx
+++ b/src/patterns/alert/Alert.test.tsx
@@ -1,0 +1,194 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "jest-axe";
+import { describe, expect, it, vi } from "vitest";
+import { Alert } from "./Alert";
+
+describe("Alert", () => {
+  // High Priority: APG Core Compliance
+  describe("APG: ARIA 属性", () => {
+    it('role="alert" を持つ', () => {
+      render(<Alert message="Test message" />);
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    it("メッセージがなくても role=alert コンテナは DOM に存在する", () => {
+      render(<Alert />);
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    it("メッセージ変更時もコンテナは同じ要素のまま", () => {
+      const { rerender } = render(<Alert message="First message" />);
+      const alertElement = screen.getByRole("alert");
+      const alertId = alertElement.id;
+
+      rerender(<Alert message="Second message" />);
+      expect(screen.getByRole("alert")).toHaveAttribute("id", alertId);
+      expect(screen.getByRole("alert")).toHaveTextContent("Second message");
+    });
+
+    it("メッセージがクリアされてもコンテナは残る", () => {
+      const { rerender } = render(<Alert message="Test message" />);
+      expect(screen.getByRole("alert")).toHaveTextContent("Test message");
+
+      rerender(<Alert message="" />);
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(screen.getByRole("alert")).not.toHaveTextContent("Test message");
+    });
+  });
+
+  describe("APG: フォーカス管理", () => {
+    it("アラート表示時にフォーカスを移動しない", async () => {
+      const user = userEvent.setup();
+      render(
+        <>
+          <button>Other button</button>
+          <Alert message="Test message" />
+        </>
+      );
+
+      const button = screen.getByRole("button", { name: "Other button" });
+      await user.click(button);
+      expect(button).toHaveFocus();
+
+      // アラートが表示されてもフォーカスは移動しない
+      expect(button).toHaveFocus();
+    });
+
+    it("アラート自体はフォーカスを受け取らない（tabindex なし）", () => {
+      render(<Alert message="Test message" />);
+      expect(screen.getByRole("alert")).not.toHaveAttribute("tabindex");
+    });
+  });
+
+  describe("Dismiss 機能", () => {
+    it("dismissible=true で閉じるボタンが表示される", () => {
+      render(<Alert message="Test message" dismissible />);
+      expect(
+        screen.getByRole("button", { name: "Dismiss alert" })
+      ).toBeInTheDocument();
+    });
+
+    it("dismissible=false（デフォルト）で閉じるボタンが表示されない", () => {
+      render(<Alert message="Test message" />);
+      expect(
+        screen.queryByRole("button", { name: "Dismiss alert" })
+      ).not.toBeInTheDocument();
+    });
+
+    it("閉じるボタンクリックで onDismiss が呼び出される", async () => {
+      const handleDismiss = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <Alert message="Test message" dismissible onDismiss={handleDismiss} />
+      );
+
+      await user.click(screen.getByRole("button", { name: "Dismiss alert" }));
+      expect(handleDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it("閉じるボタンは type=button を持つ", () => {
+      render(<Alert message="Test message" dismissible />);
+      expect(screen.getByRole("button", { name: "Dismiss alert" })).toHaveAttribute(
+        "type",
+        "button"
+      );
+    });
+
+    it("閉じるボタンに aria-label がある", () => {
+      render(<Alert message="Test message" dismissible />);
+      expect(screen.getByRole("button", { name: "Dismiss alert" })).toHaveAccessibleName(
+        "Dismiss alert"
+      );
+    });
+  });
+
+  // Medium Priority: Accessibility Validation
+  describe("アクセシビリティ", () => {
+    it("axe による WCAG 2.1 AA 違反がない（メッセージあり）", async () => {
+      const { container } = render(<Alert message="Test message" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("axe による WCAG 2.1 AA 違反がない（メッセージなし）", async () => {
+      const { container } = render(<Alert />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("axe による WCAG 2.1 AA 違反がない（dismissible）", async () => {
+      const { container } = render(
+        <Alert message="Test message" dismissible onDismiss={() => {}} />
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  describe("Variant スタイル", () => {
+    it.each(["info", "success", "warning", "error"] as const)(
+      "variant=%s で適切なスタイルクラスが適用される",
+      (variant) => {
+        render(<Alert message="Test message" variant={variant} />);
+        const alert = screen.getByRole("alert");
+        // apg-alert class is on the parent wrapper, not on role="alert"
+        const wrapper = alert.parentElement;
+        expect(wrapper).toHaveClass("apg-alert");
+      }
+    );
+
+    it("デフォルトの variant は info", () => {
+      render(<Alert message="Test message" />);
+      const alert = screen.getByRole("alert");
+      // info variant のスタイルが親ラッパーに適用されている
+      const wrapper = alert.parentElement;
+      expect(wrapper).toHaveClass("bg-blue-50");
+    });
+  });
+
+  // Low Priority: Props & Extensibility
+  describe("Props", () => {
+    it("id prop でカスタム ID を設定できる", () => {
+      render(<Alert message="Test message" id="custom-alert-id" />);
+      expect(screen.getByRole("alert")).toHaveAttribute("id", "custom-alert-id");
+    });
+
+    it("className が正しくマージされる", () => {
+      render(<Alert message="Test message" className="custom-class" />);
+      const alert = screen.getByRole("alert");
+      // className は親ラッパーに適用される
+      const wrapper = alert.parentElement;
+      expect(wrapper).toHaveClass("apg-alert");
+      expect(wrapper).toHaveClass("custom-class");
+    });
+
+    it("children で複雑なコンテンツを渡せる", () => {
+      render(
+        <Alert>
+          <strong>Important:</strong> This is a message
+        </Alert>
+      );
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Important: This is a message"
+      );
+    });
+
+    it("message と children 両方ある場合は message が優先される", () => {
+      render(
+        <Alert message="Message prop">
+          <span>Children content</span>
+        </Alert>
+      );
+      expect(screen.getByRole("alert")).toHaveTextContent("Message prop");
+      expect(screen.getByRole("alert")).not.toHaveTextContent("Children content");
+    });
+  });
+
+  describe("HTML 属性継承", () => {
+    it("追加の HTML 属性が渡せる", () => {
+      render(<Alert message="Test" data-testid="custom-alert" />);
+      expect(screen.getByTestId("custom-alert")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/patterns/alert/Alert.tsx
+++ b/src/patterns/alert/Alert.tsx
@@ -1,0 +1,127 @@
+import { cn } from "@/lib/utils";
+import { Info, CircleCheck, AlertTriangle, OctagonAlert, X } from "lucide-react";
+import { useId, type ReactNode } from "react";
+import { type AlertVariant, variantStyles } from "./alert-config";
+
+export type { AlertVariant };
+
+export interface AlertProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, "role" | "children"> {
+  /**
+   * Alert message content.
+   * Changes to this prop trigger screen reader announcements.
+   */
+  message?: string;
+  /**
+   * Optional children for complex content.
+   * Use message prop for simple text alerts.
+   */
+  children?: ReactNode;
+  /**
+   * Alert variant for visual styling.
+   * Does NOT affect ARIA - all variants use role="alert"
+   */
+  variant?: AlertVariant;
+  /**
+   * Custom ID for the alert container.
+   * Useful for SSR/hydration consistency.
+   */
+  id?: string;
+  /**
+   * Whether to show dismiss button.
+   * Note: Manual dismiss only - NO auto-dismiss per WCAG 2.2.3
+   */
+  dismissible?: boolean;
+  /**
+   * Callback when alert is dismissed.
+   * Should clear the message to hide the alert content.
+   */
+  onDismiss?: () => void;
+}
+
+const variantIcons: Record<AlertVariant, React.ReactNode> = {
+  info: <Info className="size-5" />,
+  success: <CircleCheck className="size-5" />,
+  warning: <AlertTriangle className="size-5" />,
+  error: <OctagonAlert className="size-5" />,
+};
+
+/**
+ * Alert component following WAI-ARIA APG Alert Pattern
+ *
+ * IMPORTANT: The live region container (role="alert") is always present in the DOM.
+ * Only the content inside changes dynamically - NOT the container itself.
+ * This ensures screen readers properly announce alert messages.
+ *
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/alert/
+ */
+export const Alert: React.FC<AlertProps> = ({
+  message,
+  children,
+  variant = "info",
+  id: providedId,
+  className,
+  dismissible = false,
+  onDismiss,
+  ...restProps
+}) => {
+  const generatedId = useId();
+  const alertId = providedId ?? `alert-${generatedId}`;
+
+  const content = message || children;
+  const hasContent = Boolean(content);
+
+  return (
+    <div
+      className={cn(
+        "apg-alert",
+        hasContent && [
+          "relative flex items-start gap-3 px-4 py-3 rounded-lg border",
+          "transition-colors duration-150",
+          variantStyles[variant],
+        ],
+        !hasContent && "contents",
+        className
+      )}
+      {...restProps}
+    >
+      {/* Live region - contains only content for screen reader announcement */}
+      <div
+        id={alertId}
+        role="alert"
+        className={cn(
+          hasContent && "flex-1 flex items-start gap-3",
+          !hasContent && "contents"
+        )}
+      >
+        {hasContent && (
+          <>
+            <span className="apg-alert-icon flex-shrink-0 mt-0.5" aria-hidden="true">
+              {variantIcons[variant]}
+            </span>
+            <span className="apg-alert-content flex-1">{content}</span>
+          </>
+        )}
+      </div>
+      {/* Dismiss button - outside live region to avoid SR announcing it as part of alert */}
+      {hasContent && dismissible && (
+        <button
+          type="button"
+          className={cn(
+            "apg-alert-dismiss",
+            "flex-shrink-0 min-w-11 min-h-11 p-2 -m-2 rounded",
+            "flex items-center justify-center",
+            "hover:bg-black/10 dark:hover:bg-white/10",
+            "focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-current"
+          )}
+          onClick={onDismiss}
+          aria-label="Dismiss alert"
+        >
+          <X className="size-5" aria-hidden="true" />
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default Alert;

--- a/src/patterns/alert/Alert.vue
+++ b/src/patterns/alert/Alert.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import { computed, useId } from "vue";
+import { cn } from "@/lib/utils";
+import { Info, CircleCheck, AlertTriangle, OctagonAlert, X } from "lucide-vue-next";
+import { type AlertVariant, variantStyles } from "./alert-config";
+
+export type { AlertVariant };
+
+export interface AlertProps {
+  /**
+   * Alert message content.
+   * Changes to this prop trigger screen reader announcements.
+   */
+  message?: string;
+  /**
+   * Alert variant for visual styling.
+   * Does NOT affect ARIA - all variants use role="alert"
+   */
+  variant?: AlertVariant;
+  /**
+   * Custom ID for the alert container.
+   * Useful for SSR/hydration consistency.
+   */
+  id?: string;
+  /**
+   * Whether to show dismiss button.
+   * Note: Manual dismiss only - NO auto-dismiss per WCAG 2.2.3
+   */
+  dismissible?: boolean;
+  /**
+   * Additional class name for the alert container
+   */
+  class?: string;
+}
+
+const props = withDefaults(defineProps<AlertProps>(), {
+  message: undefined,
+  variant: "info",
+  id: undefined,
+  dismissible: false,
+  class: "",
+});
+
+const emit = defineEmits<{
+  dismiss: [];
+}>();
+
+// Generate SSR-safe unique ID
+const generatedId = useId();
+const alertId = computed(() => props.id ?? `alert-${generatedId}`);
+
+const hasContent = computed(() => Boolean(props.message) || Boolean(slots.default));
+
+const slots = defineSlots<{
+  default?: () => unknown;
+}>();
+
+const variantIcons = {
+  info: Info,
+  success: CircleCheck,
+  warning: AlertTriangle,
+  error: OctagonAlert,
+};
+
+const handleDismiss = () => {
+  emit("dismiss");
+};
+</script>
+
+<template>
+  <div
+    :class="
+      cn(
+        'apg-alert',
+        hasContent && [
+          'relative flex items-start gap-3 px-4 py-3 rounded-lg border',
+          'transition-colors duration-150',
+          variantStyles[variant],
+        ],
+        !hasContent && 'contents',
+        props.class
+      )
+    "
+  >
+    <!-- Live region - contains only content for screen reader announcement -->
+    <div
+      :id="alertId"
+      role="alert"
+      :class="cn(
+        hasContent && 'flex-1 flex items-start gap-3',
+        !hasContent && 'contents'
+      )"
+    >
+      <template v-if="hasContent">
+        <span class="apg-alert-icon flex-shrink-0 mt-0.5" aria-hidden="true">
+          <component :is="variantIcons[variant]" class="size-5" />
+        </span>
+        <span class="apg-alert-content flex-1">
+          <template v-if="message">{{ message }}</template>
+          <slot v-else />
+        </span>
+      </template>
+    </div>
+    <!-- Dismiss button - outside live region to avoid SR announcing it as part of alert -->
+    <button
+      v-if="hasContent && dismissible"
+      type="button"
+      :class="
+        cn(
+          'apg-alert-dismiss',
+          'flex-shrink-0 min-w-11 min-h-11 p-2 -m-2 rounded',
+          'flex items-center justify-center',
+          'hover:bg-black/10 dark:hover:bg-white/10',
+          'focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-current'
+        )
+      "
+      aria-label="Dismiss alert"
+      @click="handleDismiss"
+    >
+      <X class="size-5" aria-hidden="true" />
+    </button>
+  </div>
+</template>

--- a/src/patterns/alert/AlertDemo.svelte
+++ b/src/patterns/alert/AlertDemo.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import Alert, { type AlertVariant } from "./Alert.svelte";
+
+  let variant = $state<AlertVariant>("info");
+  let message = $state("");
+
+  const messages: Record<AlertVariant, string> = {
+    info: "This is an informational message.",
+    success: "Operation completed successfully!",
+    warning: "Please review your input before proceeding.",
+    error: "An error occurred. Please try again.",
+  };
+
+  function showAlert(v: AlertVariant) {
+    variant = v;
+    message = messages[v];
+  }
+
+  function clearAlert() {
+    message = "";
+  }
+</script>
+
+<div class="space-y-4">
+  <Alert
+    id="demo-alert"
+    {message}
+    {variant}
+    dismissible
+    onDismiss={clearAlert}
+  />
+  <div class="flex flex-wrap gap-2">
+    <button
+      type="button"
+      class="px-4 py-2 text-sm font-medium text-blue-700 bg-blue-100 rounded-md hover:bg-blue-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+      onclick={() => showAlert("info")}
+    >
+      Info
+    </button>
+    <button
+      type="button"
+      class="px-4 py-2 text-sm font-medium text-green-700 bg-green-100 rounded-md hover:bg-green-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+      onclick={() => showAlert("success")}
+    >
+      Success
+    </button>
+    <button
+      type="button"
+      class="px-4 py-2 text-sm font-medium text-amber-700 bg-amber-100 rounded-md hover:bg-amber-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-500"
+      onclick={() => showAlert("warning")}
+    >
+      Warning
+    </button>
+    <button
+      type="button"
+      class="px-4 py-2 text-sm font-medium text-red-700 bg-red-100 rounded-md hover:bg-red-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+      onclick={() => showAlert("error")}
+    >
+      Error
+    </button>
+  </div>
+</div>

--- a/src/patterns/alert/AlertDemo.tsx
+++ b/src/patterns/alert/AlertDemo.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import { Alert, type AlertVariant } from "./Alert";
+
+export function AlertDemo() {
+  const [variant, setVariant] = useState<AlertVariant>("info");
+  const [message, setMessage] = useState("");
+
+  const messages: Record<AlertVariant, string> = {
+    info: "This is an informational message.",
+    success: "Operation completed successfully!",
+    warning: "Please review your input before proceeding.",
+    error: "An error occurred. Please try again.",
+  };
+
+  const showAlert = (v: AlertVariant) => {
+    setVariant(v);
+    setMessage(messages[v]);
+  };
+
+  const clearAlert = () => {
+    setMessage("");
+  };
+
+  return (
+    <div className="space-y-4">
+      <Alert
+        message={message}
+        variant={variant}
+        dismissible
+        onDismiss={clearAlert}
+      />
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          className="px-4 py-2 text-sm font-medium text-blue-700 bg-blue-100 rounded-md hover:bg-blue-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+          onClick={() => showAlert("info")}
+        >
+          Info
+        </button>
+        <button
+          type="button"
+          className="px-4 py-2 text-sm font-medium text-green-700 bg-green-100 rounded-md hover:bg-green-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+          onClick={() => showAlert("success")}
+        >
+          Success
+        </button>
+        <button
+          type="button"
+          className="px-4 py-2 text-sm font-medium text-amber-700 bg-amber-100 rounded-md hover:bg-amber-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-500"
+          onClick={() => showAlert("warning")}
+        >
+          Warning
+        </button>
+        <button
+          type="button"
+          className="px-4 py-2 text-sm font-medium text-red-700 bg-red-100 rounded-md hover:bg-red-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+          onClick={() => showAlert("error")}
+        >
+          Error
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/patterns/alert/AlertDemo.vue
+++ b/src/patterns/alert/AlertDemo.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import Alert from "./Alert.vue";
+import type { AlertVariant } from "./Alert.vue";
+
+const variant = ref<AlertVariant>("info");
+const message = ref("");
+
+const messages: Record<AlertVariant, string> = {
+  info: "This is an informational message.",
+  success: "Operation completed successfully!",
+  warning: "Please review your input before proceeding.",
+  error: "An error occurred. Please try again.",
+};
+
+const showAlert = (v: AlertVariant) => {
+  variant.value = v;
+  message.value = messages[v];
+};
+
+const clearAlert = () => {
+  message.value = "";
+};
+</script>
+
+<template>
+  <div class="space-y-4">
+    <Alert
+      :message="message"
+      :variant="variant"
+      :dismissible="true"
+      @dismiss="clearAlert"
+    />
+    <div class="flex flex-wrap gap-2">
+      <button
+        type="button"
+        class="px-4 py-2 text-sm font-medium text-blue-700 bg-blue-100 rounded-md hover:bg-blue-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+        @click="showAlert('info')"
+      >
+        Info
+      </button>
+      <button
+        type="button"
+        class="px-4 py-2 text-sm font-medium text-green-700 bg-green-100 rounded-md hover:bg-green-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+        @click="showAlert('success')"
+      >
+        Success
+      </button>
+      <button
+        type="button"
+        class="px-4 py-2 text-sm font-medium text-amber-700 bg-amber-100 rounded-md hover:bg-amber-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-500"
+        @click="showAlert('warning')"
+      >
+        Warning
+      </button>
+      <button
+        type="button"
+        class="px-4 py-2 text-sm font-medium text-red-700 bg-red-100 rounded-md hover:bg-red-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+        @click="showAlert('error')"
+      >
+        Error
+      </button>
+    </div>
+  </div>
+</template>

--- a/src/patterns/alert/TestingDocs.astro
+++ b/src/patterns/alert/TestingDocs.astro
@@ -1,0 +1,175 @@
+---
+import { ResponsiveTable } from '@/components/ui/table';
+---
+
+<div class="prose dark:prose-invert max-w-none">
+  <h3 class="text-lg font-medium mb-3">Testing Overview</h3>
+  <p class="text-muted-foreground mb-4">
+    The Alert component tests focus on verifying correct live region behavior and APG compliance.
+    The most critical test is ensuring the alert container remains in the DOM when content changes.
+  </p>
+
+  <h3 class="text-lg font-medium mb-3">Test Categories</h3>
+
+  <div class="mb-6">
+    <h4 class="font-medium mb-2 flex items-center gap-2">
+      <span class="inline-block w-3 h-3 rounded-full bg-red-500"></span>
+      High Priority: APG Core Compliance
+    </h4>
+    <ResponsiveTable>
+      <table class="w-full border-collapse text-sm">
+        <thead>
+          <tr class="border-b border-border">
+            <th class="text-left py-2 pr-4">Test</th>
+            <th class="text-left py-2">APG Requirement</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">role="alert" exists</td>
+            <td class="py-2">Alert container must have alert role</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">Container always in DOM</td>
+            <td class="py-2">Live region must not be dynamically added/removed</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">Same container on message change</td>
+            <td class="py-2">Container element identity preserved during updates</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">Focus unchanged after alert</td>
+            <td class="py-2">Alert must not move keyboard focus</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">Alert not focusable</td>
+            <td class="py-2">Alert container must not have tabindex</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </div>
+
+  <div class="mb-6">
+    <h4 class="font-medium mb-2 flex items-center gap-2">
+      <span class="inline-block w-3 h-3 rounded-full bg-yellow-500"></span>
+      Medium Priority: Accessibility Validation
+    </h4>
+    <ResponsiveTable>
+      <table class="w-full border-collapse text-sm">
+        <thead>
+          <tr class="border-b border-border">
+            <th class="text-left py-2 pr-4">Test</th>
+            <th class="text-left py-2">WCAG Requirement</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">No axe violations (with message)</td>
+            <td class="py-2">WCAG 2.1 AA compliance</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">No axe violations (empty)</td>
+            <td class="py-2">WCAG 2.1 AA compliance</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">No axe violations (dismissible)</td>
+            <td class="py-2">WCAG 2.1 AA compliance</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">Dismiss button accessible name</td>
+            <td class="py-2">Button has aria-label</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">Dismiss button type="button"</td>
+            <td class="py-2">Prevents form submission</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </div>
+
+  <div class="mb-6">
+    <h4 class="font-medium mb-2 flex items-center gap-2">
+      <span class="inline-block w-3 h-3 rounded-full bg-green-500"></span>
+      Low Priority: Props &amp; Extensibility
+    </h4>
+    <ResponsiveTable>
+      <table class="w-full border-collapse text-sm">
+        <thead>
+          <tr class="border-b border-border">
+            <th class="text-left py-2 pr-4">Test</th>
+            <th class="text-left py-2">Feature</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">variant prop changes styling</td>
+            <td class="py-2">Visual customization</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">id prop sets custom ID</td>
+            <td class="py-2">SSR support</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">className inheritance</td>
+            <td class="py-2">Style customization</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">children for complex content</td>
+            <td class="py-2">Content flexibility</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4">onDismiss callback fires</td>
+            <td class="py-2">Event handling</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </div>
+
+  <h3 class="text-lg font-medium mb-3">Screen Reader Testing</h3>
+  <p class="text-muted-foreground mb-4">
+    Automated tests verify DOM structure, but manual testing with screen readers is essential for validating actual announcement behavior:
+  </p>
+  <ResponsiveTable>
+    <table class="w-full border-collapse text-sm">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Screen Reader</th>
+          <th class="text-left py-2">Platform</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4">VoiceOver</td>
+          <td class="py-2">macOS / iOS</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4">NVDA</td>
+          <td class="py-2">Windows</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4">JAWS</td>
+          <td class="py-2">Windows</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4">TalkBack</td>
+          <td class="py-2">Android</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+  <p class="text-muted-foreground mt-2 text-sm">
+    Verify that message changes trigger immediate announcement and that existing content on page load is NOT announced.
+  </p>
+
+  <h3 class="text-lg font-medium mb-3 mt-6">Running Tests</h3>
+  <pre class="bg-gray-100 dark:bg-gray-800 p-4 rounded-lg text-sm overflow-x-auto"><code># Run all Alert tests
+npm run test -- alert
+
+# Run tests for specific framework
+npm run test -- Alert.test.tsx    # React
+npm run test -- Alert.test.vue    # Vue
+npm run test -- Alert.test.svelte # Svelte</code></pre>
+</div>

--- a/src/patterns/alert/alert-config.ts
+++ b/src/patterns/alert/alert-config.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared configuration for Alert component across all frameworks.
+ * Centralizes variant styles and icon mappings to reduce duplication.
+ */
+
+export type AlertVariant = "info" | "success" | "warning" | "error";
+
+/**
+ * Variant-specific Tailwind CSS classes for styling the alert container.
+ */
+export const variantStyles: Record<AlertVariant, string> = {
+  info: "bg-blue-50 border-blue-200 text-blue-800 dark:bg-blue-900/20 dark:border-blue-800 dark:text-blue-200",
+  success:
+    "bg-green-50 border-green-200 text-green-800 dark:bg-green-900/20 dark:border-green-800 dark:text-green-200",
+  warning:
+    "bg-amber-50 border-amber-200 text-amber-800 dark:bg-amber-900/20 dark:border-amber-800 dark:text-amber-200",
+  error:
+    "bg-red-50 border-red-200 text-red-800 dark:bg-red-900/20 dark:border-red-800 dark:text-red-200",
+};
+
+/**
+ * Icon names for each variant.
+ * Each framework imports from its own lucide package:
+ * - React: lucide-react
+ * - Vue: lucide-vue-next
+ * - Svelte: lucide-svelte
+ * - Astro: lucide-static
+ */
+export const variantIconNames: Record<AlertVariant, string> = {
+  info: "Info",
+  success: "CircleCheck",
+  warning: "AlertTriangle",
+  error: "OctagonAlert",
+};
+
+/**
+ * Inline SVG icons for use in JavaScript (e.g., Astro's setMessage method).
+ * These are hardcoded Lucide icon SVGs to avoid XSS when updating content dynamically.
+ */
+export const variantIconSvgs: Record<AlertVariant, string> = {
+  info: '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-5"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>',
+  success:
+    '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-5"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg>',
+  warning:
+    '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-5"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg>',
+  error:
+    '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-5"><path d="M12 16h.01"/><path d="M12 8v4"/><path d="M15.312 2a2 2 0 0 1 1.414.586l4.688 4.688A2 2 0 0 1 22 8.688v6.624a2 2 0 0 1-.586 1.414l-4.688 4.688a2 2 0 0 1-1.414.586H8.688a2 2 0 0 1-1.414-.586l-4.688-4.688A2 2 0 0 1 2 15.312V8.688a2 2 0 0 1 .586-1.414l4.688-4.688A2 2 0 0 1 8.688 2z"/></svg>',
+};
+
+/**
+ * Dismiss button SVG icon (X mark).
+ */
+export const dismissIconSvg =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="size-5" aria-hidden="true"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>';


### PR DESCRIPTION
## Summary

   - Implement Alert pattern following WAI-ARIA APG guidelines across React, Vue,
   Svelte, and Astro
   - Live region (`role="alert"`) always exists in DOM - only content changes
   dynamically
   - Dismiss button placed outside live region to avoid screen reader verbosity
   - SSR-safe ID generation using `useId` (React/Vue) and module-level counter
   (Svelte)
   - XSS-safe dynamic content updates in Astro using `textContent` instead of
   `innerHTML`
   - Centralized variant styles/icons in `alert-config.ts` to reduce duplication
   - 44x44px minimum touch target for dismiss button (WCAG compliance)
   - No auto-dismiss per WCAG 2.2.3

   ## Files

   - `src/patterns/alert/Alert.tsx` - React implementation
   - `src/patterns/alert/Alert.vue` - Vue implementation
   - `src/patterns/alert/Alert.svelte` - Svelte implementation
   - `src/patterns/alert/Alert.astro` - Astro/Web Components implementation
   - `src/patterns/alert/alert-config.ts` - Shared variant styles/icons
   - `src/patterns/alert/AlertDemo.*` - Demo components for each framework
   - `src/patterns/alert/AccessibilityDocs.astro` - APG compliance documentation
   - `src/patterns/alert/TestingDocs.astro` - Testing guidance
   - `src/patterns/alert/Alert.test.tsx` - Comprehensive test suite
   - `src/pages/patterns/alert/*/index.astro` - Framework-specific pages

   ## Test plan

   - [x] All 24 tests pass (`npm run test -- --run src/patterns/alert/`)
   - [x] Build succeeds (`npm run build`)
   - [x] Lint passes (`npm run lint`)
   - [ ] Manual testing with screen reader (VoiceOver/NVDA)
   - [ ] Verify dismiss button has 44x44px touch target
   - [ ] Verify alert announcements work correctly