### PR TITLE
feat: implement Disclosure APG pattern

### DIFF
--- a/.internal/disclosure-implementation-plan.md
+++ b/.internal/disclosure-implementation-plan.md
@@ -1,0 +1,353 @@
+# Disclosure パターン実装計画
+
+## 概要
+
+WAI-ARIA APG の Disclosure パターンを React、Vue、Svelte、Astro の4フレームワークで実装する。
+
+- APG 仕様: https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/
+
+## Disclosure vs Accordion の違い
+
+| 項目 | Disclosure | Accordion |
+|------|-----------|-----------|
+| 単位 | 単独コンポーネント | グループ管理 |
+| 複数展開 | N/A（単独なので常に独立） | allowMultiple で制御 |
+| キーボード | Enter/Space のみ（buttonネイティブ） | Enter/Space + 矢印キー |
+| ユースケース | FAQ回答、詳細表示、ナビ展開 | セクション切り替え |
+
+## APG 仕様要件
+
+### ARIA 属性
+
+| 属性 | 要素 | 値 | 必須 |
+|------|------|-----|------|
+| `aria-expanded` | button | `"true"` / `"false"` | ✅ |
+| `aria-controls` | button | パネルのID | ✅ |
+
+### キーボード操作
+
+| キー | アクション |
+|------|----------|
+| Enter | 開閉をトグル（buttonネイティブ動作） |
+| Space | 開閉をトグル（buttonネイティブ動作） |
+
+**注意**: `<button>` 要素のネイティブ動作に任せるため、独自のキーハンドラは実装しない。
+
+### HTML 構造
+
+**閉じた状態:**
+```html
+<div class="apg-disclosure">
+  <button
+    type="button"
+    aria-expanded="false"
+    aria-controls="panel-id"
+  >
+    開閉ボタン
+  </button>
+  <div id="panel-id" class="apg-disclosure-panel" aria-hidden="true" inert>
+    <div class="apg-disclosure-panel-content">
+      パネルコンテンツ
+    </div>
+  </div>
+</div>
+```
+
+**開いた状態:**
+```html
+<div class="apg-disclosure">
+  <button
+    type="button"
+    aria-expanded="true"
+    aria-controls="panel-id"
+  >
+    開閉ボタン
+  </button>
+  <div id="panel-id" class="apg-disclosure-panel apg-disclosure-panel--expanded">
+    <div class="apg-disclosure-panel-content">
+      パネルコンテンツ
+    </div>
+  </div>
+</div>
+```
+
+**状態切り替え時の属性変更:**
+
+| 状態 | `aria-expanded` | パネルの `aria-hidden` | パネルの `inert` | パネルの class |
+|------|-----------------|----------------------|-----------------|---------------|
+| 閉じ | `"false"` | `"true"` | あり | `apg-disclosure-panel` |
+| 開き | `"true"` | なし（削除） | なし（削除） | `apg-disclosure-panel--expanded` |
+
+**トリガーボタンの動作:**
+- `aria-expanded`: パネルの開閉状態に応じて `"true"` / `"false"` を切り替え
+- `aria-controls`: パネルの `id` を参照（常に設定）
+- クリック/Enter/Space で開閉をトグル（button のネイティブ動作）
+
+## ネイティブ HTML との比較
+
+ネイティブの `<details>` / `<summary>` 要素との比較を AccessibilityDocs に記載する。
+
+```html
+<!-- ネイティブ HTML -->
+<details>
+  <summary>詳細を見る</summary>
+  <p>コンテンツ</p>
+</details>
+```
+
+**ネイティブを使うべきケース:**
+- シンプルな開閉コンテンツ
+- JavaScript 無効環境での動作が必要
+- アニメーションが不要
+
+**カスタム実装が必要なケース:**
+- スムーズな開閉アニメーション
+- 外部からの状態制御
+- 複数 Disclosure の連携
+- 細かいスタイリング制御
+
+## コンポーネント設計
+
+### Props 設計
+
+```typescript
+interface DisclosureProps {
+  /** パネルが開いた状態で初期化（Accordionと命名統一） */
+  defaultExpanded?: boolean;
+  /** 開閉変更時のコールバック */
+  onExpandedChange?: (expanded: boolean) => void;
+  /** トリガーボタンのコンテンツ（テキスト/アイコンのみ推奨） */
+  trigger: React.ReactNode;
+  /** パネルのコンテンツ */
+  children: React.ReactNode;
+  /** 無効状態 */
+  disabled?: boolean;
+  /** 追加の CSS クラス */
+  className?: string;
+}
+```
+
+**設計判断:**
+- **Uncontrolled のみ**: `open` prop は削除。Switch/Accordion と同様に uncontrolled パターンに統一
+- **命名統一**: `defaultExpanded` で Accordion と整合性を取る
+- **trigger の制約**: ボタン内にフォーカス可能な要素を置かないことを推奨（ドキュメント化）
+
+### ID 生成ポリシー
+
+各フレームワークでSSR-safe なID生成を行う:
+
+| Framework | 方法 | 備考 |
+|-----------|------|------|
+| React | `useId()` フック | SSR対応済み |
+| Vue | `useId()` (Vue 3.5+) | SSR対応済み |
+| Svelte | `id` prop を受け取り、Astro側で生成 | Svelte 5 には `useId()` がない |
+| Astro | サーバーサイドで `crypto.randomUUID()` | SSRのみ（ハイドレーションなし）なのでOK |
+
+**注意事項:**
+- Vue: `useId()` は Vue 3.5+ でのみ利用可能。このプロジェクトは Vue 3.5+ を前提とする
+- Svelte: Svelte 5 には `useId()` がないため、`id` prop を必須とし、Astro ページ側で `crypto.randomUUID()` を使ってIDを生成して渡す
+- Astro: Web Components として実装するため、`client:*` ディレクティブを使わない限りハイドレーションは発生しない
+
+**Svelte での実装例:**
+```svelte
+<script lang="ts">
+  interface DisclosureProps {
+    id: string;  // 必須
+    // ...
+  }
+  let { id, ... }: DisclosureProps = $props();
+
+  // IDを使ってaria-controls用のpanelIdを生成
+  const panelId = `${id}-panel`;
+</script>
+```
+
+```astro
+<!-- Astro ページ側 -->
+<Disclosure id={crypto.randomUUID()} client:load>
+```
+
+### disabled 挙動
+
+- `disabled` 属性のみをボタンに設定（ネイティブ動作を活用）
+- `aria-disabled` は使用しない（`disabled` で十分、冗長を避ける）
+- `onExpandedChange` は disabled 時に呼ばれない（ネイティブ動作でクリック無効）
+
+## アニメーション実装
+
+`grid-template-rows` を使用したCSSアニメーションを採用（クロスブラウザ対応）。
+
+参考: https://www.tak-dcxi.com/article/css-only-details-animation-2025/
+
+### APG準拠のための `aria-hidden` + `inert` 戦略
+
+`grid-template-rows: 0fr` だけではアクセシビリティツリーからパネルが削除されないため、
+スクリーンリーダーが折りたたまれたコンテンツにアクセスできてしまう問題がある。
+
+**解決策**: `aria-hidden` + `inert` 属性を使用
+
+```html
+<!-- 閉じた状態 -->
+<div
+  id="panel-id"
+  class="apg-disclosure-panel"
+  aria-hidden="true"
+  inert
+>
+  <div class="apg-disclosure-panel-content">
+    パネルコンテンツ
+  </div>
+</div>
+
+<!-- 開いた状態 -->
+<div
+  id="panel-id"
+  class="apg-disclosure-panel apg-disclosure-panel--expanded"
+>
+  <div class="apg-disclosure-panel-content">
+    パネルコンテンツ
+  </div>
+</div>
+```
+
+- `aria-hidden="true"`: スクリーンリーダーからコンテンツを隠す
+- `inert`: パネル内のフォーカス可能要素へのフォーカス移動を防止
+- 展開時は両属性を削除（`aria-hidden` と `inert` を設定しない）
+
+**視覚的な非表示:**
+- `grid-template-rows: 0fr` + `overflow: hidden` により視覚的にも非表示
+- `aria-hidden` + `inert` はアクセシビリティツリーとフォーカス管理用
+
+**`inert` のフォールバック:**
+- `inert` 属性は IE/古いブラウザでサポートされない
+- フォールバックとして、閉じた状態で `tabindex="-1"` をフォーカス可能要素に設定
+- または inert polyfill (https://github.com/WICG/inert) を使用
+- このプロジェクトではモダンブラウザをターゲットとするため、polyfill なしで `inert` を使用
+
+### CSS アニメーション
+
+```css
+.apg-disclosure-panel {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 200ms ease-out;
+}
+
+.apg-disclosure-panel--expanded {
+  grid-template-rows: 1fr;
+}
+
+.apg-disclosure-panel-content {
+  overflow: hidden;
+}
+
+/* prefers-reduced-motion 対応 */
+@media (prefers-reduced-motion: reduce) {
+  .apg-disclosure-panel {
+    transition: none;
+  }
+}
+```
+
+**メリット:**
+- `aria-hidden` + `inert` でAPG準拠
+- Safari/Firefox でも動作
+- スムーズな高さアニメーション
+- `prefers-reduced-motion` 対応
+
+### ファイル構成
+
+```
+src/patterns/disclosure/
+├── Disclosure.tsx          # React 実装
+├── Disclosure.vue          # Vue 実装
+├── Disclosure.svelte       # Svelte 実装
+├── Disclosure.astro        # Astro (Web Components) 実装
+├── AccessibilityDocs.astro # アクセシビリティドキュメント
+└── disclosure.css          # 共通スタイル（オプション）
+```
+
+### ページ構成
+
+```
+src/pages/patterns/disclosure/
+├── index.astro             # リダイレクト
+├── react/index.astro
+├── vue/index.astro
+├── svelte/index.astro
+└── astro/index.astro
+```
+
+## 実装順序
+
+1. **React 実装** (基準実装)
+   - Disclosure.tsx 作成
+   - デモページ作成
+   - 動作確認
+
+2. **Vue 実装**
+   - Disclosure.vue 作成
+   - デモページ作成
+
+3. **Svelte 実装**
+   - Disclosure.svelte 作成
+   - デモページ作成
+
+4. **Astro (Web Components) 実装**
+   - Disclosure.astro 作成
+   - デモページ作成
+
+5. **AccessibilityDocs 作成**
+   - Native HTML Considerations（details/summary）
+   - WAI-ARIA Roles
+   - WAI-ARIA States / Properties
+   - Keyboard Support
+
+6. **パターン一覧への追加**
+   - src/lib/patterns.ts 更新
+
+## デモ内容
+
+各フレームワークで以下のデモを実装:
+
+1. **基本的な Disclosure**
+   - シンプルな開閉
+
+2. **FAQ 形式**
+   - 複数の独立した Disclosure
+
+3. **詳細情報表示**
+   - 画像の説明など
+
+## スタイリング方針
+
+- 既存パターン（Accordion 等）と統一感のあるデザイン
+- 開閉状態を示す視覚的インジケーター（矢印アイコン）
+- フォーカス状態の明確な表示
+- ダークモード対応
+
+## テスト観点
+
+1. **アクセシビリティ**
+   - `aria-expanded` が正しく切り替わる
+   - `aria-controls` が正しいIDを参照
+   - キーボード操作（Enter/Space）で開閉（buttonネイティブ動作）
+
+2. **機能**
+   - 初期状態（defaultExpanded）
+   - disabled 状態
+   - onExpandedChange コールバック
+
+3. **スクリーンリーダー**
+   - 状態の読み上げ確認
+
+4. **アニメーション**
+   - grid-template-rows によるスムーズな開閉
+   - 各ブラウザでの動作確認
+
+## 参考資料
+
+- [APG Disclosure Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/)
+- [MDN: details element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details)
+- [CSS Only Details Animation](https://www.tak-dcxi.com/article/css-only-details-animation-2025/)
+- 既存実装: `src/patterns/accordion/`

--- a/src/lib/patterns.ts
+++ b/src/lib/patterns.ts
@@ -27,9 +27,6 @@ export interface Pattern {
  * Based on WAI-ARIA APG: https://www.w3.org/WAI/ARIA/apg/patterns/
  */
 export const PATTERNS: Pattern[] = [
-  // ============================================
-  // Available patterns (implemented)
-  // ============================================
   {
     id: 'accordion',
     name: 'Accordion',
@@ -40,75 +37,19 @@ export const PATTERNS: Pattern[] = [
     status: 'available',
   },
   {
-    id: 'button',
-    name: 'Button',
-    description:
-      'A widget that enables users to trigger an action or event, such as submitting a form or toggling a state.',
-    icon: '🔘',
-    complexity: 'Low',
-    status: 'available',
-  },
-  {
-    id: 'dialog',
-    name: 'Dialog (Modal)',
-    description: 'A window overlaid on the primary window, rendering the content underneath inert.',
-    icon: '💬',
-    complexity: 'High',
-    status: 'available',
-  },
-  {
-    id: 'switch',
-    name: 'Switch',
-    description:
-      'A type of checkbox that represents on/off values, as opposed to checked/unchecked.',
-    icon: '🎚️',
-    complexity: 'Low',
-    status: 'available',
-  },
-  {
-    id: 'tabs',
-    name: 'Tabs',
-    description:
-      'A set of layered sections of content, known as tab panels, that display one panel at a time.',
-    icon: '📑',
-    complexity: 'Medium',
-    status: 'available',
-  },
-  {
-    id: 'toolbar',
-    name: 'Toolbar',
-    description:
-      'A container for grouping a set of controls, such as buttons, toggle buttons, or checkboxes.',
-    icon: '🔧',
-    complexity: 'Medium',
-    status: 'available',
-  },
-  {
-    id: 'tooltip',
-    name: 'Tooltip',
-    description:
-      'A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.',
-    icon: '💡',
-    complexity: 'Medium',
-    status: 'available',
-  },
-  {
     id: 'alert',
     name: 'Alert',
     description:
-      "An element that displays a brief, important message in a way that attracts the user's attention without interrupting the user's task.",
+      'An element that displays a brief, important message in a way that attracts the user\'s attention without interrupting the user\'s task.',
     icon: '⚠️',
     complexity: 'Low',
     status: 'available',
   },
-  // ============================================
-  // Planned patterns (not yet implemented)
-  // ============================================
   {
     id: 'alert-dialog',
     name: 'Alert Dialog',
     description:
-      "A modal dialog that interrupts the user's workflow to communicate an important message and acquire a response.",
+      'A modal dialog that interrupts the user\'s workflow to communicate an important message and acquire a response.',
     icon: '🚨',
     complexity: 'High',
     status: 'planned',
@@ -116,10 +57,20 @@ export const PATTERNS: Pattern[] = [
   {
     id: 'breadcrumb',
     name: 'Breadcrumb',
-    description: 'A list of links to the parent pages of the current page in hierarchical order.',
+    description:
+      'A list of links to the parent pages of the current page in hierarchical order.',
     icon: '🔗',
     complexity: 'Low',
     status: 'planned',
+  },
+  {
+    id: 'button',
+    name: 'Button',
+    description:
+      'A widget that enables users to trigger an action or event, such as submitting a form or toggling a state.',
+    icon: '🔘',
+    complexity: 'Low',
+    status: 'available',
   },
   {
     id: 'carousel',
@@ -149,20 +100,22 @@ export const PATTERNS: Pattern[] = [
     status: 'planned',
   },
   {
-    id: 'menu-button',
-    name: 'Menu Button',
-    description: 'A button that opens a menu of actions or options.',
-    icon: '☰',
+    id: 'dialog',
+    name: 'Dialog (Modal)',
+    description:
+      'A window overlaid on the primary window, rendering the content underneath inert.',
+    icon: '💬',
     complexity: 'High',
-    status: 'planned',
+    status: 'available',
   },
   {
     id: 'disclosure',
     name: 'Disclosure',
-    description: 'A button that controls the visibility of a section of content.',
+    description:
+      'A button that controls the visibility of a section of content.',
     icon: '▼',
     complexity: 'Low',
-    status: 'planned',
+    status: 'available',
   },
   {
     id: 'feed',
@@ -185,7 +138,8 @@ export const PATTERNS: Pattern[] = [
   {
     id: 'landmarks',
     name: 'Landmarks',
-    description: 'A set of eight roles that identify the major sections of a page.',
+    description:
+      'A set of eight roles that identify the major sections of a page.',
     icon: '🗺️',
     complexity: 'Low',
     status: 'planned',
@@ -193,7 +147,8 @@ export const PATTERNS: Pattern[] = [
   {
     id: 'link',
     name: 'Link',
-    description: 'A widget that provides an interactive reference to a resource.',
+    description:
+      'A widget that provides an interactive reference to a resource.',
     icon: '↗️',
     complexity: 'Low',
     status: 'planned',
@@ -217,9 +172,19 @@ export const PATTERNS: Pattern[] = [
     status: 'planned',
   },
   {
+    id: 'menu-button',
+    name: 'Menu Button',
+    description:
+      'A button that opens a menu of actions or options.',
+    icon: '☰',
+    complexity: 'High',
+    status: 'planned',
+  },
+  {
     id: 'meter',
     name: 'Meter',
-    description: 'A graphical display of a numeric value that varies within a defined range.',
+    description:
+      'A graphical display of a numeric value that varies within a defined range.',
     icon: '📶',
     complexity: 'Low',
     status: 'planned',
@@ -236,7 +201,8 @@ export const PATTERNS: Pattern[] = [
   {
     id: 'slider',
     name: 'Slider',
-    description: 'An input where the user selects a value from within a given range.',
+    description:
+      'An input where the user selects a value from within a given range.',
     icon: '🎚️',
     complexity: 'Medium',
     status: 'planned',
@@ -251,6 +217,15 @@ export const PATTERNS: Pattern[] = [
     status: 'planned',
   },
   {
+    id: 'switch',
+    name: 'Switch',
+    description:
+      'A type of checkbox that represents on/off values, as opposed to checked/unchecked.',
+    icon: '🎚️',
+    complexity: 'Low',
+    status: 'available',
+  },
+  {
     id: 'table',
     name: 'Table',
     description:
@@ -258,6 +233,33 @@ export const PATTERNS: Pattern[] = [
     icon: '📋',
     complexity: 'Medium',
     status: 'planned',
+  },
+  {
+    id: 'tabs',
+    name: 'Tabs',
+    description:
+      'A set of layered sections of content, known as tab panels, that display one panel at a time.',
+    icon: '📑',
+    complexity: 'Medium',
+    status: 'available',
+  },
+  {
+    id: 'toolbar',
+    name: 'Toolbar',
+    description:
+      'A container for grouping a set of controls, such as buttons, toggle buttons, or checkboxes.',
+    icon: '🔧',
+    complexity: 'Medium',
+    status: 'available',
+  },
+  {
+    id: 'tooltip',
+    name: 'Tooltip',
+    description:
+      'A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.',
+    icon: '💡',
+    complexity: 'Medium',
+    status: 'available',
   },
   {
     id: 'tree-view',

--- a/src/pages/patterns/disclosure/astro/index.astro
+++ b/src/pages/patterns/disclosure/astro/index.astro
@@ -1,0 +1,217 @@
+---
+import PatternLayout from '../../../../layouts/PatternLayout.astro';
+import Disclosure from '@patterns/disclosure/Disclosure.astro';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AccessibilityDocs from '@patterns/disclosure/AccessibilityDocs.astro';
+import NativeHtmlNotice from '@patterns/disclosure/NativeHtmlNotice.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/disclosure/Disclosure.astro?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'native-html', text: 'Native HTML' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'resources', text: 'Resources' },
+];
+---
+
+<PatternLayout title="Disclosure - Astro" pattern="disclosure" framework="astro" tocItems={tocItems}>
+    <header class="mb-8">
+      <h1 class="text-3xl font-bold mb-4">Disclosure</h1>
+      <p class="text-lg text-muted-foreground">
+        A button that controls the visibility of a section of content.
+      </p>
+    </header>
+
+    <!-- Framework Selector -->
+    <FrameworkTabs pattern="disclosure" currentFramework="astro" />
+
+    <!-- Demo Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
+
+      <!-- Basic Disclosure -->
+      <div class="mb-8">
+        <h3 class="text-lg font-medium mb-3">Basic Disclosure</h3>
+        <p class="text-sm text-muted-foreground mb-4">
+          A simple disclosure that toggles the visibility of content when clicked.
+        </p>
+        <div class="p-6 rounded-lg border border-border bg-background">
+          <Disclosure trigger="What is a Disclosure?">
+            <p>
+              A disclosure is a button that controls the visibility of a section of content.
+              It is commonly used for FAQ sections, additional details, or expandable navigation.
+            </p>
+          </Disclosure>
+        </div>
+      </div>
+
+      <!-- Initially Expanded -->
+      <div class="mb-8">
+        <h3 class="text-lg font-medium mb-3">Initially Expanded</h3>
+        <p class="text-sm text-muted-foreground mb-4">
+          Use the <code>defaultExpanded</code> prop to show the content on initial render.
+        </p>
+        <div class="p-6 rounded-lg border border-border bg-background">
+          <Disclosure trigger="This section is open by default" defaultExpanded={true}>
+            <p>
+              This content is visible when the page loads because <code>defaultExpanded</code> is set to <code>true</code>.
+            </p>
+          </Disclosure>
+        </div>
+      </div>
+
+      <!-- Disabled -->
+      <div>
+        <h3 class="text-lg font-medium mb-3">Disabled State</h3>
+        <p class="text-sm text-muted-foreground mb-4">
+          Use the <code>disabled</code> prop to prevent interaction with the disclosure.
+        </p>
+        <div class="p-6 rounded-lg border border-border bg-background">
+          <Disclosure trigger="This disclosure is disabled" disabled={true}>
+            <p>This content cannot be revealed because the disclosure is disabled.</p>
+          </Disclosure>
+        </div>
+      </div>
+    </section>
+
+    <!-- Native HTML Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Native HTML</Heading>
+      <NativeHtmlNotice />
+    </section>
+
+    <!-- Accessibility Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
+      <AccessibilityDocs />
+    </section>
+
+    <!-- Source Code Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
+      <CodeBlock
+        collapsible
+        collapsedLines={5}
+        code={sourceCode}
+        lang="astro"
+        title="Disclosure.astro"
+      />
+    </section>
+
+    <!-- Usage Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
+      <CodeBlock
+        code={`---
+import Disclosure from './Disclosure.astro';
+---
+
+<Disclosure trigger="Show details" defaultExpanded={false}>
+  <p>Hidden content that can be revealed</p>
+</Disclosure>`}
+        lang="astro"
+        title="Example"
+      />
+    </section>
+
+    <!-- API Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
+
+      <h3 class="text-lg font-medium mb-3">Props</h3>
+      <ResponsiveTable class="mb-6">
+        <table class="w-full border-collapse">
+          <thead>
+            <tr class="border-b border-border">
+              <th class="text-left py-2 pr-4">Prop</th>
+              <th class="text-left py-2 pr-4">Type</th>
+              <th class="text-left py-2 pr-4">Default</th>
+              <th class="text-left py-2">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>trigger</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">string</td>
+              <td class="py-2 pr-4 text-muted-foreground">required</td>
+              <td class="py-2">Content displayed in the trigger button</td>
+            </tr>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>slot (default)</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">any</td>
+              <td class="py-2 pr-4 text-muted-foreground">-</td>
+              <td class="py-2">Content displayed in the panel</td>
+            </tr>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>defaultExpanded</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+              <td class="py-2 pr-4 text-muted-foreground">false</td>
+              <td class="py-2">Initially expanded state</td>
+            </tr>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>disabled</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+              <td class="py-2 pr-4 text-muted-foreground">false</td>
+              <td class="py-2">Disable the disclosure</td>
+            </tr>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>class</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">string</td>
+              <td class="py-2 pr-4 text-muted-foreground">""</td>
+              <td class="py-2">Additional CSS class</td>
+            </tr>
+          </tbody>
+        </table>
+      </ResponsiveTable>
+
+      <h3 class="text-lg font-medium mb-3">Custom Events</h3>
+      <ResponsiveTable>
+        <table class="w-full border-collapse">
+          <thead>
+            <tr class="border-b border-border">
+              <th class="text-left py-2 pr-4">Event</th>
+              <th class="text-left py-2 pr-4">Detail</th>
+              <th class="text-left py-2">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>expandedchange</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">{'{ expanded: boolean }'}</td>
+              <td class="py-2">Dispatched when expanded state changes</td>
+            </tr>
+          </tbody>
+        </table>
+      </ResponsiveTable>
+    </section>
+
+    <!-- Resources -->
+    <section>
+      <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
+      <ul class="list-disc pl-6 space-y-2">
+        <li>
+          <ExternalLink
+            href="https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/"
+            class="text-primary hover:underline"
+          >
+            WAI-ARIA APG: Disclosure Pattern
+          </ExternalLink>
+        </li>
+        <li>
+          <ExternalLink
+            href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details"
+            class="text-primary hover:underline"
+          >
+            MDN: &lt;details&gt; element
+          </ExternalLink>
+        </li>
+      </ul>
+    </section>
+</PatternLayout>

--- a/src/pages/patterns/disclosure/index.astro
+++ b/src/pages/patterns/disclosure/index.astro
@@ -1,0 +1,4 @@
+---
+// Redirect to React implementation by default
+return Astro.redirect('/patterns/disclosure/react/');
+---

--- a/src/pages/patterns/disclosure/react/index.astro
+++ b/src/pages/patterns/disclosure/react/index.astro
@@ -1,0 +1,209 @@
+---
+import PatternLayout from '../../../../layouts/PatternLayout.astro';
+import Disclosure from '@patterns/disclosure/Disclosure';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AccessibilityDocs from '@patterns/disclosure/AccessibilityDocs.astro';
+import NativeHtmlNotice from '@patterns/disclosure/NativeHtmlNotice.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/disclosure/Disclosure.tsx?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'native-html', text: 'Native HTML' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'resources', text: 'Resources' },
+];
+---
+
+<PatternLayout title="Disclosure - React" pattern="disclosure" framework="react" tocItems={tocItems}>
+    <header class="mb-8">
+      <h1 class="text-3xl font-bold mb-4">Disclosure</h1>
+      <p class="text-lg text-muted-foreground">
+        A button that controls the visibility of a section of content.
+      </p>
+    </header>
+
+    <!-- Framework Selector -->
+    <FrameworkTabs pattern="disclosure" currentFramework="react" />
+
+    <!-- Demo Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
+
+      <!-- Basic Disclosure -->
+      <div class="mb-8">
+        <h3 class="text-lg font-medium mb-3">Basic Disclosure</h3>
+        <p class="text-sm text-muted-foreground mb-4">
+          A simple disclosure that toggles the visibility of content when clicked.
+        </p>
+        <div class="p-6 rounded-lg border border-border bg-background">
+          <Disclosure client:load trigger="What is a Disclosure?">
+            <p>
+              A disclosure is a button that controls the visibility of a section of content.
+              It is commonly used for FAQ sections, additional details, or expandable navigation.
+            </p>
+          </Disclosure>
+        </div>
+      </div>
+
+      <!-- Initially Expanded -->
+      <div class="mb-8">
+        <h3 class="text-lg font-medium mb-3">Initially Expanded</h3>
+        <p class="text-sm text-muted-foreground mb-4">
+          Use the <code>defaultExpanded</code> prop to show the content on initial render.
+        </p>
+        <div class="p-6 rounded-lg border border-border bg-background">
+          <Disclosure client:load trigger="This section is open by default" defaultExpanded={true}>
+            <p>
+              This content is visible when the page loads because <code>defaultExpanded</code> is set to <code>true</code>.
+            </p>
+          </Disclosure>
+        </div>
+      </div>
+
+      <!-- Disabled -->
+      <div>
+        <h3 class="text-lg font-medium mb-3">Disabled State</h3>
+        <p class="text-sm text-muted-foreground mb-4">
+          Use the <code>disabled</code> prop to prevent interaction with the disclosure.
+        </p>
+        <div class="p-6 rounded-lg border border-border bg-background">
+          <Disclosure client:load trigger="This disclosure is disabled" disabled={true}>
+            <p>This content cannot be revealed because the disclosure is disabled.</p>
+          </Disclosure>
+        </div>
+      </div>
+    </section>
+
+    <!-- Native HTML Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Native HTML</Heading>
+      <NativeHtmlNotice />
+    </section>
+
+    <!-- Accessibility Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
+      <AccessibilityDocs />
+    </section>
+
+    <!-- Source Code Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
+      <CodeBlock
+        collapsible
+        collapsedLines={5}
+        code={sourceCode}
+        lang="tsx"
+        title="Disclosure.tsx"
+      />
+    </section>
+
+    <!-- Usage Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
+      <CodeBlock
+        code={`import { Disclosure } from './Disclosure';
+
+function App() {
+  return (
+    <Disclosure
+      trigger="Show details"
+      defaultExpanded={false}
+      onExpandedChange={(expanded) => console.log('Expanded:', expanded)}
+    >
+      <p>Hidden content that can be revealed</p>
+    </Disclosure>
+  );
+}`}
+        lang="tsx"
+        title="Example"
+      />
+    </section>
+
+    <!-- API Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
+
+      <h3 class="text-lg font-medium mb-3">DisclosureProps</h3>
+      <ResponsiveTable class="mb-6">
+        <table class="w-full border-collapse">
+          <thead>
+            <tr class="border-b border-border">
+              <th class="text-left py-2 pr-4">Prop</th>
+              <th class="text-left py-2 pr-4">Type</th>
+              <th class="text-left py-2 pr-4">Default</th>
+              <th class="text-left py-2">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>trigger</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">ReactNode</td>
+              <td class="py-2 pr-4 text-muted-foreground">required</td>
+              <td class="py-2">Content displayed in the trigger button</td>
+            </tr>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>children</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">ReactNode</td>
+              <td class="py-2 pr-4 text-muted-foreground">required</td>
+              <td class="py-2">Content displayed in the panel</td>
+            </tr>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>defaultExpanded</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+              <td class="py-2 pr-4 text-muted-foreground">false</td>
+              <td class="py-2">Initially expanded state</td>
+            </tr>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>onExpandedChange</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">(expanded: boolean) =&gt; void</td>
+              <td class="py-2 pr-4 text-muted-foreground">-</td>
+              <td class="py-2">Callback when expanded state changes</td>
+            </tr>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>disabled</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+              <td class="py-2 pr-4 text-muted-foreground">false</td>
+              <td class="py-2">Disable the disclosure</td>
+            </tr>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>className</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">string</td>
+              <td class="py-2 pr-4 text-muted-foreground">""</td>
+              <td class="py-2">Additional CSS class</td>
+            </tr>
+          </tbody>
+        </table>
+      </ResponsiveTable>
+    </section>
+
+    <!-- Resources -->
+    <section>
+      <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
+      <ul class="list-disc pl-6 space-y-2">
+        <li>
+          <ExternalLink
+            href="https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/"
+            class="text-primary hover:underline"
+          >
+            WAI-ARIA APG: Disclosure Pattern
+          </ExternalLink>
+        </li>
+        <li>
+          <ExternalLink
+            href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details"
+            class="text-primary hover:underline"
+          >
+            MDN: &lt;details&gt; element
+          </ExternalLink>
+        </li>
+      </ul>
+    </section>
+</PatternLayout>

--- a/src/pages/patterns/disclosure/svelte/index.astro
+++ b/src/pages/patterns/disclosure/svelte/index.astro
@@ -1,0 +1,228 @@
+---
+import PatternLayout from '../../../../layouts/PatternLayout.astro';
+import Disclosure from '@patterns/disclosure/Disclosure.svelte';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AccessibilityDocs from '@patterns/disclosure/AccessibilityDocs.astro';
+import NativeHtmlNotice from '@patterns/disclosure/NativeHtmlNotice.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/disclosure/Disclosure.svelte?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'native-html', text: 'Native HTML' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'resources', text: 'Resources' },
+];
+---
+
+<PatternLayout title="Disclosure - Svelte" pattern="disclosure" framework="svelte" tocItems={tocItems}>
+    <header class="mb-8">
+      <h1 class="text-3xl font-bold mb-4">Disclosure</h1>
+      <p class="text-lg text-muted-foreground">
+        A button that controls the visibility of a section of content.
+      </p>
+    </header>
+
+    <!-- Framework Selector -->
+    <FrameworkTabs pattern="disclosure" currentFramework="svelte" />
+
+    <!-- Demo Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
+
+      <!-- Basic Disclosure -->
+      <div class="mb-8">
+        <h3 class="text-lg font-medium mb-3">Basic Disclosure</h3>
+        <p class="text-sm text-muted-foreground mb-4">
+          A simple disclosure that toggles the visibility of content when clicked.
+        </p>
+        <div class="p-6 rounded-lg border border-border bg-background">
+          <Disclosure
+            client:load
+            id={crypto.randomUUID()}
+            trigger="What is a Disclosure?"
+          >
+            <p>
+              A disclosure is a button that controls the visibility of a section of content.
+              It is commonly used for FAQ sections, additional details, or expandable navigation.
+            </p>
+          </Disclosure>
+        </div>
+      </div>
+
+      <!-- Initially Expanded -->
+      <div class="mb-8">
+        <h3 class="text-lg font-medium mb-3">Initially Expanded</h3>
+        <p class="text-sm text-muted-foreground mb-4">
+          Use the <code>defaultExpanded</code> prop to show the content on initial render.
+        </p>
+        <div class="p-6 rounded-lg border border-border bg-background">
+          <Disclosure
+            client:load
+            id={crypto.randomUUID()}
+            trigger="This section is open by default"
+            defaultExpanded={true}
+          >
+            <p>
+              This content is visible when the page loads because <code>defaultExpanded</code> is set to <code>true</code>.
+            </p>
+          </Disclosure>
+        </div>
+      </div>
+
+      <!-- Disabled -->
+      <div>
+        <h3 class="text-lg font-medium mb-3">Disabled State</h3>
+        <p class="text-sm text-muted-foreground mb-4">
+          Use the <code>disabled</code> prop to prevent interaction with the disclosure.
+        </p>
+        <div class="p-6 rounded-lg border border-border bg-background">
+          <Disclosure
+            client:load
+            id={crypto.randomUUID()}
+            trigger="This disclosure is disabled"
+            disabled={true}
+          >
+            <p>This content cannot be revealed because the disclosure is disabled.</p>
+          </Disclosure>
+        </div>
+      </div>
+    </section>
+
+    <!-- Native HTML Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Native HTML</Heading>
+      <NativeHtmlNotice />
+    </section>
+
+    <!-- Accessibility Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
+      <AccessibilityDocs />
+    </section>
+
+    <!-- Source Code Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
+      <CodeBlock
+        collapsible
+        collapsedLines={5}
+        code={sourceCode}
+        lang="svelte"
+        title="Disclosure.svelte"
+      />
+    </section>
+
+    <!-- Usage Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
+      <CodeBlock
+        code={`<script>
+  import Disclosure from './Disclosure.svelte';
+</script>
+
+<Disclosure
+  id="my-disclosure"
+  trigger="Show details"
+  defaultExpanded={false}
+  onExpandedChange={(expanded) => console.log('Expanded:', expanded)}
+>
+  <p>Hidden content that can be revealed</p>
+</Disclosure>`}
+        lang="svelte"
+        title="Example"
+      />
+    </section>
+
+    <!-- API Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
+
+      <h3 class="text-lg font-medium mb-3">Props</h3>
+      <ResponsiveTable class="mb-6">
+        <table class="w-full border-collapse">
+          <thead>
+            <tr class="border-b border-border">
+              <th class="text-left py-2 pr-4">Prop</th>
+              <th class="text-left py-2 pr-4">Type</th>
+              <th class="text-left py-2 pr-4">Default</th>
+              <th class="text-left py-2">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>id</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">string</td>
+              <td class="py-2 pr-4 text-muted-foreground">auto-generated</td>
+              <td class="py-2">Unique identifier for aria-controls (recommended for SSR)</td>
+            </tr>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>trigger</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">string</td>
+              <td class="py-2 pr-4 text-muted-foreground">required</td>
+              <td class="py-2">Content displayed in the trigger button</td>
+            </tr>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>children</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">Snippet</td>
+              <td class="py-2 pr-4 text-muted-foreground">-</td>
+              <td class="py-2">Content displayed in the panel</td>
+            </tr>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>defaultExpanded</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+              <td class="py-2 pr-4 text-muted-foreground">false</td>
+              <td class="py-2">Initially expanded state</td>
+            </tr>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>disabled</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+              <td class="py-2 pr-4 text-muted-foreground">false</td>
+              <td class="py-2">Disable the disclosure</td>
+            </tr>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>className</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">string</td>
+              <td class="py-2 pr-4 text-muted-foreground">""</td>
+              <td class="py-2">Additional CSS class</td>
+            </tr>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>onExpandedChange</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">(expanded: boolean) =&gt; void</td>
+              <td class="py-2 pr-4 text-muted-foreground">-</td>
+              <td class="py-2">Callback when expanded state changes</td>
+            </tr>
+          </tbody>
+        </table>
+      </ResponsiveTable>
+    </section>
+
+    <!-- Resources -->
+    <section>
+      <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
+      <ul class="list-disc pl-6 space-y-2">
+        <li>
+          <ExternalLink
+            href="https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/"
+            class="text-primary hover:underline"
+          >
+            WAI-ARIA APG: Disclosure Pattern
+          </ExternalLink>
+        </li>
+        <li>
+          <ExternalLink
+            href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details"
+            class="text-primary hover:underline"
+          >
+            MDN: &lt;details&gt; element
+          </ExternalLink>
+        </li>
+      </ul>
+    </section>
+</PatternLayout>

--- a/src/pages/patterns/disclosure/vue/index.astro
+++ b/src/pages/patterns/disclosure/vue/index.astro
@@ -1,0 +1,239 @@
+---
+import PatternLayout from '../../../../layouts/PatternLayout.astro';
+import Disclosure from '@patterns/disclosure/Disclosure.vue';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AccessibilityDocs from '@patterns/disclosure/AccessibilityDocs.astro';
+import NativeHtmlNotice from '@patterns/disclosure/NativeHtmlNotice.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/disclosure/Disclosure.vue?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'native-html', text: 'Native HTML' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'resources', text: 'Resources' },
+];
+---
+
+<PatternLayout title="Disclosure - Vue" pattern="disclosure" framework="vue" tocItems={tocItems}>
+    <header class="mb-8">
+      <h1 class="text-3xl font-bold mb-4">Disclosure</h1>
+      <p class="text-lg text-muted-foreground">
+        A button that controls the visibility of a section of content.
+      </p>
+    </header>
+
+    <!-- Framework Selector -->
+    <FrameworkTabs pattern="disclosure" currentFramework="vue" />
+
+    <!-- Demo Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Demo</Heading>
+
+      <!-- Basic Disclosure -->
+      <div class="mb-8">
+        <h3 class="text-lg font-medium mb-3">Basic Disclosure</h3>
+        <p class="text-sm text-muted-foreground mb-4">
+          A simple disclosure that toggles the visibility of content when clicked.
+        </p>
+        <div class="p-6 rounded-lg border border-border bg-background">
+          <Disclosure client:load trigger="What is a Disclosure?">
+            <p>
+              A disclosure is a button that controls the visibility of a section of content.
+              It is commonly used for FAQ sections, additional details, or expandable navigation.
+            </p>
+          </Disclosure>
+        </div>
+      </div>
+
+      <!-- Initially Expanded -->
+      <div class="mb-8">
+        <h3 class="text-lg font-medium mb-3">Initially Expanded</h3>
+        <p class="text-sm text-muted-foreground mb-4">
+          Use the <code>defaultExpanded</code> prop to show the content on initial render.
+        </p>
+        <div class="p-6 rounded-lg border border-border bg-background">
+          <Disclosure client:load trigger="This section is open by default" defaultExpanded={true}>
+            <p>
+              This content is visible when the page loads because <code>defaultExpanded</code> is set to <code>true</code>.
+            </p>
+          </Disclosure>
+        </div>
+      </div>
+
+      <!-- Disabled -->
+      <div>
+        <h3 class="text-lg font-medium mb-3">Disabled State</h3>
+        <p class="text-sm text-muted-foreground mb-4">
+          Use the <code>disabled</code> prop to prevent interaction with the disclosure.
+        </p>
+        <div class="p-6 rounded-lg border border-border bg-background">
+          <Disclosure client:load trigger="This disclosure is disabled" disabled={true}>
+            <p>This content cannot be revealed because the disclosure is disabled.</p>
+          </Disclosure>
+        </div>
+      </div>
+    </section>
+
+    <!-- Native HTML Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Native HTML</Heading>
+      <NativeHtmlNotice />
+    </section>
+
+    <!-- Accessibility Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Accessibility Features</Heading>
+      <AccessibilityDocs />
+    </section>
+
+    <!-- Source Code Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Source Code</Heading>
+      <CodeBlock
+        collapsible
+        collapsedLines={5}
+        code={sourceCode}
+        lang="vue"
+        title="Disclosure.vue"
+      />
+    </section>
+
+    <!-- Usage Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">Usage</Heading>
+      <CodeBlock
+        code={`<script setup>
+import Disclosure from './Disclosure.vue';
+</script>
+
+<template>
+  <Disclosure
+    trigger="Show details"
+    :default-expanded="false"
+    @expanded-change="(expanded) => console.log('Expanded:', expanded)"
+  >
+    <p>Hidden content that can be revealed</p>
+  </Disclosure>
+</template>`}
+        lang="vue"
+        title="Example"
+      />
+    </section>
+
+    <!-- API Section -->
+    <section class="mb-12">
+      <Heading level={2} class="text-xl font-semibold mb-4">API</Heading>
+
+      <h3 class="text-lg font-medium mb-3">Props</h3>
+      <ResponsiveTable class="mb-6">
+        <table class="w-full border-collapse">
+          <thead>
+            <tr class="border-b border-border">
+              <th class="text-left py-2 pr-4">Prop</th>
+              <th class="text-left py-2 pr-4">Type</th>
+              <th class="text-left py-2 pr-4">Default</th>
+              <th class="text-left py-2">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>trigger</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">string</td>
+              <td class="py-2 pr-4 text-muted-foreground">""</td>
+              <td class="py-2">Content displayed in the trigger button (or use #trigger slot)</td>
+            </tr>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>defaultExpanded</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+              <td class="py-2 pr-4 text-muted-foreground">false</td>
+              <td class="py-2">Initially expanded state</td>
+            </tr>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>disabled</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+              <td class="py-2 pr-4 text-muted-foreground">false</td>
+              <td class="py-2">Disable the disclosure</td>
+            </tr>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>className</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">string</td>
+              <td class="py-2 pr-4 text-muted-foreground">""</td>
+              <td class="py-2">Additional CSS class</td>
+            </tr>
+          </tbody>
+        </table>
+      </ResponsiveTable>
+
+      <h3 class="text-lg font-medium mb-3">Events</h3>
+      <ResponsiveTable class="mb-6">
+        <table class="w-full border-collapse">
+          <thead>
+            <tr class="border-b border-border">
+              <th class="text-left py-2 pr-4">Event</th>
+              <th class="text-left py-2 pr-4">Payload</th>
+              <th class="text-left py-2">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>expandedChange</code></td>
+              <td class="py-2 pr-4 text-muted-foreground">boolean</td>
+              <td class="py-2">Emitted when expanded state changes</td>
+            </tr>
+          </tbody>
+        </table>
+      </ResponsiveTable>
+
+      <h3 class="text-lg font-medium mb-3">Slots</h3>
+      <ResponsiveTable>
+        <table class="w-full border-collapse">
+          <thead>
+            <tr class="border-b border-border">
+              <th class="text-left py-2 pr-4">Slot</th>
+              <th class="text-left py-2">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>default</code></td>
+              <td class="py-2">Content displayed in the panel</td>
+            </tr>
+            <tr class="border-b border-border">
+              <td class="py-2 pr-4"><code>#trigger</code></td>
+              <td class="py-2">Custom trigger content (alternative to trigger prop)</td>
+            </tr>
+          </tbody>
+        </table>
+      </ResponsiveTable>
+    </section>
+
+    <!-- Resources -->
+    <section>
+      <Heading level={2} class="text-xl font-semibold mb-4">Resources</Heading>
+      <ul class="list-disc pl-6 space-y-2">
+        <li>
+          <ExternalLink
+            href="https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/"
+            class="text-primary hover:underline"
+          >
+            WAI-ARIA APG: Disclosure Pattern
+          </ExternalLink>
+        </li>
+        <li>
+          <ExternalLink
+            href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details"
+            class="text-primary hover:underline"
+          >
+            MDN: &lt;details&gt; element
+          </ExternalLink>
+        </li>
+      </ul>
+    </section>
+</PatternLayout>

--- a/src/patterns/disclosure/AccessibilityDocs.astro
+++ b/src/patterns/disclosure/AccessibilityDocs.astro
@@ -1,0 +1,124 @@
+---
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+---
+
+<div class="prose dark:prose-invert max-w-none">
+  <h3 class="text-lg font-medium mb-3">WAI-ARIA Roles</h3>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Role</th>
+          <th class="text-left py-2 pr-4">Target Element</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>button</code></td>
+          <td class="py-2 pr-4">Trigger element</td>
+          <td class="py-2">Interactive element that toggles panel visibility (use native <code>&lt;button&gt;</code>)</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+  <p class="text-sm text-muted-foreground mb-6">
+    <ExternalLink href="https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/" class="text-primary hover:underline">
+      WAI-ARIA Disclosure Pattern
+    </ExternalLink>
+  </p>
+
+  <h3 class="text-lg font-medium mb-3">WAI-ARIA Properties</h3>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Attribute</th>
+          <th class="text-left py-2 pr-4">Target</th>
+          <th class="text-left py-2 pr-4">Values</th>
+          <th class="text-left py-2 pr-4">Required</th>
+          <th class="text-left py-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>aria-controls</code></td>
+          <td class="py-2 pr-4">button</td>
+          <td class="py-2 pr-4">ID reference to panel</td>
+          <td class="py-2 pr-4">Yes</td>
+          <td class="py-2">Associates the button with the panel it controls</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><code>aria-hidden</code></td>
+          <td class="py-2 pr-4">panel</td>
+          <td class="py-2 pr-4"><code>true</code> | <code>false</code></td>
+          <td class="py-2 pr-4">No</td>
+          <td class="py-2">Hides panel from assistive technology when collapsed</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h3 class="text-lg font-medium mb-3">WAI-ARIA States</h3>
+  <div class="mb-6">
+    <h4 class="font-medium mb-2"><code>aria-expanded</code></h4>
+    <p class="text-muted-foreground mb-3">Indicates whether the disclosure panel is expanded or collapsed.</p>
+    <ResponsiveTable class="mb-2">
+      <table class="w-full border-collapse">
+        <tbody>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4 font-medium w-32">Target</td>
+            <td class="py-2">button element</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4 font-medium">Values</td>
+            <td class="py-2"><code>true</code> | <code>false</code></td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4 font-medium">Required</td>
+            <td class="py-2">Yes</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4 font-medium">Change Trigger</td>
+            <td class="py-2">Click, Enter, Space</td>
+          </tr>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4 font-medium">Reference</td>
+            <td class="py-2">
+              <ExternalLink href="https://w3c.github.io/aria/#aria-expanded" class="text-primary hover:underline">
+                aria-expanded
+              </ExternalLink>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </div>
+
+  <h3 class="text-lg font-medium mb-3">Keyboard Support</h3>
+  <ResponsiveTable class="mb-4">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Key</th>
+          <th class="text-left py-2">Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><kbd class="px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded">Tab</kbd></td>
+          <td class="py-2">Move focus to the disclosure button</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4"><kbd class="px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded">Space</kbd> / <kbd class="px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded">Enter</kbd></td>
+          <td class="py-2">Toggle the visibility of the disclosure panel</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+  <p class="text-sm text-muted-foreground">
+    Disclosure uses native <code>&lt;button&gt;</code> element behavior for keyboard interaction.
+    No additional keyboard handlers are required.
+  </p>
+</div>

--- a/src/patterns/disclosure/Disclosure.astro
+++ b/src/patterns/disclosure/Disclosure.astro
@@ -1,0 +1,150 @@
+---
+/**
+ * APG Disclosure Pattern - Astro Implementation
+ *
+ * A button that controls the visibility of a section of content.
+ * Uses Web Components for client-side state management.
+ *
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/
+ */
+
+export interface Props {
+  /** Content displayed in the disclosure trigger button */
+  trigger: string;
+  /** When true, the panel is expanded on initial render */
+  defaultExpanded?: boolean;
+  /** When true, the disclosure cannot be expanded/collapsed */
+  disabled?: boolean;
+  /** Additional CSS class */
+  class?: string;
+}
+
+const {
+  trigger,
+  defaultExpanded = false,
+  disabled = false,
+  class: className = "",
+} = Astro.props;
+
+// Generate unique ID for this instance
+const instanceId = crypto.randomUUID();
+const panelId = `${instanceId}-panel`;
+---
+
+<apg-disclosure
+  class:list={["apg-disclosure", className]}
+  data-expanded={defaultExpanded}
+>
+  <button
+    type="button"
+    aria-expanded={defaultExpanded}
+    aria-controls={panelId}
+    disabled={disabled}
+    class="apg-disclosure-trigger"
+  >
+    <span class="apg-disclosure-icon" aria-hidden="true">
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+      >
+        <polyline points="9 6 15 12 9 18"></polyline>
+      </svg>
+    </span>
+    <span class="apg-disclosure-trigger-content">{trigger}</span>
+  </button>
+  <div
+    id={panelId}
+    class="apg-disclosure-panel"
+    aria-hidden={!defaultExpanded}
+    inert={!defaultExpanded ? true : undefined}
+  >
+    <div class="apg-disclosure-panel-content">
+      <slot />
+    </div>
+  </div>
+</apg-disclosure>
+
+<script>
+  class ApgDisclosure extends HTMLElement {
+    private button: HTMLButtonElement | null = null;
+    private panel: HTMLElement | null = null;
+    private expanded = false;
+    private rafId: number | null = null;
+
+    connectedCallback() {
+      // Use requestAnimationFrame to ensure DOM is fully constructed
+      this.rafId = requestAnimationFrame(() => this.initialize());
+    }
+
+    private initialize() {
+      this.rafId = null;
+      this.button = this.querySelector(".apg-disclosure-trigger");
+      this.panel = this.querySelector(".apg-disclosure-panel");
+
+      if (!this.button || !this.panel) {
+        console.warn("apg-disclosure: button or panel not found");
+        return;
+      }
+
+      this.expanded = this.dataset.expanded === "true";
+
+      // Attach event listener
+      this.button.addEventListener("click", this.handleClick);
+    }
+
+    disconnectedCallback() {
+      // Cancel pending initialization
+      if (this.rafId !== null) {
+        cancelAnimationFrame(this.rafId);
+        this.rafId = null;
+      }
+      // Remove event listener
+      this.button?.removeEventListener("click", this.handleClick);
+      // Clean up references
+      this.button = null;
+      this.panel = null;
+    }
+
+    private toggle() {
+      this.expanded = !this.expanded;
+      this.updateDOM();
+
+      // Dispatch custom event
+      this.dispatchEvent(
+        new CustomEvent("expandedchange", {
+          detail: { expanded: this.expanded },
+          bubbles: true,
+        }),
+      );
+    }
+
+    private updateDOM() {
+      if (!this.button || !this.panel) return;
+
+      // Update button aria-expanded
+      this.button.setAttribute("aria-expanded", String(this.expanded));
+
+      // Update panel aria-hidden
+      this.panel.setAttribute("aria-hidden", String(!this.expanded));
+
+      // Toggle inert attribute
+      if (this.expanded) {
+        this.panel.removeAttribute("inert");
+      } else {
+        this.panel.setAttribute("inert", "");
+      }
+    }
+
+    private handleClick = () => {
+      if (this.button?.disabled) return;
+      this.toggle();
+    };
+  }
+
+  // Register the custom element
+  if (!customElements.get("apg-disclosure")) {
+    customElements.define("apg-disclosure", ApgDisclosure);
+  }
+</script>

--- a/src/patterns/disclosure/Disclosure.svelte
+++ b/src/patterns/disclosure/Disclosure.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  /**
+   * APG Disclosure Pattern - Svelte Implementation
+   *
+   * A button that controls the visibility of a section of content.
+   *
+   * @see https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/
+   */
+
+  /**
+   * Props for the Disclosure component
+   */
+  interface DisclosureProps {
+    /** Unique identifier (recommended for SSR-safe aria-controls) */
+    id?: string;
+    /** Content displayed in the disclosure trigger button */
+    trigger: string;
+    /** Content displayed in the collapsible panel */
+    children?: Snippet;
+    /** When true, the panel is expanded on initial render */
+    defaultExpanded?: boolean;
+    /** When true, the disclosure cannot be expanded/collapsed */
+    disabled?: boolean;
+    /** Additional CSS class */
+    className?: string;
+    /** Callback fired when the expanded state changes */
+    onExpandedChange?: (expanded: boolean) => void;
+  }
+
+  let {
+    id,
+    trigger,
+    children,
+    defaultExpanded = false,
+    disabled = false,
+    className = '',
+    onExpandedChange = () => {},
+  }: DisclosureProps = $props();
+
+  // Generate fallback ID if not provided (client-side only, may cause SSR mismatch)
+  const instanceId = id ?? crypto.randomUUID();
+
+  let expanded = $state(defaultExpanded);
+
+  const panelId = `${instanceId}-panel`;
+
+  function handleToggle() {
+    if (disabled) return;
+
+    expanded = !expanded;
+    onExpandedChange(expanded);
+  }
+</script>
+
+<div class="apg-disclosure {className}">
+  <button
+    type="button"
+    aria-expanded={expanded}
+    aria-controls={panelId}
+    {disabled}
+    class="apg-disclosure-trigger"
+    onclick={handleToggle}
+  >
+    <span class="apg-disclosure-icon" aria-hidden="true">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <polyline points="9 6 15 12 9 18" />
+      </svg>
+    </span>
+    <span class="apg-disclosure-trigger-content">{trigger}</span>
+  </button>
+  <div
+    id={panelId}
+    class="apg-disclosure-panel"
+    aria-hidden={!expanded}
+    inert={!expanded ? true : undefined}
+  >
+    <div class="apg-disclosure-panel-content">
+      {@render children?.()}
+    </div>
+  </div>
+</div>

--- a/src/patterns/disclosure/Disclosure.tsx
+++ b/src/patterns/disclosure/Disclosure.tsx
@@ -1,0 +1,102 @@
+import { useId, useState, useCallback } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Props for the Disclosure component
+ *
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/
+ *
+ * @example
+ * ```tsx
+ * <Disclosure trigger="Show details">
+ *   <p>Hidden content that can be revealed</p>
+ * </Disclosure>
+ * ```
+ */
+export interface DisclosureProps {
+  /**
+   * Content displayed in the disclosure trigger button
+   */
+  trigger: React.ReactNode;
+  /**
+   * Content displayed in the collapsible panel
+   */
+  children: React.ReactNode;
+  /**
+   * When true, the panel is expanded on initial render
+   * @default false
+   */
+  defaultExpanded?: boolean;
+  /**
+   * Callback fired when the expanded state changes
+   * @param expanded - The new expanded state
+   */
+  onExpandedChange?: (expanded: boolean) => void;
+  /**
+   * When true, the disclosure cannot be expanded/collapsed
+   * @default false
+   */
+  disabled?: boolean;
+  /**
+   * Additional CSS class to apply to the disclosure container
+   * @default ""
+   */
+  className?: string;
+}
+
+export function Disclosure({
+  trigger,
+  children,
+  defaultExpanded = false,
+  onExpandedChange,
+  disabled = false,
+  className = "",
+}: DisclosureProps): React.ReactElement {
+  const instanceId = useId();
+  const panelId = `${instanceId}-panel`;
+
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  const handleToggle = useCallback(() => {
+    if (disabled) return;
+
+    const newExpanded = !expanded;
+    setExpanded(newExpanded);
+    onExpandedChange?.(newExpanded);
+  }, [expanded, disabled, onExpandedChange]);
+
+  return (
+    <div className={cn("apg-disclosure", className)}>
+      <button
+        type="button"
+        aria-expanded={expanded}
+        aria-controls={panelId}
+        disabled={disabled}
+        className="apg-disclosure-trigger"
+        onClick={handleToggle}
+      >
+        <span className="apg-disclosure-icon" aria-hidden="true">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <polyline points="9 6 15 12 9 18" />
+          </svg>
+        </span>
+        <span className="apg-disclosure-trigger-content">{trigger}</span>
+      </button>
+      <div
+        id={panelId}
+        className="apg-disclosure-panel"
+        aria-hidden={!expanded}
+        inert={!expanded ? true : undefined}
+      >
+        <div className="apg-disclosure-panel-content">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+export default Disclosure;

--- a/src/patterns/disclosure/Disclosure.vue
+++ b/src/patterns/disclosure/Disclosure.vue
@@ -1,0 +1,87 @@
+<template>
+  <div :class="['apg-disclosure', className]">
+    <button
+      type="button"
+      :aria-expanded="expanded"
+      :aria-controls="panelId"
+      :disabled="disabled"
+      class="apg-disclosure-trigger"
+      @click="handleToggle"
+    >
+      <span class="apg-disclosure-icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <polyline points="9 6 15 12 9 18" />
+        </svg>
+      </span>
+      <span class="apg-disclosure-trigger-content">
+        <slot name="trigger">{{ trigger }}</slot>
+      </span>
+    </button>
+    <div
+      :id="panelId"
+      class="apg-disclosure-panel"
+      :aria-hidden="!expanded"
+      :inert="!expanded || undefined"
+    >
+      <div class="apg-disclosure-panel-content">
+        <slot />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * APG Disclosure Pattern - Vue Implementation
+ *
+ * A button that controls the visibility of a section of content.
+ *
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/
+ */
+import { ref, useId } from 'vue'
+
+/**
+ * Props for the Disclosure component
+ *
+ * @example
+ * ```vue
+ * <Disclosure trigger="Show details">
+ *   <p>Hidden content that can be revealed</p>
+ * </Disclosure>
+ * ```
+ */
+export interface DisclosureProps {
+  /** Content displayed in the disclosure trigger button (can also use #trigger slot) */
+  trigger?: string
+  /** When true, the panel is expanded on initial render @default false */
+  defaultExpanded?: boolean
+  /** When true, the disclosure cannot be expanded/collapsed @default false */
+  disabled?: boolean
+  /** Additional CSS class @default "" */
+  className?: string
+}
+
+const props = withDefaults(defineProps<DisclosureProps>(), {
+  trigger: '',
+  defaultExpanded: false,
+  disabled: false,
+  className: ''
+})
+
+const emit = defineEmits<{
+  expandedChange: [expanded: boolean]
+}>()
+
+const instanceId = useId()
+const panelId = `${instanceId}-panel`
+
+const expanded = ref(props.defaultExpanded)
+const { className } = props
+
+const handleToggle = () => {
+  if (props.disabled) return
+
+  expanded.value = !expanded.value
+  emit('expandedChange', expanded.value)
+}
+</script>

--- a/src/patterns/disclosure/NativeHtmlNotice.astro
+++ b/src/patterns/disclosure/NativeHtmlNotice.astro
@@ -1,0 +1,79 @@
+---
+import { ResponsiveTable } from "@/components/ui/table";
+---
+
+<div class="mb-8 p-4 border-2 border-primary rounded-lg">
+  <h2 class="text-lg font-bold mb-2 flex items-center gap-2">
+    <span aria-hidden="true">⚠️</span> Use Native HTML First
+  </h2>
+  <p class="mb-4">
+    <strong class="text-red-700 dark:text-red-400"
+      >Before using this custom component, consider using native <code
+        >&lt;details&gt;</code
+      > and <code>&lt;summary&gt;</code> elements.</strong
+    >
+    They provide built-in accessibility, work without JavaScript, and require no ARIA
+    attributes.
+  </p>
+  <div class="p-3 bg-muted rounded-md mb-4">
+    <pre
+      class="text-sm overflow-x-auto m-0"><code>&lt;details&gt;
+  &lt;summary&gt;Show details&lt;/summary&gt;
+  &lt;p&gt;Hidden content here...&lt;/p&gt;
+&lt;/details&gt;</code></pre>
+  </div>
+  <p class="text-sm mb-4">
+    Use custom implementations only when you need smooth height animations,
+    external state control, or styling that native elements cannot provide.
+  </p>
+
+  <ResponsiveTable>
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-b border-border">
+          <th class="text-left py-2 pr-4">Use Case</th>
+          <th class="text-left py-2 pr-4">Native HTML</th>
+          <th class="text-left py-2">Custom Implementation</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4">Simple toggle content</td>
+          <td class="py-2 pr-4"
+            ><b class="text-green-700 dark:text-green-400">Recommended</b></td
+          >
+          <td class="py-2">Not needed</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4">JavaScript disabled support</td>
+          <td class="py-2 pr-4"
+            ><b class="text-green-700 dark:text-green-400">Works natively</b
+            ></td
+          >
+          <td class="py-2">Requires fallback</td>
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4">Smooth animations</td>
+          <td class="py-2 pr-4">Limited support</td>
+          <td class="py-2"
+            ><b class="text-green-700 dark:text-green-400">Full control</b></td
+          >
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4">External state control</td>
+          <td class="py-2 pr-4">Limited</td>
+          <td class="py-2"
+            ><b class="text-green-700 dark:text-green-400">Full control</b></td
+          >
+        </tr>
+        <tr class="border-b border-border">
+          <td class="py-2 pr-4">Custom styling</td>
+          <td class="py-2 pr-4">Browser-dependent</td>
+          <td class="py-2"
+            ><b class="text-green-700 dark:text-green-400">Full control</b></td
+          >
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+</div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,6 +5,7 @@
 @import './patterns/dialog.css';
 @import './patterns/toolbar.css';
 @import './patterns/switch.css';
+@import './patterns/disclosure.css';
 @import 'tw-animate-css';
 
 @custom-variant dark (&:is(.dark *));

--- a/src/styles/patterns/disclosure.css
+++ b/src/styles/patterns/disclosure.css
@@ -1,0 +1,158 @@
+/* =============================================================================
+   DISCLOSURE COMPONENT STYLES
+   ============================================================================= */
+
+/* Disclosure Container */
+.apg-disclosure {
+  display: block;
+  border: 1px solid var(--border);
+  border-radius: 0.375rem;
+  background: var(--background);
+}
+
+.apg-disclosure:has(.apg-disclosure-trigger:disabled) {
+  opacity: 0.6;
+}
+
+/* Disclosure Trigger (button) */
+.apg-disclosure-trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 1rem;
+  min-height: 44px;
+  border: none;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--foreground);
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  transition: background-color 0.2s ease;
+}
+
+.apg-disclosure-trigger:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--background) 90%, var(--foreground));
+}
+
+.apg-disclosure-trigger:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+  z-index: 1;
+  position: relative;
+}
+
+.apg-disclosure-trigger:disabled {
+  cursor: not-allowed;
+  color: var(--muted-foreground);
+}
+
+/* Trigger Content */
+.apg-disclosure-trigger-content {
+  flex: 1;
+}
+
+/* Disclosure Icon */
+.apg-disclosure-icon {
+  flex-shrink: 0;
+  width: 1.25rem;
+  height: 1.25rem;
+  color: var(--muted-foreground);
+  transition: transform 0.2s ease;
+}
+
+.apg-disclosure-trigger[aria-expanded="true"] .apg-disclosure-icon {
+  transform: rotate(90deg);
+}
+
+.apg-disclosure-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+/* Disclosure Panel - Grid-based animation for height transitions */
+.apg-disclosure-panel {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.2s ease-out;
+}
+
+.apg-disclosure-panel[aria-hidden="false"] {
+  grid-template-rows: 1fr;
+}
+
+.apg-disclosure-panel>* {
+  overflow: hidden;
+}
+
+/* Inner content wrapper for padding */
+.apg-disclosure-panel-content {
+  padding: 0 1rem 0 2.75rem;
+  transition: padding 0.2s ease-out;
+}
+
+.apg-disclosure-panel[aria-hidden="false"] .apg-disclosure-panel-content {
+  padding: 1rem 1rem 1rem 2.75rem;
+}
+
+/* =============================================================================
+   ACCESSIBILITY ENHANCEMENTS
+   ============================================================================= */
+
+/* High Contrast Mode Support */
+@media (prefers-contrast: high) {
+  .apg-disclosure {
+    border-width: 4px;
+  }
+
+  .apg-disclosure-trigger[aria-expanded="true"] {
+    background: black;
+    color: white;
+  }
+
+  .apg-disclosure-trigger[aria-expanded="false"]:not(:disabled) {
+    background: white;
+    color: black;
+  }
+}
+
+/* Reduced Motion Support */
+@media (prefers-reduced-motion: reduce) {
+
+  .apg-disclosure-trigger,
+  .apg-disclosure-icon,
+  .apg-disclosure-panel,
+  .apg-disclosure-panel-content {
+    transition: none;
+  }
+}
+
+/* Windows High Contrast Mode */
+@media (forced-colors: active) {
+  .apg-disclosure {
+    border: 2px solid ButtonBorder;
+    background: ButtonFace;
+  }
+
+  .apg-disclosure-trigger {
+    background: ButtonFace;
+    color: ButtonText;
+    border-color: ButtonBorder;
+  }
+
+  .apg-disclosure-trigger[aria-expanded="true"] {
+    background: Highlight;
+    color: HighlightText;
+  }
+
+  .apg-disclosure-trigger:focus {
+    outline: 2px solid Highlight;
+  }
+
+  .apg-disclosure-panel {
+    background: ButtonFace;
+    color: ButtonText;
+  }
+}


### PR DESCRIPTION
## Summary

- Implement WAI-ARIA APG Disclosure pattern across React, Vue, Svelte, and Astro
- Add Native HTML notice promoting `<details>`/`<summary>` usage before custom implementation
- Sort patterns list alphabetically (A-Z)

## Features

- **APG-compliant ARIA**: `aria-expanded`, `aria-controls`, `aria-hidden`
- **Focus management**: `inert` attribute when collapsed
- **Animations**: CSS grid-based height transition with `prefers-reduced-motion` support
- **Accessibility modes**: High contrast and forced-colors support
- **Consistent API**: children/slot pattern across all frameworks

## Test plan

- [ ] Verify disclosure toggle works in all 4 frameworks
- [ ] Test keyboard navigation (Tab, Enter, Space)
- [ ] Test with screen reader
- [ ] Verify Native HTML notice displays correctly
- [ ] Confirm patterns are sorted A-Z on patterns page

🤖 Generated with [Claude Code](https://claude.com/claude-code)