### PR TITLE
Fix theme toggle button visibility in forced color mode

### DIFF
--- a/src/components/ui/theme-toggle/theme-toggle.astro
+++ b/src/components/ui/theme-toggle/theme-toggle.astro
@@ -44,6 +44,14 @@ const { class: className } = Astro.props;
   .theme-toggle-button[aria-selected='true'] :global(svg) {
     color: oklch(0.8 0.18 90);
   }
+
+  /* Forced colors mode support - use outline for selected state visibility */
+  @media (forced-colors: active) {
+    .theme-toggle-button[aria-selected='true'] {
+      outline: 2px solid SelectedItem;
+      outline-offset: -2px;
+    }
+  }
 </style>
 
 <script is:inline>


### PR DESCRIPTION
Add outline indicator for selected state in forced-colors mode (Windows High Contrast) so users can distinguish which theme is active.

# Pull Request

## 概要

<!-- このPRで実装・修正する内容を簡潔に説明してください -->

## 変更内容

<!-- 具体的な変更点をリストアップしてください -->

- [ ] 新機能追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] テスト追加/修正

## APGパターン準拠チェック

<!-- アクセシビリティ関連の変更がある場合はチェックしてください -->

- [ ] ARIA属性の適切な使用
- [ ] キーボードナビゲーション対応
- [ ] スクリーンリーダー対応
- [ ] フォーカス管理の実装
- [ ] 色・コントラストの考慮

## テスト

<!-- テスト方法や確認項目を記載してください -->

- [ ] 手動テスト完了
- [ ] 自動テスト追加/更新
- [ ] アクセシビリティテスト実施
- [ ] 複数ブラウザでの動作確認

## 破壊的変更

- [ ] 破壊的変更あり（詳細を下記に記載）
- [ ] 破壊的変更なし

## その他

<!-- レビュー時の注意点や補足情報があれば記載してください -->

## 関連Issue/TODO

<!-- 関連するIssueやTODOがあれば記載してください -->

- Closes #
- Related to #
