### PR TITLE
Improve theme switcher UI clarity and visibility

### DIFF
--- a/src/components/ui/theme-toggle/theme-toggle.astro
+++ b/src/components/ui/theme-toggle/theme-toggle.astro
@@ -1,6 +1,5 @@
 ---
 import { cn } from '@/lib/utils';
-import { Button } from '@/components/ui/button';
 import { Icon } from '@/components/ui/icon';
 
 interface Props {
@@ -10,16 +9,31 @@ interface Props {
 const { class: className } = Astro.props;
 ---
 
-<Button
+<div
   data-slot="theme-toggle"
-  variant="ghost"
-  size="icon-sm"
-  aria-label="Toggle theme"
-  class={cn('relative', className)}
+  role="group"
+  aria-label="Theme"
+  class={cn('inline-flex items-center rounded-md border border-input bg-muted p-0.5', className)}
 >
-  <Icon name="sun" class="dark:hidden [&:is([data-theme=dark]_&)]:hidden" />
-  <Icon name="moon" class="hidden dark:block [&:is([data-theme=dark]_&)]:block" />
-</Button>
+  <button
+    type="button"
+    data-theme-value="light"
+    aria-selected="true"
+    class="theme-toggle-button aria-selected:bg-background aria-selected:text-foreground text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 rounded-sm px-2 py-1 text-sm font-medium transition-colors aria-selected:shadow-sm"
+  >
+    <Icon name="sun" class="size-4" />
+    <span>Light</span>
+  </button>
+  <button
+    type="button"
+    data-theme-value="dark"
+    aria-selected="false"
+    class="theme-toggle-button aria-selected:bg-background aria-selected:text-foreground text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 rounded-sm px-2 py-1 text-sm font-medium transition-colors aria-selected:shadow-sm"
+  >
+    <Icon name="moon" class="size-4" />
+    <span>Dark</span>
+  </button>
+</div>
 
 <style>
   :global(html.no-transitions *) {
@@ -30,16 +44,34 @@ const { class: className } = Astro.props;
 <script is:inline>
   if (!window.__themeHandlersInitialized) {
     window.__themeHandlersInitialized = true;
-    document.querySelectorAll("[data-slot='theme-toggle']").forEach((toggle) => {
-      toggle.addEventListener('click', () => {
-        const element = document.documentElement;
-        element.classList.add('no-transitions');
-        element.classList.toggle('dark');
 
-        const isDark = element.classList.contains('dark');
-        const newTheme = isDark ? 'dark' : 'light';
+    function updateThemeButtons(theme) {
+      document.querySelectorAll('.theme-toggle-button').forEach((btn) => {
+        const isSelected = btn.getAttribute('data-theme-value') === theme;
+        btn.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+      });
+    }
+
+    // Initialize button states based on current theme
+    const currentTheme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+    updateThemeButtons(currentTheme);
+
+    document.querySelectorAll('.theme-toggle-button').forEach((button) => {
+      button.addEventListener('click', () => {
+        const newTheme = button.getAttribute('data-theme-value');
+        const element = document.documentElement;
+
+        element.classList.add('no-transitions');
+
+        if (newTheme === 'dark') {
+          element.classList.add('dark');
+        } else {
+          element.classList.remove('dark');
+        }
+
         localStorage.setItem('theme', newTheme);
         element.setAttribute('data-theme', newTheme);
+        updateThemeButtons(newTheme);
 
         requestAnimationFrame(() => {
           element.classList.remove('no-transitions');


### PR DESCRIPTION
Replace icon-only toggle with segmented control showing Light/Dark options.
- Use aria-selected to indicate current theme selection
- Both options visible for clear affordance
- Click to switch (no automatic switch on focus)

# Pull Request

## 概要

<!-- このPRで実装・修正する内容を簡潔に説明してください -->

## 変更内容

<!-- 具体的な変更点をリストアップしてください -->

- [ ] 新機能追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] テスト追加/修正

## APGパターン準拠チェック

<!-- アクセシビリティ関連の変更がある場合はチェックしてください -->

- [ ] ARIA属性の適切な使用
- [ ] キーボードナビゲーション対応
- [ ] スクリーンリーダー対応
- [ ] フォーカス管理の実装
- [ ] 色・コントラストの考慮

## テスト

<!-- テスト方法や確認項目を記載してください -->

- [ ] 手動テスト完了
- [ ] 自動テスト追加/更新
- [ ] アクセシビリティテスト実施
- [ ] 複数ブラウザでの動作確認

## 破壊的変更

- [ ] 破壊的変更あり（詳細を下記に記載）
- [ ] 破壊的変更なし

## その他

<!-- レビュー時の注意点や補足情報があれば記載してください -->

## 関連Issue/TODO

<!-- 関連するIssueやTODOがあれば記載してください -->

- Closes #
- Related to #
