### PR TITLE
Fix mobile menu theme toggle and layout

### DIFF
--- a/src/components/blocks/header-1.astro
+++ b/src/components/blocks/header-1.astro
@@ -122,62 +122,74 @@ const { logo, menus, links, socials } = Astro.props;
       <MenuIcon class="size-5" />
     </SheetTrigger>
     <SheetContent class="overflow-y-auto px-4 py-12">
-      <SidebarMenu>
-        {
-          menus?.map((menu) => (
-            <SidebarMenuItem>
-              {menu.links && menu.links.length > 0 ? (
-                <Collapsible>
-                  <CollapsibleTrigger>
-                    <SidebarMenuButton class="h-10 rounded-md px-4 text-xl">
-                      {menu.text}
-                    </SidebarMenuButton>
-                  </CollapsibleTrigger>
-                  <CollapsibleContent>
-                    <SidebarMenuSub>
-                      {menu.links?.map((link) => (
-                        <SidebarMenuSubItem>
-                          <SidebarMenuSubButton href={link.href}>{link.text}</SidebarMenuSubButton>
-                        </SidebarMenuSubItem>
-                      ))}
-                    </SidebarMenuSub>
-                  </CollapsibleContent>
-                </Collapsible>
-              ) : (
-                <SidebarMenuButton
-                  class="h-10 w-full rounded-md px-4 text-xl has-[>svg]:px-4"
-                  href={menu.href}
-                >
-                  {menu.text}
-                </SidebarMenuButton>
-              )}
-            </SidebarMenuItem>
-          ))
-        }
-      </SidebarMenu>
-      <HeaderActions class="flex flex-col gap-2">
-        {
-          links?.map(({ icon, text, ...link }, i) => (
-            <Button
-              variant={i === links.length - 1 ? 'default' : 'secondary'}
-              class="w-full"
-              {...link}
-            >
-              {icon && <Icon name={icon} />}
-              {text}
-            </Button>
-          ))
-        }
-      </HeaderActions>
-      <HeaderActions>
-        {
-          socials?.map((social) => (
-            <Button variant="ghost" size="icon" href={social}>
-              <Icon href={social} />
-            </Button>
-          ))
-        }
-      </HeaderActions>
+      <div class="flex flex-1 flex-col">
+        <SidebarMenu>
+          {
+            menus?.map((menu) => (
+              <SidebarMenuItem>
+                {menu.links && menu.links.length > 0 ? (
+                  <Collapsible>
+                    <CollapsibleTrigger>
+                      <SidebarMenuButton class="h-10 rounded-md px-4 text-xl">
+                        {menu.text}
+                      </SidebarMenuButton>
+                    </CollapsibleTrigger>
+                    <CollapsibleContent>
+                      <SidebarMenuSub>
+                        {menu.links?.map((link) => (
+                          <SidebarMenuSubItem>
+                            <SidebarMenuSubButton href={link.href}>
+                              {link.text}
+                            </SidebarMenuSubButton>
+                          </SidebarMenuSubItem>
+                        ))}
+                      </SidebarMenuSub>
+                    </CollapsibleContent>
+                  </Collapsible>
+                ) : (
+                  <SidebarMenuButton
+                    class="h-10 w-full rounded-md px-4 text-xl has-[>svg]:px-4"
+                    href={menu.href}
+                  >
+                    {menu.text}
+                  </SidebarMenuButton>
+                )}
+              </SidebarMenuItem>
+            ))
+          }
+        </SidebarMenu>
+        <HeaderActions class="flex flex-col gap-2">
+          {
+            links?.map(({ icon, text, ...link }, i) => (
+              <Button
+                variant={i === links.length - 1 ? 'default' : 'secondary'}
+                class="w-full"
+                {...link}
+              >
+                {icon && <Icon name={icon} />}
+                {text}
+              </Button>
+            ))
+          }
+        </HeaderActions>
+        <div class="border-border mt-auto border-t pt-4">
+          <div class="mb-3 flex items-center justify-between px-1">
+            <span class="text-muted-foreground text-sm font-medium">Theme</span>
+            <ThemeToggle />
+          </div>
+          {
+            socials && socials.length > 0 && (
+              <div class="flex items-center gap-2 px-1">
+                {socials.map((social) => (
+                  <Button variant="ghost" size="icon" href={social} target="_blank">
+                    <Icon href={social} />
+                  </Button>
+                ))}
+              </div>
+            )
+          }
+        </div>
+      </div>
     </SheetContent>
   </Sheet>
 </Header>

