### PR TITLE
Fix Breadcrumb links on Available pattern

### DIFF
--- a/src/pages/patterns/breadcrumb/index.astro
+++ b/src/pages/patterns/breadcrumb/index.astro
@@ -1,4 +1,0 @@
----
-// Redirect to React implementation by default
-return Astro.redirect('/patterns/breadcrumb/react/');
----

--- a/src/pages/patterns/checkbox/index.astro
+++ b/src/pages/patterns/checkbox/index.astro
@@ -1,4 +1,0 @@
----
-// Redirect to the React implementation by default
-return Astro.redirect('/patterns/checkbox/react/');
----

--- a/src/pages/patterns/disclosure/index.astro
+++ b/src/pages/patterns/disclosure/index.astro
@@ -1,4 +1,0 @@
----
-// Redirect to React implementation by default
-return Astro.redirect('/patterns/disclosure/react/');
----

--- a/src/pages/patterns/listbox/index.astro
+++ b/src/pages/patterns/listbox/index.astro
@@ -1,4 +1,0 @@
----
-// Redirect to React implementation by default
-return Astro.redirect('/patterns/listbox/react/');
----

--- a/src/pages/patterns/menu-button/index.astro
+++ b/src/pages/patterns/menu-button/index.astro
@@ -1,4 +1,0 @@
----
-// Redirect to React implementation by default
-return Astro.redirect('/patterns/menu-button/react/');
----


### PR DESCRIPTION
Remove individual pattern index.astro files that were using Astro.redirect without withBase, causing broken links on GitHub Pages. The dynamic [pattern]/index.astro already handles all patterns correctly with proper base path support.

Affected patterns: breadcrumb, checkbox, disclosure, listbox, menu-button

# Pull Request

## 概要

<!-- このPRで実装・修正する内容を簡潔に説明してください -->

## 変更内容

<!-- 具体的な変更点をリストアップしてください -->

- [ ] 新機能追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] テスト追加/修正

## APGパターン準拠チェック

<!-- アクセシビリティ関連の変更がある場合はチェックしてください -->

- [ ] ARIA属性の適切な使用
- [ ] キーボードナビゲーション対応
- [ ] スクリーンリーダー対応
- [ ] フォーカス管理の実装
- [ ] 色・コントラストの考慮

## テスト

<!-- テスト方法や確認項目を記載してください -->

- [ ] 手動テスト完了
- [ ] 自動テスト追加/更新
- [ ] アクセシビリティテスト実施
- [ ] 複数ブラウザでの動作確認

## 破壊的変更

- [ ] 破壊的変更あり（詳細を下記に記載）
- [ ] 破壊的変更なし

## その他

<!-- レビュー時の注意点や補足情報があれば記載してください -->

## 関連Issue/TODO

<!-- 関連するIssueやTODOがあれば記載してください -->

- Closes #
- Related to #
