### PR TITLE
Add GitHub link to header with icon

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,8 @@
 ---
 import '../styles/global.css';
+import { Button } from '@/components/ui/button';
 import { Header, HeaderActions } from '@/components/ui/header';
+import { Icon } from '@/components/ui/icon';
 import { Logo, LogoText } from '@/components/ui/logo';
 import {
   NavigationMenu,
@@ -10,6 +12,8 @@ import {
 } from '@/components/ui/navigation-menu';
 import { NativeSelect, NativeSelectOption } from '@/components/ui/native-select';
 import { ThemeToggle, ThemeProvider } from '@/components/ui/theme-toggle';
+
+const GITHUB_URL = 'https://github.com/masuP9/apg-patterns-examples';
 import {
   Footer,
   FooterDescription,
@@ -81,6 +85,15 @@ const navLinks = [
           <NativeSelectOption value="svelte">Svelte</NativeSelectOption>
           <NativeSelectOption value="astro">Astro</NativeSelectOption>
         </NativeSelect>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          href={GITHUB_URL}
+          target="_blank"
+          aria-label="GitHub"
+        >
+          <Icon href={GITHUB_URL} />
+        </Button>
         <ThemeToggle />
       </HeaderActions>
       <Sheet class="first:ml-auto">
@@ -112,6 +125,17 @@ const navLinks = [
               <NativeSelectOption value="svelte">Svelte</NativeSelectOption>
               <NativeSelectOption value="astro">Astro</NativeSelectOption>
             </NativeSelect>
+          </HeaderActions>
+          <HeaderActions>
+            <Button
+              variant="ghost"
+              size="icon"
+              href={GITHUB_URL}
+              target="_blank"
+              aria-label="GitHub"
+            >
+              <Icon href={GITHUB_URL} />
+            </Button>
             <ThemeToggle />
           </HeaderActions>
         </SheetContent>


### PR DESCRIPTION
Add a GitHub icon button in the header that links to the repository. The link is displayed in both desktop and mobile views.

# Pull Request

## 概要

<!-- このPRで実装・修正する内容を簡潔に説明してください -->

## 変更内容

<!-- 具体的な変更点をリストアップしてください -->

- [ ] 新機能追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] テスト追加/修正

## APGパターン準拠チェック

<!-- アクセシビリティ関連の変更がある場合はチェックしてください -->

- [ ] ARIA属性の適切な使用
- [ ] キーボードナビゲーション対応
- [ ] スクリーンリーダー対応
- [ ] フォーカス管理の実装
- [ ] 色・コントラストの考慮

## テスト

<!-- テスト方法や確認項目を記載してください -->

- [ ] 手動テスト完了
- [ ] 自動テスト追加/更新
- [ ] アクセシビリティテスト実施
- [ ] 複数ブラウザでの動作確認

## 破壊的変更

- [ ] 破壊的変更あり（詳細を下記に記載）
- [ ] 破壊的変更なし

## その他

<!-- レビュー時の注意点や補足情報があれば記載してください -->

## 関連Issue/TODO

<!-- 関連するIssueやTODOがあれば記載してください -->

- Closes #
- Related to #