--- a/src/components/ui/theme-toggle/theme-toggle.astro
+++ b/src/components/ui/theme-toggle/theme-toggle.astro
@@ -61,27 +61,36 @@ const { class: className } = Astro.props;
     const currentTheme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
     updateThemeButtons(currentTheme);
 
-    document.querySelectorAll('.theme-toggle-button').forEach((button) => {
-      button.addEventListener('click', () => {
-        const newTheme = button.getAttribute('data-theme-value');
-        const element = document.documentElement;
+    // Use event delegation for dynamically added buttons (e.g., in mobile menu)
+    document.addEventListener('click', (e) => {
+      const button = e.target.closest('.theme-toggle-button');
+      if (!button) return;
 
-        element.classList.add('no-transitions');
+      const newTheme = button.getAttribute('data-theme-value');
+      const element = document.documentElement;
 
-        if (newTheme === 'dark') {
-          element.classList.add('dark');
-        } else {
-          element.classList.remove('dark');
-        }
+      element.classList.add('no-transitions');
 
-        localStorage.setItem('theme', newTheme);
-        element.setAttribute('data-theme', newTheme);
-        updateThemeButtons(newTheme);
+      if (newTheme === 'dark') {
+        element.classList.add('dark');
+      } else {
+        element.classList.remove('dark');
+      }
 
-        requestAnimationFrame(() => {
-          element.classList.remove('no-transitions');
-        });
+      localStorage.setItem('theme', newTheme);
+      element.setAttribute('data-theme', newTheme);
+      updateThemeButtons(newTheme);
+
+      requestAnimationFrame(() => {
+        element.classList.remove('no-transitions');
       });
     });
+
+    // Update button states when sheet opens (MutationObserver for dynamic content)
+    const observer = new MutationObserver(() => {
+      const currentTheme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+      updateThemeButtons(currentTheme);
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
   }
 </script>


### PR DESCRIPTION
- Add ThemeToggle to mobile menu (Sheet)
- Use event delegation for theme toggle buttons to support dynamically added elements
- Add MutationObserver to update button states when mobile menu opens
- Reorganize mobile menu footer: theme toggle and social links now in separate section with border separator

# Pull Request

## 概要

<!-- このPRで実装・修正する内容を簡潔に説明してください -->

## 変更内容

<!-- 具体的な変更点をリストアップしてください -->

- [ ] 新機能追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] テスト追加/修正

## APGパターン準拠チェック

<!-- アクセシビリティ関連の変更がある場合はチェックしてください -->

- [ ] ARIA属性の適切な使用
- [ ] キーボードナビゲーション対応
- [ ] スクリーンリーダー対応
- [ ] フォーカス管理の実装
- [ ] 色・コントラストの考慮

## テスト

<!-- テスト方法や確認項目を記載してください -->

- [ ] 手動テスト完了
- [ ] 自動テスト追加/更新
- [ ] アクセシビリティテスト実施
- [ ] 複数ブラウザでの動作確認

## 破壊的変更

- [ ] 破壊的変更あり（詳細を下記に記載）
- [ ] 破壊的変更なし

## その他

<!-- レビュー時の注意点や補足情報があれば記載してください -->

## 関連Issue/TODO

<!-- 関連するIssueやTODOがあれば記載してください -->

- Closes #
- Related to #
