### PR TITLE
feat: implement Spinbutton pattern for React, Vue, Svelte, and Astro

### DIFF
--- a/.internal/pattern-planning-prompt.md
+++ b/.internal/pattern-planning-prompt.md
@@ -7,7 +7,8 @@
 1. `{変数}` を実際の値に置き換える
 2. プロンプト本文を Claude Code にコピー＆ペースト
 3. 計画を確認し、必要に応じて調整を依頼
-4. 承認後、TDD ワークフローに沿って実装を進める
+4. **Codex に計画書のレビューを依頼**（「Codex レビュー依頼テンプレート > 計画書レビュー依頼」を使用）
+5. レビュー結果を反映し、承認後 TDD ワークフローに沿って実装を進める
 
 ---
 
@@ -400,9 +401,10 @@ export interface {ComponentName}Props extends Omit<
    - 各フレームワーク用のページを作成
    - index.astro でのリダイレクト設定
 
-2. **patterns.ts** / **README.md** / **README.ja.md**
+2. **patterns.ts** / **README.md** / **README.ja.md** / **llm.md**
    - 実装したコンポーネントの status を available に
    - README.md / README.ja.md のコンポーネント実装状況を更新
+   - 計画と実装で乖離した点を整理して、llm.mdに反映
 
 3. **最終確認**
    ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,6 +327,30 @@ const items = [
 ];
 ```
 
+**三項演算子のネスト禁止**:
+
+三項演算子のネストは可読性が低下するため、if 文や早期リターンを使用すること。
+
+```typescript
+// ❌ ネストした三項演算子（読みにくい）
+const value = a ? a : b ? c : undefined;
+
+// ✅ 早期リターンを使った関数（読みやすい）
+const getValue = () => {
+  if (a) return a;
+  if (b) return c;
+  return undefined;
+};
+const value = getValue();
+
+// ✅ Vue computed / Svelte $derived.by でも同様
+const value = computed(() => {
+  if (a) return a;
+  if (b) return c;
+  return undefined;
+});
+```
+
 ---
 
 ## 参考リンク

--- a/src/lib/patterns.ts
+++ b/src/lib/patterns.ts
@@ -206,7 +206,7 @@ export const PATTERNS: Pattern[] = [
       'An input widget for selecting from a range of discrete values, typically with increment/decrement buttons.',
     icon: '🔢',
     complexity: 'Medium',
-    status: 'planned',
+    status: 'available',
   },
   {
     id: 'switch',

--- a/src/pages/patterns/spinbutton/astro/index.astro
+++ b/src/pages/patterns/spinbutton/astro/index.astro
@@ -1,0 +1,307 @@
+---
+import PatternLayout from '../../../../layouts/PatternLayout.astro';
+import Spinbutton from '@patterns/spinbutton/Spinbutton.astro';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
+import AccessibilityDocs from '@patterns/spinbutton/AccessibilityDocs.astro';
+import TestingDocs from '@patterns/spinbutton/TestingDocs.astro';
+import NativeHtmlNotice from '@patterns/spinbutton/NativeHtmlNotice.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/spinbutton/Spinbutton.astro?raw';
+import testCode from '@patterns/spinbutton/Spinbutton.test.astro.ts?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'native-html', text: 'Native HTML' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
+---
+
+<PatternLayout
+  title="Spinbutton - Astro"
+  pattern="spinbutton"
+  framework="astro"
+  tocItems={tocItems}
+>
+  <header class="mb-8">
+    <h1 class="mb-4 text-3xl font-bold">Spinbutton</h1>
+    <p class="text-muted-foreground text-lg">
+      An input widget that allows users to select a value from a discrete set or range by using
+      increment/decrement buttons, arrow keys, or typing directly.
+    </p>
+    <AiGuideBadge pattern="spinbutton" />
+  </header>
+
+  <!-- Framework Selector -->
+  <FrameworkTabs pattern="spinbutton" currentFramework="astro" />
+
+  <!-- Demo Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Demo</Heading>
+    <div class="border-border bg-background rounded-lg border p-6">
+      <div class="flex flex-col gap-6">
+        <div>
+          <Spinbutton defaultValue={5} min={0} max={100} label="Quantity" />
+        </div>
+        <div>
+          <Spinbutton defaultValue={3} min={1} max={10} label="Rating" format="{value} of {max}" />
+        </div>
+        <div>
+          <Spinbutton defaultValue={0.5} min={0} max={1} step={0.1} label="Opacity" />
+        </div>
+        <div>
+          <Spinbutton defaultValue={0} label="Unbounded" showButtons={true} />
+        </div>
+        <div>
+          <Spinbutton defaultValue={50} min={0} max={100} label="Read-only" readOnly />
+        </div>
+        <div>
+          <Spinbutton defaultValue={50} min={0} max={100} label="Disabled" disabled />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Native HTML Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Native HTML</Heading>
+    <NativeHtmlNotice />
+  </section>
+
+  <!-- Accessibility Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Accessibility Features</Heading>
+    <AccessibilityDocs />
+  </section>
+
+  <!-- Source Code Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Source Code</Heading>
+    <CodeBlock
+      collapsible
+      collapsedLines={5}
+      code={sourceCode}
+      lang="astro"
+      title="Spinbutton.astro"
+    />
+  </section>
+
+  <!-- Usage Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Usage</Heading>
+    <CodeBlock
+      collapsible
+      collapsedLines={5}
+      code={`---
+import Spinbutton from './Spinbutton.astro';
+---
+
+<!-- Basic usage with aria-label -->
+<Spinbutton aria-label="Quantity" />
+
+<!-- With visible label and min/max -->
+<Spinbutton
+  defaultValue={5}
+  min={0}
+  max={100}
+  label="Quantity"
+/>
+
+<!-- With format for display and aria-valuetext -->
+<Spinbutton
+  defaultValue={3}
+  min={1}
+  max={10}
+  label="Rating"
+  format="{value} of {max}"
+/>
+
+<!-- Decimal step values -->
+<Spinbutton
+  defaultValue={0.5}
+  min={0}
+  max={1}
+  step={0.1}
+  label="Opacity"
+/>
+
+<!-- Unbounded (no min/max limits) -->
+<Spinbutton
+  defaultValue={0}
+  label="Counter"
+/>
+
+<!-- Listen to value changes (Web Component event) -->
+<Spinbutton id="my-spinbutton" defaultValue={5} label="Value" />
+
+<script>
+  const spinbutton = document.querySelector('#my-spinbutton');
+  spinbutton?.addEventListener('valuechange', (e) => {
+    console.log('Value:', e.detail.value);
+  });
+</script>`}
+      lang="astro"
+      title="Example"
+    />
+  </section>
+
+  <!-- API Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">API</Heading>
+    <ResponsiveTable>
+      <table class="w-full border-collapse">
+        <thead>
+          <tr class="border-border border-b">
+            <th class="py-2 pr-4 text-left">Prop</th>
+            <th class="py-2 pr-4 text-left">Type</th>
+            <th class="py-2 pr-4 text-left">Default</th>
+            <th class="py-2 text-left">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>defaultValue</code></td>
+            <td class="text-muted-foreground py-2 pr-4">number</td>
+            <td class="text-muted-foreground py-2 pr-4">0</td>
+            <td class="py-2">Initial value of the spinbutton</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>min</code></td>
+            <td class="text-muted-foreground py-2 pr-4">number</td>
+            <td class="text-muted-foreground py-2 pr-4">undefined</td>
+            <td class="py-2">Minimum value (undefined = no limit)</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>max</code></td>
+            <td class="text-muted-foreground py-2 pr-4">number</td>
+            <td class="text-muted-foreground py-2 pr-4">undefined</td>
+            <td class="py-2">Maximum value (undefined = no limit)</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>step</code></td>
+            <td class="text-muted-foreground py-2 pr-4">number</td>
+            <td class="text-muted-foreground py-2 pr-4">1</td>
+            <td class="py-2">Step increment for keyboard/button</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>largeStep</code></td>
+            <td class="text-muted-foreground py-2 pr-4">number</td>
+            <td class="text-muted-foreground py-2 pr-4">step * 10</td>
+            <td class="py-2">Large step for PageUp/PageDown</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>disabled</code></td>
+            <td class="text-muted-foreground py-2 pr-4">boolean</td>
+            <td class="text-muted-foreground py-2 pr-4">false</td>
+            <td class="py-2">Whether the spinbutton is disabled</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>readOnly</code></td>
+            <td class="text-muted-foreground py-2 pr-4">boolean</td>
+            <td class="text-muted-foreground py-2 pr-4">false</td>
+            <td class="py-2">Whether the spinbutton is read-only</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>showButtons</code></td>
+            <td class="text-muted-foreground py-2 pr-4">boolean</td>
+            <td class="text-muted-foreground py-2 pr-4">true</td>
+            <td class="py-2">Whether to show increment/decrement buttons</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>label</code></td>
+            <td class="text-muted-foreground py-2 pr-4">string</td>
+            <td class="text-muted-foreground py-2 pr-4">-</td>
+            <td class="py-2">Visible label (also used as aria-labelledby)</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>valueText</code></td>
+            <td class="text-muted-foreground py-2 pr-4">string</td>
+            <td class="text-muted-foreground py-2 pr-4">-</td>
+            <td class="py-2">Human-readable value for aria-valuetext</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>format</code></td>
+            <td class="text-muted-foreground py-2 pr-4">string</td>
+            <td class="text-muted-foreground py-2 pr-4">-</td>
+            <td class="py-2"
+              >Format pattern for aria-valuetext (e.g., "{'{value}'} of {'{max}'}")</td
+            >
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+
+    <h3 class="mt-6 mb-3 text-lg font-medium">Web Component Events</h3>
+    <ResponsiveTable>
+      <table class="w-full border-collapse">
+        <thead>
+          <tr class="border-border border-b">
+            <th class="py-2 pr-4 text-left">Event</th>
+            <th class="py-2 pr-4 text-left">Detail</th>
+            <th class="py-2 text-left">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>valuechange</code></td>
+            <td class="text-muted-foreground py-2 pr-4">{'{value: number}'}</td>
+            <td class="py-2">Dispatched when value changes</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+    <p class="text-muted-foreground mt-4 text-sm">
+      One of <code>label</code>, <code>aria-label</code>, or <code>aria-labelledby</code> is required
+      for accessibility. This component uses Web Components for client-side interactivity without requiring
+      hydration.
+    </p>
+  </section>
+
+  <!-- Testing Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Testing</Heading>
+    <TestingDocs />
+    <div class="mt-6">
+      <CodeBlock
+        collapsible
+        collapsedLines={5}
+        code={testCode}
+        lang="typescript"
+        title="Spinbutton.test.astro.ts"
+      />
+    </div>
+  </section>
+
+  <!-- Resources -->
+  <section>
+    <Heading level={2} class="mb-4 text-xl font-semibold">Resources</Heading>
+    <ul class="list-disc space-y-2 pl-6">
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/spinbutton/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Spinbutton Pattern
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number"
+          class="text-primary hover:underline"
+        >
+          MDN: &lt;input type="number"&gt; element
+        </ExternalLink>
+      </li>
+      <AiGuideResourceItem pattern="spinbutton" />
+    </ul>
+  </section>
+</PatternLayout>

--- a/src/pages/patterns/spinbutton/react/index.astro
+++ b/src/pages/patterns/spinbutton/react/index.astro
@@ -1,0 +1,296 @@
+---
+import PatternLayout from '../../../../layouts/PatternLayout.astro';
+import { Spinbutton } from '@patterns/spinbutton/Spinbutton';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
+import AccessibilityDocs from '@patterns/spinbutton/AccessibilityDocs.astro';
+import TestingDocs from '@patterns/spinbutton/TestingDocs.astro';
+import NativeHtmlNotice from '@patterns/spinbutton/NativeHtmlNotice.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/spinbutton/Spinbutton.tsx?raw';
+import testCode from '@patterns/spinbutton/Spinbutton.test.tsx?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'native-html', text: 'Native HTML' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
+---
+
+<PatternLayout
+  title="Spinbutton - React"
+  pattern="spinbutton"
+  framework="react"
+  tocItems={tocItems}
+>
+  <header class="mb-8">
+    <h1 class="mb-4 text-3xl font-bold">Spinbutton</h1>
+    <p class="text-muted-foreground text-lg">
+      An input widget that allows users to select a value from a discrete set or range by using
+      increment/decrement buttons, arrow keys, or typing directly.
+    </p>
+    <AiGuideBadge pattern="spinbutton" />
+  </header>
+
+  <!-- Framework Selector -->
+  <FrameworkTabs pattern="spinbutton" currentFramework="react" />
+
+  <!-- Demo Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Demo</Heading>
+    <div class="border-border bg-background rounded-lg border p-6">
+      <div class="flex flex-col gap-6">
+        <div>
+          <Spinbutton client:load defaultValue={5} min={0} max={100} label="Quantity" />
+        </div>
+        <div>
+          <Spinbutton
+            client:load
+            defaultValue={3}
+            min={1}
+            max={10}
+            label="Rating"
+            format="{value} of {max}"
+          />
+        </div>
+        <div>
+          <Spinbutton client:load defaultValue={0.5} min={0} max={1} step={0.1} label="Opacity" />
+        </div>
+        <div>
+          <Spinbutton client:load defaultValue={0} label="Unbounded" showButtons={true} />
+        </div>
+        <div>
+          <Spinbutton client:load defaultValue={50} min={0} max={100} label="Read-only" readOnly />
+        </div>
+        <div>
+          <Spinbutton client:load defaultValue={50} min={0} max={100} label="Disabled" disabled />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Native HTML Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Native HTML</Heading>
+    <NativeHtmlNotice />
+  </section>
+
+  <!-- Accessibility Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Accessibility Features</Heading>
+    <AccessibilityDocs />
+  </section>
+
+  <!-- Source Code Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Source Code</Heading>
+    <CodeBlock collapsible collapsedLines={5} code={sourceCode} lang="tsx" title="Spinbutton.tsx" />
+  </section>
+
+  <!-- Usage Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Usage</Heading>
+    <CodeBlock
+      collapsible
+      collapsedLines={5}
+      code={`import { Spinbutton } from './Spinbutton';
+
+function App() {
+  return (
+    <div>
+      {/* Basic usage with aria-label */}
+      <Spinbutton aria-label="Quantity" />
+
+      {/* With visible label and min/max */}
+      <Spinbutton
+        defaultValue={5}
+        min={0}
+        max={100}
+        label="Quantity"
+      />
+
+      {/* With format for display and aria-valuetext */}
+      <Spinbutton
+        defaultValue={3}
+        min={1}
+        max={10}
+        label="Rating"
+        format="{value} of {max}"
+      />
+
+      {/* Decimal step values */}
+      <Spinbutton
+        defaultValue={0.5}
+        min={0}
+        max={1}
+        step={0.1}
+        label="Opacity"
+      />
+
+      {/* Unbounded (no min/max limits) */}
+      <Spinbutton
+        defaultValue={0}
+        label="Counter"
+      />
+
+      {/* With callback */}
+      <Spinbutton
+        defaultValue={5}
+        min={0}
+        max={100}
+        label="Value"
+        onValueChange={(value) => console.log(value)}
+      />
+    </div>
+  );
+}`}
+      lang="tsx"
+      title="Example"
+    />
+  </section>
+
+  <!-- API Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">API</Heading>
+    <ResponsiveTable>
+      <table class="w-full border-collapse">
+        <thead>
+          <tr class="border-border border-b">
+            <th class="py-2 pr-4 text-left">Prop</th>
+            <th class="py-2 pr-4 text-left">Type</th>
+            <th class="py-2 pr-4 text-left">Default</th>
+            <th class="py-2 text-left">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>defaultValue</code></td>
+            <td class="text-muted-foreground py-2 pr-4">number</td>
+            <td class="text-muted-foreground py-2 pr-4">0</td>
+            <td class="py-2">Initial value of the spinbutton</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>min</code></td>
+            <td class="text-muted-foreground py-2 pr-4">number</td>
+            <td class="text-muted-foreground py-2 pr-4">undefined</td>
+            <td class="py-2">Minimum value (undefined = no limit)</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>max</code></td>
+            <td class="text-muted-foreground py-2 pr-4">number</td>
+            <td class="text-muted-foreground py-2 pr-4">undefined</td>
+            <td class="py-2">Maximum value (undefined = no limit)</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>step</code></td>
+            <td class="text-muted-foreground py-2 pr-4">number</td>
+            <td class="text-muted-foreground py-2 pr-4">1</td>
+            <td class="py-2">Step increment for keyboard/button</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>largeStep</code></td>
+            <td class="text-muted-foreground py-2 pr-4">number</td>
+            <td class="text-muted-foreground py-2 pr-4">step * 10</td>
+            <td class="py-2">Large step for PageUp/PageDown</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>disabled</code></td>
+            <td class="text-muted-foreground py-2 pr-4">boolean</td>
+            <td class="text-muted-foreground py-2 pr-4">false</td>
+            <td class="py-2">Whether the spinbutton is disabled</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>readOnly</code></td>
+            <td class="text-muted-foreground py-2 pr-4">boolean</td>
+            <td class="text-muted-foreground py-2 pr-4">false</td>
+            <td class="py-2">Whether the spinbutton is read-only</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>showButtons</code></td>
+            <td class="text-muted-foreground py-2 pr-4">boolean</td>
+            <td class="text-muted-foreground py-2 pr-4">true</td>
+            <td class="py-2">Whether to show increment/decrement buttons</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>label</code></td>
+            <td class="text-muted-foreground py-2 pr-4">string</td>
+            <td class="text-muted-foreground py-2 pr-4">-</td>
+            <td class="py-2">Visible label (also used as aria-labelledby)</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>valueText</code></td>
+            <td class="text-muted-foreground py-2 pr-4">string</td>
+            <td class="text-muted-foreground py-2 pr-4">-</td>
+            <td class="py-2">Human-readable value for aria-valuetext</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>format</code></td>
+            <td class="text-muted-foreground py-2 pr-4">string</td>
+            <td class="text-muted-foreground py-2 pr-4">-</td>
+            <td class="py-2"
+              >Format pattern for aria-valuetext (e.g., "{'{value}'} of {'{max}'}")</td
+            >
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>onValueChange</code></td>
+            <td class="text-muted-foreground py-2 pr-4">(value: number) =&gt; void</td>
+            <td class="text-muted-foreground py-2 pr-4">-</td>
+            <td class="py-2">Callback when value changes</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+    <p class="text-muted-foreground mt-4 text-sm">
+      One of <code>label</code>, <code>aria-label</code>, or <code>aria-labelledby</code> is required
+      for accessibility.
+    </p>
+  </section>
+
+  <!-- Testing Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Testing</Heading>
+    <TestingDocs />
+    <div class="mt-6">
+      <CodeBlock
+        collapsible
+        collapsedLines={5}
+        code={testCode}
+        lang="tsx"
+        title="Spinbutton.test.tsx"
+      />
+    </div>
+  </section>
+
+  <!-- Resources -->
+  <section>
+    <Heading level={2} class="mb-4 text-xl font-semibold">Resources</Heading>
+    <ul class="list-disc space-y-2 pl-6">
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/spinbutton/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Spinbutton Pattern
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number"
+          class="text-primary hover:underline"
+        >
+          MDN: &lt;input type="number"&gt; element
+        </ExternalLink>
+      </li>
+      <AiGuideResourceItem pattern="spinbutton" />
+    </ul>
+  </section>
+</PatternLayout>

--- a/src/pages/patterns/spinbutton/svelte/index.astro
+++ b/src/pages/patterns/spinbutton/svelte/index.astro
@@ -1,0 +1,302 @@
+---
+import PatternLayout from '../../../../layouts/PatternLayout.astro';
+import Spinbutton from '@patterns/spinbutton/Spinbutton.svelte';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
+import AccessibilityDocs from '@patterns/spinbutton/AccessibilityDocs.astro';
+import TestingDocs from '@patterns/spinbutton/TestingDocs.astro';
+import NativeHtmlNotice from '@patterns/spinbutton/NativeHtmlNotice.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/spinbutton/Spinbutton.svelte?raw';
+import testCode from '@patterns/spinbutton/Spinbutton.test.svelte.ts?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'native-html', text: 'Native HTML' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
+---
+
+<PatternLayout
+  title="Spinbutton - Svelte"
+  pattern="spinbutton"
+  framework="svelte"
+  tocItems={tocItems}
+>
+  <header class="mb-8">
+    <h1 class="mb-4 text-3xl font-bold">Spinbutton</h1>
+    <p class="text-muted-foreground text-lg">
+      An input widget that allows users to select a value from a discrete set or range by using
+      increment/decrement buttons, arrow keys, or typing directly.
+    </p>
+    <AiGuideBadge pattern="spinbutton" />
+  </header>
+
+  <!-- Framework Selector -->
+  <FrameworkTabs pattern="spinbutton" currentFramework="svelte" />
+
+  <!-- Demo Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Demo</Heading>
+    <div class="border-border bg-background rounded-lg border p-6">
+      <div class="flex flex-col gap-6">
+        <div>
+          <Spinbutton client:load defaultValue={5} min={0} max={100} label="Quantity" />
+        </div>
+        <div>
+          <Spinbutton
+            client:load
+            defaultValue={3}
+            min={1}
+            max={10}
+            label="Rating"
+            format="{value} of {max}"
+          />
+        </div>
+        <div>
+          <Spinbutton client:load defaultValue={0.5} min={0} max={1} step={0.1} label="Opacity" />
+        </div>
+        <div>
+          <Spinbutton client:load defaultValue={0} label="Unbounded" showButtons={true} />
+        </div>
+        <div>
+          <Spinbutton client:load defaultValue={50} min={0} max={100} label="Read-only" readOnly />
+        </div>
+        <div>
+          <Spinbutton client:load defaultValue={50} min={0} max={100} label="Disabled" disabled />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Native HTML Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Native HTML</Heading>
+    <NativeHtmlNotice />
+  </section>
+
+  <!-- Accessibility Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Accessibility Features</Heading>
+    <AccessibilityDocs />
+  </section>
+
+  <!-- Source Code Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Source Code</Heading>
+    <CodeBlock
+      collapsible
+      collapsedLines={5}
+      code={sourceCode}
+      lang="svelte"
+      title="Spinbutton.svelte"
+    />
+  </section>
+
+  <!-- Usage Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Usage</Heading>
+    <CodeBlock
+      collapsible
+      collapsedLines={5}
+      code={`<script>
+  import Spinbutton from './Spinbutton.svelte';
+
+  function handleChange(value) {
+    console.log(value);
+  }
+</script>
+
+<!-- Basic usage with aria-label -->
+<Spinbutton aria-label="Quantity" />
+
+<!-- With visible label and min/max -->
+<Spinbutton
+  defaultValue={5}
+  min={0}
+  max={100}
+  label="Quantity"
+/>
+
+<!-- With format for display and aria-valuetext -->
+<Spinbutton
+  defaultValue={3}
+  min={1}
+  max={10}
+  label="Rating"
+  format="{value} of {max}"
+/>
+
+<!-- Decimal step values -->
+<Spinbutton
+  defaultValue={0.5}
+  min={0}
+  max={1}
+  step={0.1}
+  label="Opacity"
+/>
+
+<!-- Unbounded (no min/max limits) -->
+<Spinbutton
+  defaultValue={0}
+  label="Counter"
+/>
+
+<!-- With callback -->
+<Spinbutton
+  defaultValue={5}
+  min={0}
+  max={100}
+  label="Value"
+  onvaluechange={handleChange}
+/>`}
+      lang="svelte"
+      title="Example"
+    />
+  </section>
+
+  <!-- API Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">API</Heading>
+    <ResponsiveTable>
+      <table class="w-full border-collapse">
+        <thead>
+          <tr class="border-border border-b">
+            <th class="py-2 pr-4 text-left">Prop</th>
+            <th class="py-2 pr-4 text-left">Type</th>
+            <th class="py-2 pr-4 text-left">Default</th>
+            <th class="py-2 text-left">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>defaultValue</code></td>
+            <td class="text-muted-foreground py-2 pr-4">number</td>
+            <td class="text-muted-foreground py-2 pr-4">0</td>
+            <td class="py-2">Initial value of the spinbutton</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>min</code></td>
+            <td class="text-muted-foreground py-2 pr-4">number</td>
+            <td class="text-muted-foreground py-2 pr-4">undefined</td>
+            <td class="py-2">Minimum value (undefined = no limit)</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>max</code></td>
+            <td class="text-muted-foreground py-2 pr-4">number</td>
+            <td class="text-muted-foreground py-2 pr-4">undefined</td>
+            <td class="py-2">Maximum value (undefined = no limit)</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>step</code></td>
+            <td class="text-muted-foreground py-2 pr-4">number</td>
+            <td class="text-muted-foreground py-2 pr-4">1</td>
+            <td class="py-2">Step increment for keyboard/button</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>largeStep</code></td>
+            <td class="text-muted-foreground py-2 pr-4">number</td>
+            <td class="text-muted-foreground py-2 pr-4">step * 10</td>
+            <td class="py-2">Large step for PageUp/PageDown</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>disabled</code></td>
+            <td class="text-muted-foreground py-2 pr-4">boolean</td>
+            <td class="text-muted-foreground py-2 pr-4">false</td>
+            <td class="py-2">Whether the spinbutton is disabled</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>readOnly</code></td>
+            <td class="text-muted-foreground py-2 pr-4">boolean</td>
+            <td class="text-muted-foreground py-2 pr-4">false</td>
+            <td class="py-2">Whether the spinbutton is read-only</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>showButtons</code></td>
+            <td class="text-muted-foreground py-2 pr-4">boolean</td>
+            <td class="text-muted-foreground py-2 pr-4">true</td>
+            <td class="py-2">Whether to show increment/decrement buttons</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>label</code></td>
+            <td class="text-muted-foreground py-2 pr-4">string</td>
+            <td class="text-muted-foreground py-2 pr-4">-</td>
+            <td class="py-2">Visible label (also used as aria-labelledby)</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>valueText</code></td>
+            <td class="text-muted-foreground py-2 pr-4">string</td>
+            <td class="text-muted-foreground py-2 pr-4">-</td>
+            <td class="py-2">Human-readable value for aria-valuetext</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>format</code></td>
+            <td class="text-muted-foreground py-2 pr-4">string</td>
+            <td class="text-muted-foreground py-2 pr-4">-</td>
+            <td class="py-2"
+              >Format pattern for aria-valuetext (e.g., "{'{value}'} of {'{max}'}")</td
+            >
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>onvaluechange</code></td>
+            <td class="text-muted-foreground py-2 pr-4">(value: number) =&gt; void</td>
+            <td class="text-muted-foreground py-2 pr-4">-</td>
+            <td class="py-2">Callback when value changes</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+    <p class="text-muted-foreground mt-4 text-sm">
+      One of <code>label</code>, <code>aria-label</code>, or <code>aria-labelledby</code> is required
+      for accessibility.
+    </p>
+  </section>
+
+  <!-- Testing Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Testing</Heading>
+    <TestingDocs />
+    <div class="mt-6">
+      <CodeBlock
+        collapsible
+        collapsedLines={5}
+        code={testCode}
+        lang="typescript"
+        title="Spinbutton.test.svelte.ts"
+      />
+    </div>
+  </section>
+
+  <!-- Resources -->
+  <section>
+    <Heading level={2} class="mb-4 text-xl font-semibold">Resources</Heading>
+    <ul class="list-disc space-y-2 pl-6">
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/spinbutton/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Spinbutton Pattern
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number"
+          class="text-primary hover:underline"
+        >
+          MDN: &lt;input type="number"&gt; element
+        </ExternalLink>
+      </li>
+      <AiGuideResourceItem pattern="spinbutton" />
+    </ul>
+  </section>
+</PatternLayout>

--- a/src/pages/patterns/spinbutton/vue/index.astro
+++ b/src/pages/patterns/spinbutton/vue/index.astro
@@ -1,0 +1,307 @@
+---
+import PatternLayout from '../../../../layouts/PatternLayout.astro';
+import Spinbutton from '@patterns/spinbutton/Spinbutton.vue';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
+import AccessibilityDocs from '@patterns/spinbutton/AccessibilityDocs.astro';
+import TestingDocs from '@patterns/spinbutton/TestingDocs.astro';
+import NativeHtmlNotice from '@patterns/spinbutton/NativeHtmlNotice.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/spinbutton/Spinbutton.vue?raw';
+import testCode from '@patterns/spinbutton/Spinbutton.test.vue.ts?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'native-html', text: 'Native HTML' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'usage', text: 'Usage' },
+  { id: 'api', text: 'API' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
+---
+
+<PatternLayout title="Spinbutton - Vue" pattern="spinbutton" framework="vue" tocItems={tocItems}>
+  <header class="mb-8">
+    <h1 class="mb-4 text-3xl font-bold">Spinbutton</h1>
+    <p class="text-muted-foreground text-lg">
+      An input widget that allows users to select a value from a discrete set or range by using
+      increment/decrement buttons, arrow keys, or typing directly.
+    </p>
+    <AiGuideBadge pattern="spinbutton" />
+  </header>
+
+  <!-- Framework Selector -->
+  <FrameworkTabs pattern="spinbutton" currentFramework="vue" />
+
+  <!-- Demo Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Demo</Heading>
+    <div class="border-border bg-background rounded-lg border p-6">
+      <div class="flex flex-col gap-6">
+        <div>
+          <Spinbutton client:load defaultValue={5} min={0} max={100} label="Quantity" />
+        </div>
+        <div>
+          <Spinbutton
+            client:load
+            defaultValue={3}
+            min={1}
+            max={10}
+            label="Rating"
+            format="{value} of {max}"
+          />
+        </div>
+        <div>
+          <Spinbutton client:load defaultValue={0.5} min={0} max={1} step={0.1} label="Opacity" />
+        </div>
+        <div>
+          <Spinbutton client:load defaultValue={0} label="Unbounded" showButtons={true} />
+        </div>
+        <div>
+          <Spinbutton client:load defaultValue={50} min={0} max={100} label="Read-only" readOnly />
+        </div>
+        <div>
+          <Spinbutton client:load defaultValue={50} min={0} max={100} label="Disabled" disabled />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Native HTML Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Native HTML</Heading>
+    <NativeHtmlNotice />
+  </section>
+
+  <!-- Accessibility Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Accessibility Features</Heading>
+    <AccessibilityDocs />
+  </section>
+
+  <!-- Source Code Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Source Code</Heading>
+    <CodeBlock collapsible collapsedLines={5} code={sourceCode} lang="vue" title="Spinbutton.vue" />
+  </section>
+
+  <!-- Usage Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Usage</Heading>
+    <CodeBlock
+      collapsible
+      collapsedLines={5}
+      code={`<script setup>
+import Spinbutton from './Spinbutton.vue';
+
+function handleChange(value) {
+  console.log(value);
+}
+</script>
+
+<template>
+  <!-- Basic usage with aria-label -->
+  <Spinbutton aria-label="Quantity" />
+
+  <!-- With visible label and min/max -->
+  <Spinbutton
+    :default-value="5"
+    :min="0"
+    :max="100"
+    label="Quantity"
+  />
+
+  <!-- With format for display and aria-valuetext -->
+  <Spinbutton
+    :default-value="3"
+    :min="1"
+    :max="10"
+    label="Rating"
+    format="{value} of {max}"
+  />
+
+  <!-- Decimal step values -->
+  <Spinbutton
+    :default-value="0.5"
+    :min="0"
+    :max="1"
+    :step="0.1"
+    label="Opacity"
+  />
+
+  <!-- Unbounded (no min/max limits) -->
+  <Spinbutton
+    :default-value="0"
+    label="Counter"
+  />
+
+  <!-- With callback -->
+  <Spinbutton
+    :default-value="5"
+    :min="0"
+    :max="100"
+    label="Value"
+    @valuechange="handleChange"
+  />
+</template>`}
+      lang="vue"
+      title="Example"
+    />
+  </section>
+
+  <!-- API Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">API</Heading>
+    <ResponsiveTable>
+      <table class="w-full border-collapse">
+        <thead>
+          <tr class="border-border border-b">
+            <th class="py-2 pr-4 text-left">Prop</th>
+            <th class="py-2 pr-4 text-left">Type</th>
+            <th class="py-2 pr-4 text-left">Default</th>
+            <th class="py-2 text-left">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>defaultValue</code></td>
+            <td class="text-muted-foreground py-2 pr-4">number</td>
+            <td class="text-muted-foreground py-2 pr-4">0</td>
+            <td class="py-2">Initial value of the spinbutton</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>min</code></td>
+            <td class="text-muted-foreground py-2 pr-4">number</td>
+            <td class="text-muted-foreground py-2 pr-4">undefined</td>
+            <td class="py-2">Minimum value (undefined = no limit)</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>max</code></td>
+            <td class="text-muted-foreground py-2 pr-4">number</td>
+            <td class="text-muted-foreground py-2 pr-4">undefined</td>
+            <td class="py-2">Maximum value (undefined = no limit)</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>step</code></td>
+            <td class="text-muted-foreground py-2 pr-4">number</td>
+            <td class="text-muted-foreground py-2 pr-4">1</td>
+            <td class="py-2">Step increment for keyboard/button</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>largeStep</code></td>
+            <td class="text-muted-foreground py-2 pr-4">number</td>
+            <td class="text-muted-foreground py-2 pr-4">step * 10</td>
+            <td class="py-2">Large step for PageUp/PageDown</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>disabled</code></td>
+            <td class="text-muted-foreground py-2 pr-4">boolean</td>
+            <td class="text-muted-foreground py-2 pr-4">false</td>
+            <td class="py-2">Whether the spinbutton is disabled</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>readOnly</code></td>
+            <td class="text-muted-foreground py-2 pr-4">boolean</td>
+            <td class="text-muted-foreground py-2 pr-4">false</td>
+            <td class="py-2">Whether the spinbutton is read-only</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>showButtons</code></td>
+            <td class="text-muted-foreground py-2 pr-4">boolean</td>
+            <td class="text-muted-foreground py-2 pr-4">true</td>
+            <td class="py-2">Whether to show increment/decrement buttons</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>label</code></td>
+            <td class="text-muted-foreground py-2 pr-4">string</td>
+            <td class="text-muted-foreground py-2 pr-4">-</td>
+            <td class="py-2">Visible label (also used as aria-labelledby)</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>valueText</code></td>
+            <td class="text-muted-foreground py-2 pr-4">string</td>
+            <td class="text-muted-foreground py-2 pr-4">-</td>
+            <td class="py-2">Human-readable value for aria-valuetext</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>format</code></td>
+            <td class="text-muted-foreground py-2 pr-4">string</td>
+            <td class="text-muted-foreground py-2 pr-4">-</td>
+            <td class="py-2"
+              >Format pattern for aria-valuetext (e.g., "{'{value}'} of {'{max}'}")</td
+            >
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+
+    <h3 class="mt-6 mb-3 text-lg font-medium">Events</h3>
+    <ResponsiveTable>
+      <table class="w-full border-collapse">
+        <thead>
+          <tr class="border-border border-b">
+            <th class="py-2 pr-4 text-left">Event</th>
+            <th class="py-2 pr-4 text-left">Payload</th>
+            <th class="py-2 text-left">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4"><code>@valuechange</code></td>
+            <td class="text-muted-foreground py-2 pr-4">number</td>
+            <td class="py-2">Emitted when value changes</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+    <p class="text-muted-foreground mt-4 text-sm">
+      One of <code>label</code>, <code>aria-label</code>, or <code>aria-labelledby</code> is required
+      for accessibility.
+    </p>
+  </section>
+
+  <!-- Testing Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Testing</Heading>
+    <TestingDocs />
+    <div class="mt-6">
+      <CodeBlock
+        collapsible
+        collapsedLines={5}
+        code={testCode}
+        lang="typescript"
+        title="Spinbutton.test.vue.ts"
+      />
+    </div>
+  </section>
+
+  <!-- Resources -->
+  <section>
+    <Heading level={2} class="mb-4 text-xl font-semibold">Resources</Heading>
+    <ul class="list-disc space-y-2 pl-6">
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/spinbutton/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Spinbutton Pattern
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number"
+          class="text-primary hover:underline"
+        >
+          MDN: &lt;input type="number"&gt; element
+        </ExternalLink>
+      </li>
+      <AiGuideResourceItem pattern="spinbutton" />
+    </ul>
+  </section>
+</PatternLayout>

--- a/src/patterns/spinbutton/AccessibilityDocs.astro
+++ b/src/patterns/spinbutton/AccessibilityDocs.astro
@@ -1,0 +1,310 @@
+---
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+---
+
+<div class="prose dark:prose-invert max-w-none">
+  <h3 class="mb-3 text-lg font-medium">WAI-ARIA Role</h3>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">Role</th>
+          <th class="py-2 pr-4 text-left">Element</th>
+          <th class="py-2 text-left">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>spinbutton</code></td>
+          <td class="py-2 pr-4">Input element</td>
+          <td class="py-2">
+            Identifies the element as a spin button that allows users to select a value from a
+            discrete set or range by incrementing/decrementing or typing directly.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+  <p class="text-muted-foreground mb-6 text-sm">
+    The <code>spinbutton</code> role is used for input controls that let users select a numeric value
+    by using increment/decrement buttons, arrow keys, or typing directly. It combines the functionality
+    of a text input with up/down value adjustment.
+  </p>
+
+  <h3 class="mb-3 text-lg font-medium">WAI-ARIA States and Properties</h3>
+
+  <div class="mb-6">
+    <h4 class="mb-2 font-medium"><code>aria-valuenow</code> (Required)</h4>
+    <p class="text-muted-foreground mb-3">
+      Indicates the current numeric value of the spinbutton. Updated dynamically as the user changes
+      the value.
+    </p>
+    <ResponsiveTable class="mb-2">
+      <table class="w-full border-collapse">
+        <tbody>
+          <tr class="border-border border-b">
+            <td class="w-32 py-2 pr-4 font-medium">Type</td>
+            <td class="py-2">Number</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4 font-medium">Required</td>
+            <td class="py-2">Yes</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4 font-medium">Update</td>
+            <td class="py-2">
+              Must be updated immediately when value changes (keyboard, button click, or text input)
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </div>
+
+  <div class="mb-6">
+    <h4 class="mb-2 font-medium"><code>aria-valuemin</code></h4>
+    <p class="text-muted-foreground mb-3">
+      Specifies the minimum allowed value. Only set when a minimum limit exists.
+    </p>
+    <ResponsiveTable class="mb-2">
+      <table class="w-full border-collapse">
+        <tbody>
+          <tr class="border-border border-b">
+            <td class="w-32 py-2 pr-4 font-medium">Type</td>
+            <td class="py-2">Number</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4 font-medium">Required</td>
+            <td class="py-2">No (only set when min is defined)</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4 font-medium">Note</td>
+            <td class="py-2">Omit attribute entirely when no minimum limit exists</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </div>
+
+  <div class="mb-6">
+    <h4 class="mb-2 font-medium"><code>aria-valuemax</code></h4>
+    <p class="text-muted-foreground mb-3">
+      Specifies the maximum allowed value. Only set when a maximum limit exists.
+    </p>
+    <ResponsiveTable class="mb-2">
+      <table class="w-full border-collapse">
+        <tbody>
+          <tr class="border-border border-b">
+            <td class="w-32 py-2 pr-4 font-medium">Type</td>
+            <td class="py-2">Number</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4 font-medium">Required</td>
+            <td class="py-2">No (only set when max is defined)</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4 font-medium">Note</td>
+            <td class="py-2">Omit attribute entirely when no maximum limit exists</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </div>
+
+  <div class="mb-6">
+    <h4 class="mb-2 font-medium"><code>aria-valuetext</code></h4>
+    <p class="text-muted-foreground mb-3">
+      Provides a human-readable text alternative for the current value. Use when the numeric value
+      alone doesn't convey sufficient meaning.
+    </p>
+    <ResponsiveTable class="mb-2">
+      <table class="w-full border-collapse">
+        <tbody>
+          <tr class="border-border border-b">
+            <td class="w-32 py-2 pr-4 font-medium">Type</td>
+            <td class="py-2">String</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4 font-medium">Required</td>
+            <td class="py-2">No (recommended when value needs context)</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4 font-medium">Example</td>
+            <td class="py-2">"5 items", "3 of 10", "Tuesday"</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </div>
+
+  <div class="mb-6">
+    <h4 class="mb-2 font-medium"><code>aria-disabled</code></h4>
+    <p class="text-muted-foreground mb-3">
+      Indicates that the spinbutton is disabled and not interactive.
+    </p>
+    <ResponsiveTable class="mb-2">
+      <table class="w-full border-collapse">
+        <tbody>
+          <tr class="border-border border-b">
+            <td class="w-32 py-2 pr-4 font-medium">Type</td>
+            <td class="py-2">Boolean</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4 font-medium">Required</td>
+            <td class="py-2">No</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </div>
+
+  <div class="mb-6">
+    <h4 class="mb-2 font-medium"><code>aria-readonly</code></h4>
+    <p class="text-muted-foreground mb-3">
+      Indicates that the spinbutton is read-only. Users can navigate with Home/End but cannot change
+      the value.
+    </p>
+    <ResponsiveTable class="mb-2">
+      <table class="w-full border-collapse">
+        <tbody>
+          <tr class="border-border border-b">
+            <td class="w-32 py-2 pr-4 font-medium">Type</td>
+            <td class="py-2">Boolean</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4 font-medium">Required</td>
+            <td class="py-2">No</td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </div>
+
+  <h3 class="mb-3 text-lg font-medium">Keyboard Support</h3>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">Key</th>
+          <th class="py-2 text-left">Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><kbd>Up Arrow</kbd></td>
+          <td class="py-2">Increases the value by one step</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><kbd>Down Arrow</kbd></td>
+          <td class="py-2">Decreases the value by one step</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><kbd>Home</kbd></td>
+          <td class="py-2">Sets the value to its minimum (only when min is defined)</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><kbd>End</kbd></td>
+          <td class="py-2">Sets the value to its maximum (only when max is defined)</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><kbd>Page Up</kbd></td>
+          <td class="py-2">Increases the value by a large step (default: step * 10)</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><kbd>Page Down</kbd></td>
+          <td class="py-2">Decreases the value by a large step (default: step * 10)</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+  <p class="text-muted-foreground mb-6 text-sm">
+    <strong>Note:</strong> Unlike the slider pattern, spinbutton uses Up/Down arrows only (not Left/Right).
+    This allows users to type numeric values directly using the text input.
+  </p>
+
+  <h3 class="mb-3 text-lg font-medium">Accessible Naming</h3>
+  <p class="text-muted-foreground mb-3">
+    Spinbuttons must have an accessible name. This can be provided through:
+  </p>
+  <ul class="mb-6 list-disc space-y-2 pl-6">
+    <li>
+      <strong>Visible label</strong> - Using the <code>label</code> prop to display a visible label
+    </li>
+    <li>
+      <code>aria-label</code> - Provides an invisible label for the spinbutton
+    </li>
+    <li>
+      <code>aria-labelledby</code> - References an external element as the label
+    </li>
+  </ul>
+
+  <h3 class="mb-3 text-lg font-medium">Text Input</h3>
+  <p class="text-muted-foreground mb-3">This implementation supports direct text input:</p>
+  <ul class="mb-6 list-disc space-y-2 pl-6">
+    <li>
+      <strong>Numeric keyboard</strong> - Uses <code>inputmode="numeric"</code> for optimal mobile experience
+    </li>
+    <li>
+      <strong>Real-time validation</strong> - Value is clamped and rounded to step on each input
+    </li>
+    <li>
+      <strong>Invalid input handling</strong> - Reverts to previous valid value on blur if input is invalid
+    </li>
+    <li>
+      <strong>IME support</strong> - Waits for composition to complete before updating value
+    </li>
+  </ul>
+
+  <h3 class="mb-3 text-lg font-medium">Visual Design</h3>
+  <p class="text-muted-foreground mb-3">
+    This implementation follows WCAG guidelines for accessible visual design:
+  </p>
+  <ul class="mb-6 list-disc space-y-2 pl-6">
+    <li>
+      <strong>Focus indicator</strong> - Visible focus ring on the entire controls container (including
+      buttons), providing clear visual feedback for the focused component
+    </li>
+    <li>
+      <strong>Button states</strong> - Visual feedback on hover and active states
+    </li>
+    <li>
+      <strong>Disabled state</strong> - Clear visual indication when spinbutton is disabled
+    </li>
+    <li>
+      <strong>Read-only state</strong> - Distinct visual style for read-only mode
+    </li>
+    <li>
+      <strong>Forced colors mode</strong> - Uses system colors for accessibility in Windows High Contrast
+      Mode
+    </li>
+  </ul>
+
+  <h3 class="mb-3 text-lg font-medium">References</h3>
+  <ul class="list-disc space-y-2 pl-6">
+    <li>
+      <ExternalLink
+        href="https://www.w3.org/WAI/ARIA/apg/patterns/spinbutton/"
+        class="text-primary hover:underline"
+      >
+        WAI-ARIA APG: Spinbutton Pattern
+      </ExternalLink>
+    </li>
+    <li>
+      <ExternalLink
+        href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number"
+        class="text-primary hover:underline"
+      >
+        MDN: &lt;input type="number"&gt; element
+      </ExternalLink>
+    </li>
+    <li>
+      <ExternalLink
+        href="https://w3c.github.io/aria/#spinbutton"
+        class="text-primary hover:underline"
+      >
+        W3C ARIA: spinbutton role
+      </ExternalLink>
+    </li>
+  </ul>
+</div>

--- a/src/patterns/spinbutton/NativeHtmlNotice.astro
+++ b/src/patterns/spinbutton/NativeHtmlNotice.astro
@@ -1,0 +1,87 @@
+---
+import { ResponsiveTable } from '@/components/ui/table';
+---
+
+<div class="border-primary mb-8 rounded-lg border-2 p-4">
+  <h2 class="mb-2 flex items-center gap-2 text-lg font-bold">
+    <span aria-hidden="true">⚠️</span> Use Native HTML First
+  </h2>
+  <p class="mb-4">
+    <strong class="text-red-700 dark:text-red-400"
+      >Before using this custom component, consider using native <code
+        >&lt;input type="number"&gt;</code
+      > elements.</strong
+    >
+    They provide built-in semantics, work without JavaScript, and have native browser validation.
+  </p>
+  <div class="bg-muted mb-4 rounded-md p-3">
+    <pre
+      class="m-0 overflow-x-auto text-sm"><code>&lt;label for="quantity"&gt;Quantity&lt;/label&gt;
+&lt;input type="number" id="quantity" value="1" min="0" max="100" step="1"&gt;</code></pre>
+  </div>
+  <p class="mb-4 text-sm">
+    Use custom implementations only when you need custom styling that native elements cannot
+    provide, or when you need specific interaction patterns not available with native inputs.
+  </p>
+
+  <ResponsiveTable>
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">Use Case</th>
+          <th class="py-2 pr-4 text-left">Native HTML</th>
+          <th class="py-2 text-left">Custom Implementation</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4">Basic numeric input</td>
+          <td class="py-2 pr-4"><b class="text-green-700 dark:text-green-400">Recommended</b></td>
+          <td class="py-2">Not needed</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4">JavaScript disabled support</td>
+          <td class="py-2 pr-4"><b class="text-green-700 dark:text-green-400">Works natively</b></td
+          >
+          <td class="py-2">Requires fallback</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4">Built-in validation</td>
+          <td class="py-2 pr-4"><b class="text-green-700 dark:text-green-400">Native support</b></td
+          >
+          <td class="py-2">Manual implementation</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4">Custom button styling</td>
+          <td class="py-2 pr-4">Limited (browser-dependent)</td>
+          <td class="py-2"><b class="text-green-700 dark:text-green-400">Full control</b></td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4">Consistent cross-browser appearance</td>
+          <td class="py-2 pr-4">Varies by browser</td>
+          <td class="py-2"><b class="text-green-700 dark:text-green-400">Consistent</b></td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4">Custom step/large step behavior</td>
+          <td class="py-2 pr-4">Basic step only</td>
+          <td class="py-2"
+            ><b class="text-green-700 dark:text-green-400">PageUp/PageDown support</b></td
+          >
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4">No min/max limits</td>
+          <td class="py-2 pr-4">Requires omitting attributes</td>
+          <td class="py-2"
+            ><b class="text-green-700 dark:text-green-400">Explicit undefined support</b></td
+          >
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+  <p class="text-muted-foreground mt-3 text-xs">
+    The native <code>&lt;input type="number"&gt;</code> element provides built-in browser validation,
+    form submission support, and accessible semantics. However, its appearance and spinner button styling
+    varies significantly across browsers, making custom implementations preferable when visual consistency
+    is required.
+  </p>
+</div>

--- a/src/patterns/spinbutton/Spinbutton.astro
+++ b/src/patterns/spinbutton/Spinbutton.astro
@@ -1,0 +1,474 @@
+---
+/**
+ * APG Spinbutton Pattern - Astro Implementation
+ *
+ * A control that allows users to select a value from a discrete set or range.
+ * Uses Web Components for interactive behavior.
+ *
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/spinbutton/
+ */
+
+export interface Props {
+  /** Default value */
+  defaultValue?: number;
+  /** Minimum value (undefined = no limit) */
+  min?: number;
+  /** Maximum value (undefined = no limit) */
+  max?: number;
+  /** Step increment (default: 1) */
+  step?: number;
+  /** Large step for PageUp/PageDown */
+  largeStep?: number;
+  /** Whether spinbutton is disabled */
+  disabled?: boolean;
+  /** Whether spinbutton is read-only */
+  readOnly?: boolean;
+  /** Show increment/decrement buttons (default: true) */
+  showButtons?: boolean;
+  /** Visible label text */
+  label?: string;
+  /** Human-readable value text for aria-valuetext */
+  valueText?: string;
+  /** Format pattern for dynamic value display (e.g., "{value} items") */
+  format?: string;
+  /** Spinbutton id */
+  id?: string;
+  /** Additional CSS class */
+  class?: string;
+  /** Accessible label when no visible label */
+  'aria-label'?: string;
+  /** Reference to external label element */
+  'aria-labelledby'?: string;
+  /** Reference to description element */
+  'aria-describedby'?: string;
+  /** Whether the input value is invalid */
+  'aria-invalid'?: boolean;
+  /** Test ID */
+  'data-testid'?: string;
+}
+
+const {
+  defaultValue = 0,
+  min,
+  max,
+  step = 1,
+  largeStep,
+  disabled = false,
+  readOnly = false,
+  showButtons = true,
+  label,
+  valueText,
+  format,
+  id,
+  class: className = '',
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledby,
+  'aria-describedby': ariaDescribedby,
+  'aria-invalid': ariaInvalid,
+  'data-testid': dataTestid,
+} = Astro.props;
+
+// Utility functions
+const clamp = (val: number, minVal?: number, maxVal?: number): number => {
+  let result = val;
+  if (minVal !== undefined) result = Math.max(minVal, result);
+  if (maxVal !== undefined) result = Math.min(maxVal, result);
+  return result;
+};
+
+const roundToStep = (val: number, stepVal: number, minVal?: number): number => {
+  const base = minVal ?? 0;
+  const steps = Math.round((val - base) / stepVal);
+  const result = base + steps * stepVal;
+  const decimalPlaces = (stepVal.toString().split('.')[1] || '').length;
+  return Number(result.toFixed(decimalPlaces));
+};
+
+// Calculate initial value
+const initialValue = clamp(roundToStep(defaultValue, step, min), min, max);
+
+// Format value helper
+const formatValueText = (value: number, formatStr?: string): string => {
+  if (!formatStr) return String(value);
+  return formatStr
+    .replace('{value}', String(value))
+    .replace('{min}', min !== undefined ? String(min) : '')
+    .replace('{max}', max !== undefined ? String(max) : '');
+};
+
+// Initial aria-valuetext
+const getInitialAriaValueText = (): string | undefined => {
+  if (valueText) return valueText;
+  if (format) return formatValueText(initialValue, format);
+  return undefined;
+};
+const initialAriaValueText = getInitialAriaValueText();
+
+// Generate unique label ID
+const labelId = label ? `spinbutton-label-${Math.random().toString(36).slice(2, 9)}` : undefined;
+
+const effectiveLargeStep = largeStep ?? step * 10;
+---
+
+<apg-spinbutton
+  data-min={min}
+  data-max={max}
+  data-step={step}
+  data-large-step={effectiveLargeStep}
+  data-disabled={disabled}
+  data-readonly={readOnly}
+  data-format={format}
+>
+  <div class={`apg-spinbutton ${disabled ? 'apg-spinbutton--disabled' : ''} ${className}`.trim()}>
+    {
+      label && (
+        <span id={labelId} class="apg-spinbutton-label">
+          {label}
+        </span>
+      )
+    }
+    <div class="apg-spinbutton-controls">
+      {
+        showButtons && (
+          <button
+            type="button"
+            tabindex={-1}
+            aria-label="Decrement"
+            disabled={disabled}
+            class="apg-spinbutton-button apg-spinbutton-decrement"
+          >
+            −
+          </button>
+        )
+      }
+      <input
+        type="text"
+        role="spinbutton"
+        id={id}
+        tabindex={disabled ? -1 : 0}
+        inputmode="numeric"
+        value={String(initialValue)}
+        readonly={readOnly}
+        aria-valuenow={initialValue}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuetext={initialAriaValueText}
+        aria-label={label ? undefined : ariaLabel}
+        aria-labelledby={ariaLabelledby ?? labelId}
+        aria-describedby={ariaDescribedby}
+        aria-disabled={disabled || undefined}
+        aria-readonly={readOnly || undefined}
+        aria-invalid={ariaInvalid || undefined}
+        data-testid={dataTestid}
+        class="apg-spinbutton-input"
+      />
+      {
+        showButtons && (
+          <button
+            type="button"
+            tabindex={-1}
+            aria-label="Increment"
+            disabled={disabled}
+            class="apg-spinbutton-button apg-spinbutton-increment"
+          >
+            +
+          </button>
+        )
+      }
+    </div>
+  </div>
+</apg-spinbutton>
+
+<script>
+  class ApgSpinbutton extends HTMLElement {
+    private input: HTMLInputElement | null = null;
+    private incrementBtn: HTMLButtonElement | null = null;
+    private decrementBtn: HTMLButtonElement | null = null;
+    private isComposing = false;
+    private previousValidValue = 0;
+
+    // Bound handler references (to properly remove listeners)
+    private boundHandleKeyDown = this.handleKeyDown.bind(this);
+    private boundHandleInput = this.handleInput.bind(this);
+    private boundHandleBlur = this.handleBlur.bind(this);
+    private boundHandleCompositionStart = this.handleCompositionStart.bind(this);
+    private boundHandleCompositionEnd = this.handleCompositionEnd.bind(this);
+    private boundHandleIncrement = this.handleIncrement.bind(this);
+    private boundHandleDecrement = this.handleDecrement.bind(this);
+    private boundPreventMouseDown = this.preventMouseDown.bind(this);
+
+    connectedCallback() {
+      this.input = this.querySelector('[role="spinbutton"]');
+      this.incrementBtn = this.querySelector('.apg-spinbutton-increment');
+      this.decrementBtn = this.querySelector('.apg-spinbutton-decrement');
+
+      if (this.input) {
+        this.previousValidValue = this.currentValue;
+        this.input.addEventListener('keydown', this.boundHandleKeyDown);
+        this.input.addEventListener('input', this.boundHandleInput);
+        this.input.addEventListener('blur', this.boundHandleBlur);
+        this.input.addEventListener('compositionstart', this.boundHandleCompositionStart);
+        this.input.addEventListener('compositionend', this.boundHandleCompositionEnd);
+      }
+
+      if (this.incrementBtn) {
+        this.incrementBtn.addEventListener('mousedown', this.boundPreventMouseDown);
+        this.incrementBtn.addEventListener('click', this.boundHandleIncrement);
+      }
+
+      if (this.decrementBtn) {
+        this.decrementBtn.addEventListener('mousedown', this.boundPreventMouseDown);
+        this.decrementBtn.addEventListener('click', this.boundHandleDecrement);
+      }
+    }
+
+    disconnectedCallback() {
+      if (this.input) {
+        this.input.removeEventListener('keydown', this.boundHandleKeyDown);
+        this.input.removeEventListener('input', this.boundHandleInput);
+        this.input.removeEventListener('blur', this.boundHandleBlur);
+        this.input.removeEventListener('compositionstart', this.boundHandleCompositionStart);
+        this.input.removeEventListener('compositionend', this.boundHandleCompositionEnd);
+      }
+
+      if (this.incrementBtn) {
+        this.incrementBtn.removeEventListener('mousedown', this.boundPreventMouseDown);
+        this.incrementBtn.removeEventListener('click', this.boundHandleIncrement);
+      }
+
+      if (this.decrementBtn) {
+        this.decrementBtn.removeEventListener('mousedown', this.boundPreventMouseDown);
+        this.decrementBtn.removeEventListener('click', this.boundHandleDecrement);
+      }
+    }
+
+    private preventMouseDown(event: MouseEvent) {
+      event.preventDefault();
+    }
+
+    private get min(): number | undefined {
+      const val = this.dataset.min;
+      return val !== undefined && val !== '' ? Number(val) : undefined;
+    }
+
+    private get max(): number | undefined {
+      const val = this.dataset.max;
+      return val !== undefined && val !== '' ? Number(val) : undefined;
+    }
+
+    private get step(): number {
+      return Number(this.dataset.step) || 1;
+    }
+
+    private get largeStep(): number {
+      return Number(this.dataset.largeStep) || this.step * 10;
+    }
+
+    private get isDisabled(): boolean {
+      return this.dataset.disabled === 'true';
+    }
+
+    private get isReadOnly(): boolean {
+      return this.dataset.readonly === 'true';
+    }
+
+    private get format(): string | undefined {
+      return this.dataset.format;
+    }
+
+    private formatValue(value: number): string {
+      const fmt = this.format;
+      if (!fmt) return String(value);
+      return fmt
+        .replace('{value}', String(value))
+        .replace('{min}', this.min !== undefined ? String(this.min) : '')
+        .replace('{max}', this.max !== undefined ? String(this.max) : '');
+    }
+
+    private get currentValue(): number {
+      return Number(this.input?.getAttribute('aria-valuenow')) || 0;
+    }
+
+    private clamp(val: number): number {
+      let result = val;
+      if (this.min !== undefined) result = Math.max(this.min, result);
+      if (this.max !== undefined) result = Math.min(this.max, result);
+      return result;
+    }
+
+    private roundToStep(val: number): number {
+      const base = this.min ?? 0;
+      const steps = Math.round((val - base) / this.step);
+      const result = base + steps * this.step;
+      const decimalPlaces = (this.step.toString().split('.')[1] || '').length;
+      return Number(result.toFixed(decimalPlaces));
+    }
+
+    private updateValue(newValue: number, updateInput = true) {
+      if (!this.input || this.isDisabled) return;
+
+      const clampedValue = this.clamp(this.roundToStep(newValue));
+      const currentValue = this.currentValue;
+
+      if (clampedValue === currentValue) return;
+
+      // Update ARIA
+      this.input.setAttribute('aria-valuenow', String(clampedValue));
+
+      // Update aria-valuetext if format is provided
+      if (this.format) {
+        this.input.setAttribute('aria-valuetext', this.formatValue(clampedValue));
+      }
+
+      // Update input value
+      if (updateInput) {
+        this.input.value = String(clampedValue);
+      }
+
+      this.previousValidValue = clampedValue;
+
+      // Dispatch event
+      this.dispatchEvent(
+        new CustomEvent('valuechange', {
+          detail: { value: clampedValue },
+          bubbles: true,
+        })
+      );
+    }
+
+    private handleKeyDown(event: KeyboardEvent) {
+      if (this.isDisabled) return;
+
+      let newValue = this.currentValue;
+      let handled = false;
+
+      switch (event.key) {
+        case 'ArrowUp':
+          if (!this.isReadOnly) {
+            newValue = this.currentValue + this.step;
+            handled = true;
+          }
+          break;
+        case 'ArrowDown':
+          if (!this.isReadOnly) {
+            newValue = this.currentValue - this.step;
+            handled = true;
+          }
+          break;
+        case 'Home':
+          if (this.min !== undefined) {
+            newValue = this.min;
+            handled = true;
+          }
+          break;
+        case 'End':
+          if (this.max !== undefined) {
+            newValue = this.max;
+            handled = true;
+          }
+          break;
+        case 'PageUp':
+          if (!this.isReadOnly) {
+            newValue = this.currentValue + this.largeStep;
+            handled = true;
+          }
+          break;
+        case 'PageDown':
+          if (!this.isReadOnly) {
+            newValue = this.currentValue - this.largeStep;
+            handled = true;
+          }
+          break;
+        default:
+          return;
+      }
+
+      if (handled) {
+        event.preventDefault();
+        this.updateValue(newValue);
+      }
+    }
+
+    private handleInput() {
+      if (this.isComposing || !this.input) return;
+
+      const parsed = parseFloat(this.input.value);
+      if (!isNaN(parsed)) {
+        const clampedValue = this.clamp(this.roundToStep(parsed));
+        if (clampedValue !== this.previousValidValue) {
+          this.input.setAttribute('aria-valuenow', String(clampedValue));
+          if (this.format) {
+            this.input.setAttribute('aria-valuetext', this.formatValue(clampedValue));
+          }
+          this.previousValidValue = clampedValue;
+          this.dispatchEvent(
+            new CustomEvent('valuechange', {
+              detail: { value: clampedValue },
+              bubbles: true,
+            })
+          );
+        }
+      }
+    }
+
+    private handleBlur() {
+      if (!this.input) return;
+
+      const parsed = parseFloat(this.input.value);
+
+      if (isNaN(parsed)) {
+        // Revert to previous valid value
+        this.input.value = String(this.previousValidValue);
+        this.input.setAttribute('aria-valuenow', String(this.previousValidValue));
+      } else {
+        const newValue = this.clamp(this.roundToStep(parsed));
+        this.input.value = String(newValue);
+        this.input.setAttribute('aria-valuenow', String(newValue));
+        if (this.format) {
+          this.input.setAttribute('aria-valuetext', this.formatValue(newValue));
+        }
+        if (newValue !== this.previousValidValue) {
+          this.previousValidValue = newValue;
+          this.dispatchEvent(
+            new CustomEvent('valuechange', {
+              detail: { value: newValue },
+              bubbles: true,
+            })
+          );
+        }
+      }
+    }
+
+    private handleCompositionStart() {
+      this.isComposing = true;
+    }
+
+    private handleCompositionEnd() {
+      this.isComposing = false;
+      this.handleInput();
+    }
+
+    private handleIncrement(event: MouseEvent) {
+      event.preventDefault();
+      if (this.isDisabled || this.isReadOnly) return;
+      this.updateValue(this.currentValue + this.step);
+      this.input?.focus();
+    }
+
+    private handleDecrement(event: MouseEvent) {
+      event.preventDefault();
+      if (this.isDisabled || this.isReadOnly) return;
+      this.updateValue(this.currentValue - this.step);
+      this.input?.focus();
+    }
+
+    // Public method to update value programmatically
+    setValue(newValue: number) {
+      this.updateValue(newValue);
+    }
+  }
+
+  if (!customElements.get('apg-spinbutton')) {
+    customElements.define('apg-spinbutton', ApgSpinbutton);
+  }
+</script>

--- a/src/patterns/spinbutton/Spinbutton.svelte
+++ b/src/patterns/spinbutton/Spinbutton.svelte
@@ -1,0 +1,288 @@
+<script lang="ts">
+  import { cn } from '@/lib/utils';
+
+  interface SpinbuttonProps {
+    defaultValue?: number;
+    min?: number;
+    max?: number;
+    step?: number;
+    largeStep?: number;
+    disabled?: boolean;
+    readOnly?: boolean;
+    showButtons?: boolean;
+    label?: string;
+    valueText?: string;
+    format?: string;
+    onvaluechange?: (value: number) => void;
+    [key: string]: unknown;
+  }
+
+  let {
+    defaultValue = 0,
+    min = undefined,
+    max = undefined,
+    step = 1,
+    largeStep,
+    disabled = false,
+    readOnly = false,
+    showButtons = true,
+    label,
+    valueText,
+    format,
+    onvaluechange,
+    ...restProps
+  }: SpinbuttonProps = $props();
+
+  // Utility functions
+  function clamp(val: number, minVal?: number, maxVal?: number): number {
+    let result = val;
+    if (minVal !== undefined) result = Math.max(minVal, result);
+    if (maxVal !== undefined) result = Math.min(maxVal, result);
+    return result;
+  }
+
+  // Ensure step is valid (positive number)
+  function ensureValidStep(stepVal: number): number {
+    return stepVal > 0 ? stepVal : 1;
+  }
+
+  function roundToStep(val: number, stepVal: number, minVal?: number): number {
+    const validStep = ensureValidStep(stepVal);
+    const base = minVal ?? 0;
+    const steps = Math.round((val - base) / validStep);
+    const result = base + steps * validStep;
+    const decimalPlaces = (validStep.toString().split('.')[1] || '').length;
+    return Number(result.toFixed(decimalPlaces));
+  }
+
+  // Format value helper
+  function formatValueText(
+    val: number,
+    formatStr: string | undefined,
+    minVal?: number,
+    maxVal?: number
+  ): string {
+    if (!formatStr) return String(val);
+    return formatStr
+      .replace('{value}', String(val))
+      .replace('{min}', minVal !== undefined ? String(minVal) : '')
+      .replace('{max}', maxVal !== undefined ? String(maxVal) : '');
+  }
+
+  // Generate unique ID for label
+  const labelId = `spinbutton-label-${Math.random().toString(36).slice(2, 9)}`;
+
+  // Refs
+  let inputEl: HTMLInputElement | null = null;
+  let isComposing = $state(false);
+
+  // State
+  const initialValue = clamp(roundToStep(defaultValue, step, min), min, max);
+  let value = $state(initialValue);
+  let inputValue = $state(String(initialValue));
+
+  // Computed
+  const effectiveLargeStep = $derived(largeStep ?? step * 10);
+
+  const ariaValueText = $derived.by(() => {
+    if (valueText) return valueText;
+    if (format) return formatValueText(value, format, min, max);
+    return undefined;
+  });
+
+  const ariaLabelledby = $derived.by(() => {
+    if (restProps['aria-labelledby']) return restProps['aria-labelledby'];
+    if (label) return labelId;
+    return undefined;
+  });
+
+  // Update value and dispatch event
+  function updateValue(newValue: number) {
+    const clampedValue = clamp(roundToStep(newValue, step, min), min, max);
+    if (clampedValue !== value) {
+      value = clampedValue;
+      inputValue = String(clampedValue);
+      onvaluechange?.(clampedValue);
+    }
+  }
+
+  // Keyboard handler
+  function handleKeyDown(event: KeyboardEvent) {
+    if (disabled) return;
+
+    let newValue = value;
+    let handled = false;
+
+    switch (event.key) {
+      case 'ArrowUp':
+        if (!readOnly) {
+          newValue = value + step;
+          handled = true;
+        }
+        break;
+      case 'ArrowDown':
+        if (!readOnly) {
+          newValue = value - step;
+          handled = true;
+        }
+        break;
+      case 'Home':
+        if (min !== undefined) {
+          newValue = min;
+          handled = true;
+        }
+        break;
+      case 'End':
+        if (max !== undefined) {
+          newValue = max;
+          handled = true;
+        }
+        break;
+      case 'PageUp':
+        if (!readOnly) {
+          newValue = value + effectiveLargeStep;
+          handled = true;
+        }
+        break;
+      case 'PageDown':
+        if (!readOnly) {
+          newValue = value - effectiveLargeStep;
+          handled = true;
+        }
+        break;
+      default:
+        return;
+    }
+
+    if (handled) {
+      event.preventDefault();
+      updateValue(newValue);
+    }
+  }
+
+  // Text input handler
+  function handleInput(event: Event) {
+    const target = event.target as HTMLInputElement;
+    inputValue = target.value;
+
+    if (!isComposing) {
+      const parsed = parseFloat(target.value);
+      if (!isNaN(parsed)) {
+        const clampedValue = clamp(roundToStep(parsed, step, min), min, max);
+        if (clampedValue !== value) {
+          value = clampedValue;
+          onvaluechange?.(clampedValue);
+        }
+      }
+    }
+  }
+
+  // Blur handler
+  function handleBlur() {
+    const parsed = parseFloat(inputValue);
+
+    if (isNaN(parsed)) {
+      inputValue = String(value);
+    } else {
+      const newValue = clamp(roundToStep(parsed, step, min), min, max);
+      if (newValue !== value) {
+        value = newValue;
+        onvaluechange?.(newValue);
+      }
+      inputValue = String(newValue);
+    }
+  }
+
+  // IME composition handlers
+  function handleCompositionStart() {
+    isComposing = true;
+  }
+
+  function handleCompositionEnd() {
+    isComposing = false;
+    const parsed = parseFloat(inputValue);
+    if (!isNaN(parsed)) {
+      const clampedValue = clamp(roundToStep(parsed, step, min), min, max);
+      value = clampedValue;
+      onvaluechange?.(clampedValue);
+    }
+  }
+
+  // Button handlers
+  function handleIncrement(event: MouseEvent) {
+    event.preventDefault();
+    if (disabled || readOnly) return;
+    updateValue(value + step);
+    inputEl?.focus();
+  }
+
+  function handleDecrement(event: MouseEvent) {
+    event.preventDefault();
+    if (disabled || readOnly) return;
+    updateValue(value - step);
+    inputEl?.focus();
+  }
+</script>
+
+<div class={cn('apg-spinbutton', disabled && 'apg-spinbutton--disabled', restProps.class)}>
+  {#if label}
+    <span id={labelId} class="apg-spinbutton-label">
+      {label}
+    </span>
+  {/if}
+  <div class="apg-spinbutton-controls">
+    {#if showButtons}
+      <button
+        type="button"
+        tabindex={-1}
+        aria-label="Decrement"
+        {disabled}
+        class="apg-spinbutton-button apg-spinbutton-decrement"
+        onmousedown={(e) => e.preventDefault()}
+        onclick={handleDecrement}
+      >
+        −
+      </button>
+    {/if}
+    <input
+      bind:this={inputEl}
+      type="text"
+      role="spinbutton"
+      id={restProps.id}
+      tabindex={disabled ? -1 : 0}
+      inputmode="numeric"
+      value={inputValue}
+      readonly={readOnly}
+      aria-valuenow={value}
+      aria-valuemin={min}
+      aria-valuemax={max}
+      aria-valuetext={ariaValueText}
+      aria-label={label ? undefined : restProps['aria-label']}
+      aria-labelledby={ariaLabelledby}
+      aria-describedby={restProps['aria-describedby']}
+      aria-disabled={disabled || undefined}
+      aria-readonly={readOnly || undefined}
+      aria-invalid={restProps['aria-invalid']}
+      data-testid={restProps['data-testid']}
+      class="apg-spinbutton-input"
+      oninput={handleInput}
+      onkeydown={handleKeyDown}
+      onblur={handleBlur}
+      oncompositionstart={handleCompositionStart}
+      oncompositionend={handleCompositionEnd}
+    />
+    {#if showButtons}
+      <button
+        type="button"
+        tabindex={-1}
+        aria-label="Increment"
+        {disabled}
+        class="apg-spinbutton-button apg-spinbutton-increment"
+        onmousedown={(e) => e.preventDefault()}
+        onclick={handleIncrement}
+      >
+        +
+      </button>
+    {/if}
+  </div>
+</div>

--- a/src/patterns/spinbutton/Spinbutton.test.astro.ts
+++ b/src/patterns/spinbutton/Spinbutton.test.astro.ts
@@ -1,0 +1,1002 @@
+/**
+ * Spinbutton Web Component Tests
+ *
+ * Unit tests for the Web Component class.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+describe('Spinbutton (Web Component)', () => {
+  let container: HTMLElement;
+
+  // Web Component class extracted for testing
+  class TestApgSpinbutton extends HTMLElement {
+    private input: HTMLInputElement | null = null;
+    private incrementBtn: HTMLButtonElement | null = null;
+    private decrementBtn: HTMLButtonElement | null = null;
+    private isComposing = false;
+    private previousValidValue = 0;
+
+    connectedCallback() {
+      this.input = this.querySelector('[role="spinbutton"]');
+      this.incrementBtn = this.querySelector('.apg-spinbutton-increment');
+      this.decrementBtn = this.querySelector('.apg-spinbutton-decrement');
+
+      if (this.input) {
+        this.previousValidValue = this.currentValue;
+        this.input.addEventListener('keydown', this.handleKeyDown.bind(this));
+        this.input.addEventListener('input', this.handleInput.bind(this));
+        this.input.addEventListener('blur', this.handleBlur.bind(this));
+        this.input.addEventListener('compositionstart', this.handleCompositionStart.bind(this));
+        this.input.addEventListener('compositionend', this.handleCompositionEnd.bind(this));
+      }
+
+      if (this.incrementBtn) {
+        this.incrementBtn.addEventListener('click', this.handleIncrement.bind(this));
+      }
+
+      if (this.decrementBtn) {
+        this.decrementBtn.addEventListener('click', this.handleDecrement.bind(this));
+      }
+    }
+
+    private get min(): number | undefined {
+      const val = this.dataset.min;
+      return val !== undefined && val !== '' ? Number(val) : undefined;
+    }
+
+    private get max(): number | undefined {
+      const val = this.dataset.max;
+      return val !== undefined && val !== '' ? Number(val) : undefined;
+    }
+
+    private get step(): number {
+      return Number(this.dataset.step) || 1;
+    }
+
+    private get largeStep(): number {
+      return Number(this.dataset.largeStep) || this.step * 10;
+    }
+
+    private get isDisabled(): boolean {
+      return this.dataset.disabled === 'true';
+    }
+
+    private get isReadOnly(): boolean {
+      return this.dataset.readonly === 'true';
+    }
+
+    private get format(): string | undefined {
+      return this.dataset.format;
+    }
+
+    private formatValue(value: number): string {
+      const fmt = this.format;
+      if (!fmt) return String(value);
+      return fmt
+        .replace('{value}', String(value))
+        .replace('{min}', this.min !== undefined ? String(this.min) : '')
+        .replace('{max}', this.max !== undefined ? String(this.max) : '');
+    }
+
+    private get currentValue(): number {
+      return Number(this.input?.getAttribute('aria-valuenow')) || 0;
+    }
+
+    private clamp(val: number): number {
+      let result = val;
+      if (this.min !== undefined) result = Math.max(this.min, result);
+      if (this.max !== undefined) result = Math.min(this.max, result);
+      return result;
+    }
+
+    private roundToStep(val: number): number {
+      const base = this.min ?? 0;
+      const steps = Math.round((val - base) / this.step);
+      const result = base + steps * this.step;
+      const decimalPlaces = (this.step.toString().split('.')[1] || '').length;
+      return Number(result.toFixed(decimalPlaces));
+    }
+
+    private updateValue(newValue: number, updateInput = true) {
+      if (!this.input || this.isDisabled) return;
+
+      const clampedValue = this.clamp(this.roundToStep(newValue));
+      const currentValue = this.currentValue;
+
+      if (clampedValue === currentValue) return;
+
+      this.input.setAttribute('aria-valuenow', String(clampedValue));
+
+      if (this.format) {
+        this.input.setAttribute('aria-valuetext', this.formatValue(clampedValue));
+      }
+
+      if (updateInput) {
+        this.input.value = String(clampedValue);
+      }
+
+      this.previousValidValue = clampedValue;
+
+      this.dispatchEvent(
+        new CustomEvent('valuechange', {
+          detail: { value: clampedValue },
+          bubbles: true,
+        })
+      );
+    }
+
+    private handleKeyDown(event: KeyboardEvent) {
+      if (this.isDisabled) return;
+
+      let newValue = this.currentValue;
+      let handled = false;
+
+      switch (event.key) {
+        case 'ArrowUp':
+          if (!this.isReadOnly) {
+            newValue = this.currentValue + this.step;
+            handled = true;
+          }
+          break;
+        case 'ArrowDown':
+          if (!this.isReadOnly) {
+            newValue = this.currentValue - this.step;
+            handled = true;
+          }
+          break;
+        case 'Home':
+          if (this.min !== undefined) {
+            newValue = this.min;
+            handled = true;
+          }
+          break;
+        case 'End':
+          if (this.max !== undefined) {
+            newValue = this.max;
+            handled = true;
+          }
+          break;
+        case 'PageUp':
+          if (!this.isReadOnly) {
+            newValue = this.currentValue + this.largeStep;
+            handled = true;
+          }
+          break;
+        case 'PageDown':
+          if (!this.isReadOnly) {
+            newValue = this.currentValue - this.largeStep;
+            handled = true;
+          }
+          break;
+        default:
+          return;
+      }
+
+      if (handled) {
+        event.preventDefault();
+        this.updateValue(newValue);
+      }
+    }
+
+    private handleInput() {
+      if (this.isComposing || !this.input) return;
+
+      const parsed = parseFloat(this.input.value);
+      if (!isNaN(parsed)) {
+        const clampedValue = this.clamp(this.roundToStep(parsed));
+        this.input.setAttribute('aria-valuenow', String(clampedValue));
+        if (this.format) {
+          this.input.setAttribute('aria-valuetext', this.formatValue(clampedValue));
+        }
+        this.previousValidValue = clampedValue;
+        this.dispatchEvent(
+          new CustomEvent('valuechange', {
+            detail: { value: clampedValue },
+            bubbles: true,
+          })
+        );
+      }
+    }
+
+    private handleBlur() {
+      if (!this.input) return;
+
+      const parsed = parseFloat(this.input.value);
+
+      if (isNaN(parsed)) {
+        this.input.value = String(this.previousValidValue);
+        this.input.setAttribute('aria-valuenow', String(this.previousValidValue));
+      } else {
+        const newValue = this.clamp(this.roundToStep(parsed));
+        this.input.value = String(newValue);
+        this.input.setAttribute('aria-valuenow', String(newValue));
+        if (this.format) {
+          this.input.setAttribute('aria-valuetext', this.formatValue(newValue));
+        }
+        if (newValue !== this.previousValidValue) {
+          this.previousValidValue = newValue;
+          this.dispatchEvent(
+            new CustomEvent('valuechange', {
+              detail: { value: newValue },
+              bubbles: true,
+            })
+          );
+        }
+      }
+    }
+
+    private handleCompositionStart() {
+      this.isComposing = true;
+    }
+
+    private handleCompositionEnd() {
+      this.isComposing = false;
+      this.handleInput();
+    }
+
+    private handleIncrement(event: MouseEvent) {
+      event.preventDefault();
+      if (this.isDisabled || this.isReadOnly) return;
+      this.updateValue(this.currentValue + this.step);
+      this.input?.focus();
+    }
+
+    private handleDecrement(event: MouseEvent) {
+      event.preventDefault();
+      if (this.isDisabled || this.isReadOnly) return;
+      this.updateValue(this.currentValue - this.step);
+      this.input?.focus();
+    }
+
+    setValue(newValue: number) {
+      this.updateValue(newValue);
+    }
+
+    // Expose for testing
+    get _input() {
+      return this.input;
+    }
+    get _isComposing() {
+      return this.isComposing;
+    }
+  }
+
+  function createSpinbuttonHTML(
+    options: {
+      defaultValue?: number;
+      min?: number;
+      max?: number;
+      step?: number;
+      largeStep?: number;
+      disabled?: boolean;
+      readOnly?: boolean;
+      showButtons?: boolean;
+      label?: string;
+      valueText?: string;
+      format?: string;
+      id?: string;
+      ariaLabel?: string;
+      ariaLabelledby?: string;
+      ariaDescribedby?: string;
+    } = {}
+  ) {
+    const {
+      defaultValue = 0,
+      min,
+      max,
+      step = 1,
+      largeStep,
+      disabled = false,
+      readOnly = false,
+      showButtons = true,
+      label,
+      valueText,
+      format,
+      id,
+      ariaLabel,
+      ariaLabelledby,
+      ariaDescribedby,
+    } = options;
+
+    // Utility functions
+    const clamp = (val: number, minVal?: number, maxVal?: number): number => {
+      let result = val;
+      if (minVal !== undefined) result = Math.max(minVal, result);
+      if (maxVal !== undefined) result = Math.min(maxVal, result);
+      return result;
+    };
+
+    const roundToStep = (val: number, stepVal: number, minVal?: number): number => {
+      const base = minVal ?? 0;
+      const steps = Math.round((val - base) / stepVal);
+      const result = base + steps * stepVal;
+      const decimalPlaces = (stepVal.toString().split('.')[1] || '').length;
+      return Number(result.toFixed(decimalPlaces));
+    };
+
+    const formatValueText = (value: number, formatStr?: string): string => {
+      if (!formatStr) return String(value);
+      return formatStr
+        .replace('{value}', String(value))
+        .replace('{min}', min !== undefined ? String(min) : '')
+        .replace('{max}', max !== undefined ? String(max) : '');
+    };
+
+    const initialValue = clamp(roundToStep(defaultValue, step, min), min, max);
+    const effectiveLargeStep = largeStep ?? step * 10;
+    const labelId = label
+      ? `spinbutton-label-${Math.random().toString(36).slice(2, 9)}`
+      : undefined;
+    const initialAriaValueText =
+      valueText ?? (format ? formatValueText(initialValue, format) : undefined);
+
+    return `
+      <apg-spinbutton
+        ${min !== undefined ? `data-min="${min}"` : ''}
+        ${max !== undefined ? `data-max="${max}"` : ''}
+        data-step="${step}"
+        data-large-step="${effectiveLargeStep}"
+        data-disabled="${disabled}"
+        data-readonly="${readOnly}"
+        ${format ? `data-format="${format}"` : ''}
+      >
+        <div class="apg-spinbutton ${disabled ? 'apg-spinbutton--disabled' : ''}">
+          ${label ? `<span id="${labelId}" class="apg-spinbutton-label">${label}</span>` : ''}
+          <div class="apg-spinbutton-controls">
+            ${
+              showButtons
+                ? `
+              <button
+                type="button"
+                tabindex="-1"
+                aria-label="Decrement"
+                ${disabled ? 'disabled' : ''}
+                class="apg-spinbutton-button apg-spinbutton-decrement"
+              >
+                −
+              </button>
+            `
+                : ''
+            }
+            <input
+              type="text"
+              role="spinbutton"
+              ${id ? `id="${id}"` : ''}
+              tabindex="${disabled ? -1 : 0}"
+              inputmode="numeric"
+              value="${initialValue}"
+              ${readOnly ? 'readonly' : ''}
+              aria-valuenow="${initialValue}"
+              ${min !== undefined ? `aria-valuemin="${min}"` : ''}
+              ${max !== undefined ? `aria-valuemax="${max}"` : ''}
+              ${initialAriaValueText ? `aria-valuetext="${initialAriaValueText}"` : ''}
+              ${!label && ariaLabel ? `aria-label="${ariaLabel}"` : ''}
+              ${ariaLabelledby ? `aria-labelledby="${ariaLabelledby}"` : label ? `aria-labelledby="${labelId}"` : ''}
+              ${ariaDescribedby ? `aria-describedby="${ariaDescribedby}"` : ''}
+              ${disabled ? 'aria-disabled="true"' : ''}
+              ${readOnly ? 'aria-readonly="true"' : ''}
+              class="apg-spinbutton-input"
+            />
+            ${
+              showButtons
+                ? `
+              <button
+                type="button"
+                tabindex="-1"
+                aria-label="Increment"
+                ${disabled ? 'disabled' : ''}
+                class="apg-spinbutton-button apg-spinbutton-increment"
+              >
+                +
+              </button>
+            `
+                : ''
+            }
+          </div>
+        </div>
+      </apg-spinbutton>
+    `;
+  }
+
+  beforeEach(() => {
+    if (!customElements.get('apg-spinbutton')) {
+      customElements.define('apg-spinbutton', TestApgSpinbutton);
+    }
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  // 🔴 High Priority: ARIA Attributes
+  describe('ARIA Attributes', () => {
+    it('has role="spinbutton"', () => {
+      container.innerHTML = createSpinbuttonHTML();
+      expect(container.querySelector('[role="spinbutton"]')).not.toBeNull();
+    });
+
+    it('has aria-valuenow set to current value', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 50 });
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+      expect(spinbutton?.getAttribute('aria-valuenow')).toBe('50');
+    });
+
+    it('has aria-valuenow set to 0 when no defaultValue', () => {
+      container.innerHTML = createSpinbuttonHTML();
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+      expect(spinbutton?.getAttribute('aria-valuenow')).toBe('0');
+    });
+
+    it('has aria-valuemin set when min is provided', () => {
+      container.innerHTML = createSpinbuttonHTML({ min: 0 });
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+      expect(spinbutton?.getAttribute('aria-valuemin')).toBe('0');
+    });
+
+    it('does not have aria-valuemin when min is not provided', () => {
+      container.innerHTML = createSpinbuttonHTML();
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+      expect(spinbutton?.hasAttribute('aria-valuemin')).toBe(false);
+    });
+
+    it('has aria-valuemax set when max is provided', () => {
+      container.innerHTML = createSpinbuttonHTML({ max: 100 });
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+      expect(spinbutton?.getAttribute('aria-valuemax')).toBe('100');
+    });
+
+    it('does not have aria-valuemax when max is not provided', () => {
+      container.innerHTML = createSpinbuttonHTML();
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+      expect(spinbutton?.hasAttribute('aria-valuemax')).toBe(false);
+    });
+
+    it('has aria-valuetext when valueText provided', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 5, valueText: '5 items' });
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+      expect(spinbutton?.getAttribute('aria-valuetext')).toBe('5 items');
+    });
+
+    it('has aria-valuetext when format provided', () => {
+      container.innerHTML = createSpinbuttonHTML({
+        defaultValue: 5,
+        min: 0,
+        max: 10,
+        format: '{value} of {max}',
+      });
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+      expect(spinbutton?.getAttribute('aria-valuetext')).toBe('5 of 10');
+    });
+
+    it('does not have aria-valuetext when not provided', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 50 });
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+      expect(spinbutton?.hasAttribute('aria-valuetext')).toBe(false);
+    });
+
+    it('has aria-disabled="true" when disabled', () => {
+      container.innerHTML = createSpinbuttonHTML({ disabled: true });
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+      expect(spinbutton?.getAttribute('aria-disabled')).toBe('true');
+    });
+
+    it('does not have aria-disabled when not disabled', () => {
+      container.innerHTML = createSpinbuttonHTML({ disabled: false });
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+      expect(spinbutton?.hasAttribute('aria-disabled')).toBe(false);
+    });
+
+    it('has aria-readonly="true" when read-only', () => {
+      container.innerHTML = createSpinbuttonHTML({ readOnly: true });
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+      expect(spinbutton?.getAttribute('aria-readonly')).toBe('true');
+    });
+
+    it('does not have aria-readonly when not read-only', () => {
+      container.innerHTML = createSpinbuttonHTML({ readOnly: false });
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+      expect(spinbutton?.hasAttribute('aria-readonly')).toBe(false);
+    });
+  });
+
+  // 🔴 High Priority: Accessible Name
+  describe('Accessible Name', () => {
+    it('has accessible name via aria-label', () => {
+      container.innerHTML = createSpinbuttonHTML({ ariaLabel: 'Quantity' });
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+      expect(spinbutton?.getAttribute('aria-label')).toBe('Quantity');
+    });
+
+    it('has accessible name via aria-labelledby', () => {
+      container.innerHTML = createSpinbuttonHTML({ ariaLabelledby: 'external-label' });
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+      expect(spinbutton?.getAttribute('aria-labelledby')).toBe('external-label');
+    });
+
+    it('has accessible name via visible label', () => {
+      container.innerHTML = createSpinbuttonHTML({ label: 'Item Count' });
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+      expect(spinbutton?.hasAttribute('aria-labelledby')).toBe(true);
+      expect(container.querySelector('.apg-spinbutton-label')?.textContent).toBe('Item Count');
+    });
+
+    it('has aria-describedby when provided', () => {
+      container.innerHTML = createSpinbuttonHTML({ ariaDescribedby: 'help-text' });
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+      expect(spinbutton?.getAttribute('aria-describedby')).toBe('help-text');
+    });
+  });
+
+  // 🔴 High Priority: Keyboard Interaction
+  describe('Keyboard Interaction', () => {
+    it('increases value by step on ArrowUp', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 50, step: 1 });
+      const spinbutton = container.querySelector('[role="spinbutton"]') as HTMLElement;
+
+      const event = new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true });
+      spinbutton.dispatchEvent(event);
+
+      expect(spinbutton.getAttribute('aria-valuenow')).toBe('51');
+    });
+
+    it('decreases value by step on ArrowDown', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 50, step: 1 });
+      const spinbutton = container.querySelector('[role="spinbutton"]') as HTMLElement;
+
+      const event = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
+      spinbutton.dispatchEvent(event);
+
+      expect(spinbutton.getAttribute('aria-valuenow')).toBe('49');
+    });
+
+    it('sets min value on Home when min is defined', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 50, min: 0 });
+      const spinbutton = container.querySelector('[role="spinbutton"]') as HTMLElement;
+
+      const event = new KeyboardEvent('keydown', { key: 'Home', bubbles: true });
+      spinbutton.dispatchEvent(event);
+
+      expect(spinbutton.getAttribute('aria-valuenow')).toBe('0');
+    });
+
+    it('does not change value on Home when min is not defined', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 50 });
+      const spinbutton = container.querySelector('[role="spinbutton"]') as HTMLElement;
+
+      const event = new KeyboardEvent('keydown', { key: 'Home', bubbles: true });
+      spinbutton.dispatchEvent(event);
+
+      expect(spinbutton.getAttribute('aria-valuenow')).toBe('50');
+    });
+
+    it('sets max value on End when max is defined', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 50, max: 100 });
+      const spinbutton = container.querySelector('[role="spinbutton"]') as HTMLElement;
+
+      const event = new KeyboardEvent('keydown', { key: 'End', bubbles: true });
+      spinbutton.dispatchEvent(event);
+
+      expect(spinbutton.getAttribute('aria-valuenow')).toBe('100');
+    });
+
+    it('does not change value on End when max is not defined', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 50 });
+      const spinbutton = container.querySelector('[role="spinbutton"]') as HTMLElement;
+
+      const event = new KeyboardEvent('keydown', { key: 'End', bubbles: true });
+      spinbutton.dispatchEvent(event);
+
+      expect(spinbutton.getAttribute('aria-valuenow')).toBe('50');
+    });
+
+    it('increases value by large step on PageUp', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 50, step: 1 });
+      const spinbutton = container.querySelector('[role="spinbutton"]') as HTMLElement;
+
+      const event = new KeyboardEvent('keydown', { key: 'PageUp', bubbles: true });
+      spinbutton.dispatchEvent(event);
+
+      expect(spinbutton.getAttribute('aria-valuenow')).toBe('60');
+    });
+
+    it('decreases value by large step on PageDown', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 50, step: 1 });
+      const spinbutton = container.querySelector('[role="spinbutton"]') as HTMLElement;
+
+      const event = new KeyboardEvent('keydown', { key: 'PageDown', bubbles: true });
+      spinbutton.dispatchEvent(event);
+
+      expect(spinbutton.getAttribute('aria-valuenow')).toBe('40');
+    });
+
+    it('does not exceed max on ArrowUp', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 100, max: 100 });
+      const spinbutton = container.querySelector('[role="spinbutton"]') as HTMLElement;
+
+      const event = new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true });
+      spinbutton.dispatchEvent(event);
+
+      expect(spinbutton.getAttribute('aria-valuenow')).toBe('100');
+    });
+
+    it('does not go below min on ArrowDown', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 0, min: 0 });
+      const spinbutton = container.querySelector('[role="spinbutton"]') as HTMLElement;
+
+      const event = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
+      spinbutton.dispatchEvent(event);
+
+      expect(spinbutton.getAttribute('aria-valuenow')).toBe('0');
+    });
+
+    it('allows values beyond default range when no min/max', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 0 });
+      const spinbutton = container.querySelector('[role="spinbutton"]') as HTMLElement;
+
+      // Can go negative
+      const downEvent = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
+      spinbutton.dispatchEvent(downEvent);
+      expect(spinbutton.getAttribute('aria-valuenow')).toBe('-1');
+
+      // Can go positive without limit
+      for (let i = 0; i < 200; i++) {
+        const upEvent = new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true });
+        spinbutton.dispatchEvent(upEvent);
+      }
+      expect(spinbutton.getAttribute('aria-valuenow')).toBe('199');
+    });
+
+    it('does not change value when disabled', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 50, disabled: true });
+      const spinbutton = container.querySelector('[role="spinbutton"]') as HTMLElement;
+
+      const event = new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true });
+      spinbutton.dispatchEvent(event);
+
+      expect(spinbutton.getAttribute('aria-valuenow')).toBe('50');
+    });
+
+    it('does not change value with arrow keys when read-only', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 50, readOnly: true });
+      const spinbutton = container.querySelector('[role="spinbutton"]') as HTMLElement;
+
+      const event = new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true });
+      spinbutton.dispatchEvent(event);
+
+      expect(spinbutton.getAttribute('aria-valuenow')).toBe('50');
+    });
+
+    it('allows Home/End navigation when read-only', () => {
+      container.innerHTML = createSpinbuttonHTML({
+        defaultValue: 50,
+        min: 0,
+        max: 100,
+        readOnly: true,
+      });
+      const spinbutton = container.querySelector('[role="spinbutton"]') as HTMLElement;
+
+      const homeEvent = new KeyboardEvent('keydown', { key: 'Home', bubbles: true });
+      spinbutton.dispatchEvent(homeEvent);
+
+      expect(spinbutton.getAttribute('aria-valuenow')).toBe('0');
+
+      const endEvent = new KeyboardEvent('keydown', { key: 'End', bubbles: true });
+      spinbutton.dispatchEvent(endEvent);
+
+      expect(spinbutton.getAttribute('aria-valuenow')).toBe('100');
+    });
+  });
+
+  // 🔴 High Priority: Focus Management
+  describe('Focus Management', () => {
+    it('has tabindex="0" on input', () => {
+      container.innerHTML = createSpinbuttonHTML();
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+      expect(spinbutton?.getAttribute('tabindex')).toBe('0');
+    });
+
+    it('has tabindex="-1" when disabled', () => {
+      container.innerHTML = createSpinbuttonHTML({ disabled: true });
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+      expect(spinbutton?.getAttribute('tabindex')).toBe('-1');
+    });
+
+    it('has tabindex="-1" on buttons', () => {
+      container.innerHTML = createSpinbuttonHTML({ showButtons: true });
+      const incrementBtn = container.querySelector('.apg-spinbutton-increment');
+      const decrementBtn = container.querySelector('.apg-spinbutton-decrement');
+      expect(incrementBtn?.getAttribute('tabindex')).toBe('-1');
+      expect(decrementBtn?.getAttribute('tabindex')).toBe('-1');
+    });
+  });
+
+  // 🔴 High Priority: Button Interaction
+  describe('Button Interaction', () => {
+    it('shows increment and decrement buttons by default', () => {
+      container.innerHTML = createSpinbuttonHTML();
+      expect(container.querySelector('.apg-spinbutton-increment')).not.toBeNull();
+      expect(container.querySelector('.apg-spinbutton-decrement')).not.toBeNull();
+    });
+
+    it('hides buttons when showButtons is false', () => {
+      container.innerHTML = createSpinbuttonHTML({ showButtons: false });
+      expect(container.querySelector('.apg-spinbutton-increment')).toBeNull();
+      expect(container.querySelector('.apg-spinbutton-decrement')).toBeNull();
+    });
+
+    it('increments value on increment button click', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 50, step: 1 });
+      const incrementBtn = container.querySelector('.apg-spinbutton-increment') as HTMLElement;
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+
+      incrementBtn.click();
+
+      expect(spinbutton?.getAttribute('aria-valuenow')).toBe('51');
+    });
+
+    it('decrements value on decrement button click', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 50, step: 1 });
+      const decrementBtn = container.querySelector('.apg-spinbutton-decrement') as HTMLElement;
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+
+      decrementBtn.click();
+
+      expect(spinbutton?.getAttribute('aria-valuenow')).toBe('49');
+    });
+
+    it('does not change value on button click when disabled', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 50, disabled: true });
+      const incrementBtn = container.querySelector('.apg-spinbutton-increment') as HTMLElement;
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+
+      incrementBtn.click();
+
+      expect(spinbutton?.getAttribute('aria-valuenow')).toBe('50');
+    });
+
+    it('does not change value on button click when read-only', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 50, readOnly: true });
+      const incrementBtn = container.querySelector('.apg-spinbutton-increment') as HTMLElement;
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+
+      incrementBtn.click();
+
+      expect(spinbutton?.getAttribute('aria-valuenow')).toBe('50');
+    });
+
+    it('has accessible label on increment button', () => {
+      container.innerHTML = createSpinbuttonHTML();
+      const incrementBtn = container.querySelector('.apg-spinbutton-increment');
+      expect(incrementBtn?.getAttribute('aria-label')).toBe('Increment');
+    });
+
+    it('has accessible label on decrement button', () => {
+      container.innerHTML = createSpinbuttonHTML();
+      const decrementBtn = container.querySelector('.apg-spinbutton-decrement');
+      expect(decrementBtn?.getAttribute('aria-label')).toBe('Decrement');
+    });
+  });
+
+  // 🟡 Medium Priority: Text Input
+  describe('Text Input', () => {
+    it('has inputmode="numeric" for mobile keyboard', () => {
+      container.innerHTML = createSpinbuttonHTML();
+      const input = container.querySelector('[role="spinbutton"]');
+      expect(input?.getAttribute('inputmode')).toBe('numeric');
+    });
+
+    it('updates aria-valuenow on valid text input', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 0 });
+      const input = container.querySelector('[role="spinbutton"]') as HTMLInputElement;
+
+      input.value = '42';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+
+      expect(input.getAttribute('aria-valuenow')).toBe('42');
+    });
+
+    it('clamps input value to min/max', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 50, min: 0, max: 100 });
+      const input = container.querySelector('[role="spinbutton"]') as HTMLInputElement;
+
+      input.value = '150';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+
+      expect(input.getAttribute('aria-valuenow')).toBe('100');
+    });
+
+    it('reverts to previous value on blur with invalid input', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 50 });
+      const input = container.querySelector('[role="spinbutton"]') as HTMLInputElement;
+
+      input.value = 'abc';
+      input.dispatchEvent(new Event('blur', { bubbles: true }));
+
+      expect(input.value).toBe('50');
+      expect(input.getAttribute('aria-valuenow')).toBe('50');
+    });
+
+    it('normalizes value on blur', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 0, min: 0, max: 100, step: 5 });
+      const input = container.querySelector('[role="spinbutton"]') as HTMLInputElement;
+
+      input.value = '53';
+      input.dispatchEvent(new Event('blur', { bubbles: true }));
+
+      expect(input.value).toBe('55');
+      expect(input.getAttribute('aria-valuenow')).toBe('55');
+    });
+  });
+
+  // 🟡 Medium Priority: IME Composition
+  describe('IME Composition', () => {
+    it('does not update value during IME composition', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 50 });
+      const input = container.querySelector('[role="spinbutton"]') as HTMLInputElement;
+
+      input.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+      input.value = '123';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+
+      expect(input.getAttribute('aria-valuenow')).toBe('50');
+    });
+
+    it('updates value on composition end', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 50 });
+      const input = container.querySelector('[role="spinbutton"]') as HTMLInputElement;
+
+      input.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+      input.value = '75';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+
+      expect(input.getAttribute('aria-valuenow')).toBe('50');
+
+      input.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }));
+
+      expect(input.getAttribute('aria-valuenow')).toBe('75');
+    });
+  });
+
+  // 🟡 Medium Priority: Events
+  describe('Events', () => {
+    it('dispatches valuechange event on value change', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 50 });
+      const component = container.querySelector('apg-spinbutton') as TestApgSpinbutton;
+      const spinbutton = container.querySelector('[role="spinbutton"]') as HTMLElement;
+
+      const eventHandler = vi.fn();
+      component.addEventListener('valuechange', eventHandler);
+
+      const event = new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true });
+      spinbutton.dispatchEvent(event);
+
+      expect(eventHandler).toHaveBeenCalled();
+      expect(eventHandler.mock.calls[0][0].detail.value).toBe(51);
+    });
+
+    it('does not dispatch event when value does not change', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 100, max: 100 });
+      const component = container.querySelector('apg-spinbutton') as TestApgSpinbutton;
+      const spinbutton = container.querySelector('[role="spinbutton"]') as HTMLElement;
+
+      const eventHandler = vi.fn();
+      component.addEventListener('valuechange', eventHandler);
+
+      const event = new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true });
+      spinbutton.dispatchEvent(event);
+
+      expect(eventHandler).not.toHaveBeenCalled();
+    });
+
+    it('dispatches valuechange on text input', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 0 });
+      const component = container.querySelector('apg-spinbutton') as TestApgSpinbutton;
+      const input = container.querySelector('[role="spinbutton"]') as HTMLInputElement;
+
+      const eventHandler = vi.fn();
+      component.addEventListener('valuechange', eventHandler);
+
+      input.value = '25';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+
+      expect(eventHandler).toHaveBeenCalled();
+      expect(eventHandler.mock.calls[0][0].detail.value).toBe(25);
+    });
+
+    it('dispatches valuechange on button click', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 50 });
+      const component = container.querySelector('apg-spinbutton') as TestApgSpinbutton;
+      const incrementBtn = container.querySelector('.apg-spinbutton-increment') as HTMLElement;
+
+      const eventHandler = vi.fn();
+      component.addEventListener('valuechange', eventHandler);
+
+      incrementBtn.click();
+
+      expect(eventHandler).toHaveBeenCalled();
+      expect(eventHandler.mock.calls[0][0].detail.value).toBe(51);
+    });
+  });
+
+  // 🟡 Medium Priority: Edge Cases
+  describe('Edge Cases', () => {
+    it('handles decimal step values correctly', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 0.5, min: 0, max: 1, step: 0.1 });
+      const spinbutton = container.querySelector('[role="spinbutton"]') as HTMLElement;
+
+      const event = new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true });
+      spinbutton.dispatchEvent(event);
+
+      expect(spinbutton.getAttribute('aria-valuenow')).toBe('0.6');
+    });
+
+    it('clamps value to min/max on init', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: -10, min: 0, max: 100 });
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+      expect(spinbutton?.getAttribute('aria-valuenow')).toBe('0');
+    });
+
+    it('rounds value to step on init', () => {
+      container.innerHTML = createSpinbuttonHTML({ defaultValue: 53, min: 0, max: 100, step: 5 });
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+      expect(spinbutton?.getAttribute('aria-valuenow')).toBe('55');
+    });
+
+    it('uses custom large step when provided', () => {
+      container.innerHTML = createSpinbuttonHTML({
+        defaultValue: 50,
+        step: 1,
+        largeStep: 20,
+      });
+      const spinbutton = container.querySelector('[role="spinbutton"]') as HTMLElement;
+
+      const event = new KeyboardEvent('keydown', { key: 'PageUp', bubbles: true });
+      spinbutton.dispatchEvent(event);
+
+      expect(spinbutton.getAttribute('aria-valuenow')).toBe('70');
+    });
+  });
+
+  // 🟡 Medium Priority: Format
+  describe('Format', () => {
+    it('updates aria-valuetext with format on value change', () => {
+      container.innerHTML = createSpinbuttonHTML({
+        defaultValue: 5,
+        min: 0,
+        max: 10,
+        format: '{value} of {max}',
+      });
+      const spinbutton = container.querySelector('[role="spinbutton"]') as HTMLElement;
+
+      expect(spinbutton.getAttribute('aria-valuetext')).toBe('5 of 10');
+
+      const event = new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true });
+      spinbutton.dispatchEvent(event);
+
+      expect(spinbutton.getAttribute('aria-valuetext')).toBe('6 of 10');
+    });
+  });
+
+  // 🟢 Low Priority: HTML Attributes
+  describe('HTML Attributes', () => {
+    it('sets id attribute', () => {
+      container.innerHTML = createSpinbuttonHTML({ id: 'my-spinbutton' });
+      const spinbutton = container.querySelector('[role="spinbutton"]');
+      expect(spinbutton?.getAttribute('id')).toBe('my-spinbutton');
+    });
+
+    it('has readonly attribute when read-only', () => {
+      container.innerHTML = createSpinbuttonHTML({ readOnly: true });
+      const input = container.querySelector('[role="spinbutton"]') as HTMLInputElement;
+      expect(input.readOnly).toBe(true);
+    });
+
+    it('displays visible label when label provided', () => {
+      container.innerHTML = createSpinbuttonHTML({ label: 'Quantity' });
+      expect(container.querySelector('.apg-spinbutton-label')?.textContent).toBe('Quantity');
+    });
+  });
+});

--- a/src/patterns/spinbutton/Spinbutton.test.svelte.ts
+++ b/src/patterns/spinbutton/Spinbutton.test.svelte.ts
@@ -1,0 +1,558 @@
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+import Spinbutton from './Spinbutton.svelte';
+import SpinbuttonWithLabel from './SpinbuttonWithLabel.test.svelte';
+
+describe('Spinbutton (Svelte)', () => {
+  // 🔴 High Priority: ARIA Attributes
+  describe('ARIA Attributes', () => {
+    it('has role="spinbutton"', () => {
+      render(Spinbutton, {
+        props: { 'aria-label': 'Quantity' },
+      });
+      expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+    });
+
+    it('has aria-valuenow set to current value', () => {
+      render(Spinbutton, {
+        props: { defaultValue: 5, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '5');
+    });
+
+    it('has aria-valuenow set to 0 when no defaultValue', () => {
+      render(Spinbutton, {
+        props: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('has aria-valuemin when min is defined', () => {
+      render(Spinbutton, {
+        props: { min: 0, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuemin', '0');
+    });
+
+    it('does not have aria-valuemin when min is undefined', () => {
+      render(Spinbutton, {
+        props: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).not.toHaveAttribute('aria-valuemin');
+    });
+
+    it('has aria-valuemax when max is defined', () => {
+      render(Spinbutton, {
+        props: { max: 100, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuemax', '100');
+    });
+
+    it('does not have aria-valuemax when max is undefined', () => {
+      render(Spinbutton, {
+        props: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).not.toHaveAttribute('aria-valuemax');
+    });
+
+    it('has aria-valuetext when valueText provided', () => {
+      render(Spinbutton, {
+        props: { defaultValue: 5, valueText: '5 items', 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuetext', '5 items');
+    });
+
+    it('does not have aria-valuetext when not provided', () => {
+      render(Spinbutton, {
+        props: { defaultValue: 5, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).not.toHaveAttribute('aria-valuetext');
+    });
+
+    it('uses format for aria-valuetext', () => {
+      render(Spinbutton, {
+        props: { defaultValue: 5, format: '{value} items', 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuetext', '5 items');
+    });
+
+    it('has aria-disabled="true" when disabled', () => {
+      render(Spinbutton, {
+        props: { disabled: true, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('does not have aria-disabled when not disabled', () => {
+      render(Spinbutton, {
+        props: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).not.toHaveAttribute('aria-disabled');
+    });
+
+    it('has aria-readonly="true" when readOnly', () => {
+      render(Spinbutton, {
+        props: { readOnly: true, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-readonly', 'true');
+    });
+  });
+
+  // 🔴 High Priority: Accessible Name
+  describe('Accessible Name', () => {
+    it('has accessible name via aria-label', () => {
+      render(Spinbutton, {
+        props: { 'aria-label': 'Quantity' },
+      });
+      expect(screen.getByRole('spinbutton', { name: 'Quantity' })).toBeInTheDocument();
+    });
+
+    it('has accessible name via aria-labelledby', () => {
+      render(SpinbuttonWithLabel);
+      expect(screen.getByRole('spinbutton', { name: 'Item Count' })).toBeInTheDocument();
+    });
+
+    it('has accessible name via visible label', () => {
+      render(Spinbutton, {
+        props: { label: 'Quantity' },
+      });
+      expect(screen.getByRole('spinbutton', { name: 'Quantity' })).toBeInTheDocument();
+    });
+  });
+
+  // 🔴 High Priority: Keyboard Interaction
+  describe('Keyboard Interaction', () => {
+    it('increases value by step on ArrowUp', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 5, step: 1, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '6');
+    });
+
+    it('decreases value by step on ArrowDown', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 5, step: 1, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowDown}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '4');
+    });
+
+    it('sets min value on Home when min is defined', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 50, min: 0, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{Home}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('Home key has no effect when min is undefined', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 50, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{Home}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '50');
+    });
+
+    it('sets max value on End when max is defined', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 50, max: 100, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{End}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '100');
+    });
+
+    it('End key has no effect when max is undefined', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 50, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{End}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '50');
+    });
+
+    it('increases value by large step on PageUp', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 50, step: 1, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{PageUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '60');
+    });
+
+    it('decreases value by large step on PageDown', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 50, step: 1, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{PageDown}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '40');
+    });
+
+    it('does not exceed max on ArrowUp', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 100, max: 100, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '100');
+    });
+
+    it('does not go below min on ArrowDown', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 0, min: 0, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowDown}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('does not change value when disabled', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 5, disabled: true, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      spinbutton.focus();
+      await user.keyboard('{ArrowUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '5');
+    });
+
+    it('does not change value on ArrowUp/Down when readOnly', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 5, readOnly: true, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '5');
+    });
+  });
+
+  // 🔴 High Priority: Focus Management
+  describe('Focus Management', () => {
+    it('has tabindex="0" on input', () => {
+      render(Spinbutton, {
+        props: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('tabindex', '0');
+    });
+
+    it('has tabindex="-1" when disabled', () => {
+      render(Spinbutton, {
+        props: { disabled: true, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('buttons have tabindex="-1"', () => {
+      render(Spinbutton, {
+        props: { showButtons: true, 'aria-label': 'Quantity' },
+      });
+      const buttons = screen.getAllByRole('button');
+      buttons.forEach((button) => {
+        expect(button).toHaveAttribute('tabindex', '-1');
+      });
+    });
+
+    it('focus stays on spinbutton after increment button click', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 5, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      const incrementButton = screen.getByLabelText(/increment/i);
+
+      await user.click(spinbutton);
+      await user.click(incrementButton);
+
+      expect(spinbutton).toHaveFocus();
+    });
+  });
+
+  // 🟡 Medium Priority: Button Interaction
+  describe('Button Interaction', () => {
+    it('increases value on increment button click', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 5, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      const incrementButton = screen.getByLabelText(/increment/i);
+
+      await user.click(incrementButton);
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '6');
+    });
+
+    it('decreases value on decrement button click', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 5, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      const decrementButton = screen.getByLabelText(/decrement/i);
+
+      await user.click(decrementButton);
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '4');
+    });
+
+    it('hides buttons when showButtons is false', () => {
+      render(Spinbutton, {
+        props: { showButtons: false, 'aria-label': 'Quantity' },
+      });
+      expect(screen.queryByLabelText(/increment/i)).not.toBeInTheDocument();
+      expect(screen.queryByLabelText(/decrement/i)).not.toBeInTheDocument();
+    });
+  });
+
+  // 🟡 Medium Priority: Text Input
+  describe('Text Input', () => {
+    it('accepts direct text input', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 5, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.clear(spinbutton);
+      await user.type(spinbutton, '42');
+      await user.tab();
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '42');
+    });
+
+    it('reverts to previous value on invalid input', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 5, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.clear(spinbutton);
+      await user.type(spinbutton, 'abc');
+      await user.tab();
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '5');
+    });
+
+    it('clamps value to max on valid input exceeding max', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 5, max: 10, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.clear(spinbutton);
+      await user.type(spinbutton, '999');
+      await user.tab();
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '10');
+    });
+  });
+
+  // 🟡 Medium Priority: Accessibility
+  describe('Accessibility', () => {
+    it('has no axe violations', async () => {
+      const { container } = render(Spinbutton, {
+        props: { 'aria-label': 'Quantity' },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with visible label', async () => {
+      const { container } = render(Spinbutton, {
+        props: { label: 'Quantity' },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations when disabled', async () => {
+      const { container } = render(Spinbutton, {
+        props: { disabled: true, 'aria-label': 'Quantity' },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  // 🟡 Medium Priority: Callbacks
+  describe('Callbacks', () => {
+    it('calls onvaluechange on keyboard interaction', async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 5, onvaluechange: handleChange, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowUp}');
+
+      expect(handleChange).toHaveBeenCalledWith(6);
+    });
+
+    it('calls onvaluechange on button click', async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 5, onvaluechange: handleChange, 'aria-label': 'Quantity' },
+      });
+      const incrementButton = screen.getByLabelText(/increment/i);
+
+      await user.click(incrementButton);
+
+      expect(handleChange).toHaveBeenCalledWith(6);
+    });
+  });
+
+  // 🟡 Medium Priority: Edge Cases
+  describe('Edge Cases', () => {
+    it('handles decimal step values correctly', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 0.5, step: 0.1, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '0.6');
+    });
+
+    it('handles negative values', () => {
+      render(Spinbutton, {
+        props: { defaultValue: -5, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '-5');
+    });
+
+    it('allows value beyond range when min/max undefined', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 1000, 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '1001');
+    });
+  });
+
+  // 🟡 Medium Priority: Visual Display
+  describe('Visual Display', () => {
+    it('displays visible label when label provided', () => {
+      render(Spinbutton, {
+        props: { label: 'Quantity' },
+      });
+      expect(screen.getByText('Quantity')).toBeInTheDocument();
+    });
+
+    it('has inputmode="numeric"', () => {
+      render(Spinbutton, {
+        props: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('inputmode', 'numeric');
+    });
+  });
+
+  // 🟢 Low Priority: HTML Attribute Inheritance
+  describe('HTML Attribute Inheritance', () => {
+    it('applies className to container', () => {
+      render(Spinbutton, {
+        props: { 'aria-label': 'Quantity', class: 'custom-spinbutton' },
+      });
+      const container = screen.getByRole('spinbutton').closest('.apg-spinbutton');
+      expect(container).toHaveClass('custom-spinbutton');
+    });
+
+    it('sets id attribute on spinbutton element', () => {
+      render(Spinbutton, {
+        props: { 'aria-label': 'Quantity', id: 'my-spinbutton' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('id', 'my-spinbutton');
+    });
+
+    it('passes through data-testid', () => {
+      render(Spinbutton, {
+        props: { 'aria-label': 'Quantity', 'data-testid': 'custom-spinbutton' },
+      });
+      expect(screen.getByTestId('custom-spinbutton')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/patterns/spinbutton/Spinbutton.test.tsx
+++ b/src/patterns/spinbutton/Spinbutton.test.tsx
@@ -1,0 +1,718 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+import { Spinbutton } from './Spinbutton';
+
+describe('Spinbutton', () => {
+  // 🔴 High Priority: ARIA Attributes
+  describe('ARIA Attributes', () => {
+    it('has role="spinbutton"', () => {
+      render(<Spinbutton aria-label="Quantity" />);
+      expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+    });
+
+    it('has aria-valuenow set to current value', () => {
+      render(<Spinbutton defaultValue={5} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '5');
+    });
+
+    it('has aria-valuenow set to 0 when no defaultValue', () => {
+      render(<Spinbutton aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('has aria-valuemin when min is defined', () => {
+      render(<Spinbutton min={0} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuemin', '0');
+    });
+
+    it('does not have aria-valuemin when min is undefined', () => {
+      render(<Spinbutton aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).not.toHaveAttribute('aria-valuemin');
+    });
+
+    it('has aria-valuemax when max is defined', () => {
+      render(<Spinbutton max={100} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuemax', '100');
+    });
+
+    it('does not have aria-valuemax when max is undefined', () => {
+      render(<Spinbutton aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).not.toHaveAttribute('aria-valuemax');
+    });
+
+    it('has aria-valuetext when valueText provided', () => {
+      render(<Spinbutton defaultValue={5} valueText="5 items" aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuetext', '5 items');
+    });
+
+    it('does not have aria-valuetext when not provided', () => {
+      render(<Spinbutton defaultValue={5} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).not.toHaveAttribute('aria-valuetext');
+    });
+
+    it('uses format for aria-valuetext', () => {
+      render(<Spinbutton defaultValue={5} format="{value} items" aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuetext', '5 items');
+    });
+
+    it('updates aria-valuetext on value change', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={5} format="{value} items" aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuetext', '6 items');
+    });
+
+    it('has aria-disabled="true" when disabled', () => {
+      render(<Spinbutton disabled aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('does not have aria-disabled when not disabled', () => {
+      render(<Spinbutton aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).not.toHaveAttribute('aria-disabled');
+    });
+
+    it('has aria-readonly="true" when readOnly', () => {
+      render(<Spinbutton readOnly aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-readonly', 'true');
+    });
+
+    it('does not have aria-readonly when not readOnly', () => {
+      render(<Spinbutton aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).not.toHaveAttribute('aria-readonly');
+    });
+  });
+
+  // 🔴 High Priority: Accessible Name
+  describe('Accessible Name', () => {
+    it('has accessible name via aria-label', () => {
+      render(<Spinbutton aria-label="Quantity" />);
+      expect(screen.getByRole('spinbutton', { name: 'Quantity' })).toBeInTheDocument();
+    });
+
+    it('has accessible name via aria-labelledby', () => {
+      render(
+        <>
+          <span id="spinbutton-label">Item Count</span>
+          <Spinbutton aria-labelledby="spinbutton-label" />
+        </>
+      );
+      expect(screen.getByRole('spinbutton', { name: 'Item Count' })).toBeInTheDocument();
+    });
+
+    it('has accessible name via visible label', () => {
+      render(<Spinbutton label="Quantity" />);
+      expect(screen.getByRole('spinbutton', { name: 'Quantity' })).toBeInTheDocument();
+    });
+  });
+
+  // 🔴 High Priority: Keyboard Interaction
+  describe('Keyboard Interaction', () => {
+    it('increases value by step on ArrowUp', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={5} step={1} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '6');
+    });
+
+    it('decreases value by step on ArrowDown', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={5} step={1} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowDown}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '4');
+    });
+
+    it('sets min value on Home when min is defined', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={50} min={0} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{Home}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('Home key has no effect when min is undefined', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={50} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{Home}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '50');
+    });
+
+    it('sets max value on End when max is defined', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={50} max={100} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{End}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '100');
+    });
+
+    it('End key has no effect when max is undefined', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={50} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{End}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '50');
+    });
+
+    it('increases value by large step on PageUp', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={50} step={1} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{PageUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '60'); // default largeStep = step * 10
+    });
+
+    it('decreases value by large step on PageDown', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={50} step={1} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{PageDown}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '40');
+    });
+
+    it('uses custom largeStep when provided', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={50} step={1} largeStep={20} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{PageUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '70');
+    });
+
+    it('respects custom step value', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={50} step={5} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '55');
+    });
+
+    it('does not exceed max on ArrowUp', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={100} max={100} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '100');
+    });
+
+    it('does not go below min on ArrowDown', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={0} min={0} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowDown}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('does not change value when disabled', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={5} disabled aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      spinbutton.focus();
+      await user.keyboard('{ArrowUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '5');
+    });
+
+    it('does not change value on ArrowUp/Down when readOnly', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={5} readOnly aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '5');
+    });
+  });
+
+  // 🔴 High Priority: Focus Management
+  describe('Focus Management', () => {
+    it('has tabindex="0" on input', () => {
+      render(<Spinbutton aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('tabindex', '0');
+    });
+
+    it('has tabindex="-1" when disabled', () => {
+      render(<Spinbutton disabled aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('is focusable via Tab', async () => {
+      const user = userEvent.setup();
+      render(
+        <>
+          <button>Before</button>
+          <Spinbutton aria-label="Quantity" />
+          <button>After</button>
+        </>
+      );
+
+      await user.tab(); // Focus "Before" button
+      await user.tab(); // Focus spinbutton
+
+      expect(screen.getByRole('spinbutton')).toHaveFocus();
+    });
+
+    it('is not focusable via Tab when disabled', async () => {
+      const user = userEvent.setup();
+      render(
+        <>
+          <button>Before</button>
+          <Spinbutton disabled aria-label="Quantity" />
+          <button>After</button>
+        </>
+      );
+
+      await user.tab(); // Focus "Before" button
+      await user.tab(); // Focus "After" button (skip spinbutton)
+
+      expect(screen.getByRole('button', { name: 'After' })).toHaveFocus();
+    });
+
+    it('buttons have tabindex="-1"', () => {
+      render(<Spinbutton aria-label="Quantity" showButtons />);
+      const buttons = screen.getAllByRole('button');
+      buttons.forEach((button) => {
+        expect(button).toHaveAttribute('tabindex', '-1');
+      });
+    });
+
+    it('focus stays on spinbutton after increment button click', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={5} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      const incrementButton = screen.getByLabelText(/increment/i);
+
+      await user.click(spinbutton);
+      await user.click(incrementButton);
+
+      expect(spinbutton).toHaveFocus();
+    });
+
+    it('focus stays on spinbutton after decrement button click', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={5} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      const decrementButton = screen.getByLabelText(/decrement/i);
+
+      await user.click(spinbutton);
+      await user.click(decrementButton);
+
+      expect(spinbutton).toHaveFocus();
+    });
+  });
+
+  // 🟡 Medium Priority: Button Interaction
+  describe('Button Interaction', () => {
+    it('increases value on increment button click', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={5} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      const incrementButton = screen.getByLabelText(/increment/i);
+
+      await user.click(incrementButton);
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '6');
+    });
+
+    it('decreases value on decrement button click', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={5} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      const decrementButton = screen.getByLabelText(/decrement/i);
+
+      await user.click(decrementButton);
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '4');
+    });
+
+    it('increment button does not exceed max', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={100} max={100} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      const incrementButton = screen.getByLabelText(/increment/i);
+
+      await user.click(incrementButton);
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '100');
+    });
+
+    it('decrement button does not go below min', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={0} min={0} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      const decrementButton = screen.getByLabelText(/decrement/i);
+
+      await user.click(decrementButton);
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('buttons are disabled when component is disabled', async () => {
+      render(<Spinbutton defaultValue={5} disabled aria-label="Quantity" />);
+      const incrementButton = screen.getByLabelText(/increment/i);
+      const decrementButton = screen.getByLabelText(/decrement/i);
+
+      expect(incrementButton).toBeDisabled();
+      expect(decrementButton).toBeDisabled();
+    });
+
+    it('hides buttons when showButtons is false', () => {
+      render(<Spinbutton aria-label="Quantity" showButtons={false} />);
+      expect(screen.queryByLabelText(/increment/i)).not.toBeInTheDocument();
+      expect(screen.queryByLabelText(/decrement/i)).not.toBeInTheDocument();
+    });
+
+    it('keyboard still works when showButtons is false', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={5} aria-label="Quantity" showButtons={false} />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '6');
+    });
+  });
+
+  // 🟡 Medium Priority: Text Input
+  describe('Text Input', () => {
+    it('accepts direct text input', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={5} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.clear(spinbutton);
+      await user.type(spinbutton, '42');
+      await user.tab(); // blur to confirm
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '42');
+    });
+
+    it('reverts to previous value on invalid input', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={5} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.clear(spinbutton);
+      await user.type(spinbutton, 'abc');
+      await user.tab(); // blur to confirm
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '5');
+    });
+
+    it('clamps value to max on valid input exceeding max', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={5} max={10} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.clear(spinbutton);
+      await user.type(spinbutton, '999');
+      await user.tab(); // blur to confirm
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '10');
+    });
+
+    it('clamps value to min on valid input below min', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={5} min={0} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.clear(spinbutton);
+      await user.type(spinbutton, '-10');
+      await user.tab(); // blur to confirm
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('does not allow text input when readOnly', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={5} readOnly aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.type(spinbutton, '42');
+
+      expect(spinbutton).toHaveValue('5');
+    });
+  });
+
+  // 🟡 Medium Priority: Accessibility
+  describe('Accessibility', () => {
+    it('has no axe violations', async () => {
+      const { container } = render(<Spinbutton aria-label="Quantity" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with visible label', async () => {
+      const { container } = render(<Spinbutton label="Quantity" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with aria-labelledby', async () => {
+      const { container } = render(
+        <>
+          <span id="label">Quantity</span>
+          <Spinbutton aria-labelledby="label" />
+        </>
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations when disabled', async () => {
+      const { container } = render(<Spinbutton disabled aria-label="Quantity" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations when readOnly', async () => {
+      const { container } = render(<Spinbutton readOnly aria-label="Quantity" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with valueText', async () => {
+      const { container } = render(
+        <Spinbutton defaultValue={5} valueText="5 items" aria-label="Quantity" />
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  // 🟡 Medium Priority: Callbacks
+  describe('Callbacks', () => {
+    it('calls onValueChange on keyboard interaction', async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={5} onValueChange={handleChange} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowUp}');
+
+      expect(handleChange).toHaveBeenCalledWith(6);
+    });
+
+    it('calls onValueChange on button click', async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={5} onValueChange={handleChange} aria-label="Quantity" />);
+      const incrementButton = screen.getByLabelText(/increment/i);
+
+      await user.click(incrementButton);
+
+      expect(handleChange).toHaveBeenCalledWith(6);
+    });
+
+    it('calls onValueChange on text input', async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={5} onValueChange={handleChange} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.clear(spinbutton);
+      await user.type(spinbutton, '42');
+      await user.tab();
+
+      expect(handleChange).toHaveBeenCalledWith(42);
+    });
+
+    it('does not call onValueChange when disabled', async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <Spinbutton defaultValue={5} disabled onValueChange={handleChange} aria-label="Quantity" />
+      );
+      const spinbutton = screen.getByRole('spinbutton');
+
+      spinbutton.focus();
+      await user.keyboard('{ArrowUp}');
+
+      expect(handleChange).not.toHaveBeenCalled();
+    });
+
+    it('does not call onValueChange when value does not change', async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <Spinbutton
+          defaultValue={100}
+          max={100}
+          onValueChange={handleChange}
+          aria-label="Quantity"
+        />
+      );
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowUp}');
+
+      expect(handleChange).not.toHaveBeenCalled();
+    });
+  });
+
+  // 🟡 Medium Priority: Edge Cases
+  describe('Edge Cases', () => {
+    it('handles decimal step values correctly', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={0.5} step={0.1} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '0.6');
+    });
+
+    it('handles negative values', () => {
+      render(<Spinbutton defaultValue={-5} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '-5');
+    });
+
+    it('handles negative min/max range', () => {
+      render(<Spinbutton defaultValue={0} min={-50} max={50} aria-label="Temperature" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '0');
+      expect(spinbutton).toHaveAttribute('aria-valuemin', '-50');
+      expect(spinbutton).toHaveAttribute('aria-valuemax', '50');
+    });
+
+    it('clamps defaultValue to max when exceeding', () => {
+      render(<Spinbutton defaultValue={150} max={100} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '100');
+    });
+
+    it('clamps defaultValue to min when below', () => {
+      render(<Spinbutton defaultValue={-10} min={0} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('rounds value to step', () => {
+      render(<Spinbutton defaultValue={53} step={5} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '55');
+    });
+
+    it('allows value beyond range when min/max undefined', async () => {
+      const user = userEvent.setup();
+      render(<Spinbutton defaultValue={1000} aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '1001');
+    });
+  });
+
+  // 🟡 Medium Priority: Visual Display
+  describe('Visual Display', () => {
+    it('displays visible label when label provided', () => {
+      render(<Spinbutton label="Quantity" />);
+      expect(screen.getByText('Quantity')).toBeInTheDocument();
+    });
+
+    it('has inputmode="numeric"', () => {
+      render(<Spinbutton aria-label="Quantity" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('inputmode', 'numeric');
+    });
+  });
+
+  // 🟢 Low Priority: HTML Attribute Inheritance
+  describe('HTML Attribute Inheritance', () => {
+    it('applies className to container', () => {
+      render(<Spinbutton aria-label="Quantity" className="custom-spinbutton" />);
+      const container = screen.getByRole('spinbutton').closest('.apg-spinbutton');
+      expect(container).toHaveClass('custom-spinbutton');
+    });
+
+    it('sets id attribute on spinbutton element', () => {
+      render(<Spinbutton aria-label="Quantity" id="my-spinbutton" />);
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('id', 'my-spinbutton');
+    });
+
+    it('passes through data-* attributes', () => {
+      render(<Spinbutton aria-label="Quantity" data-testid="custom-spinbutton" />);
+      expect(screen.getByTestId('custom-spinbutton')).toBeInTheDocument();
+    });
+
+    it('supports aria-describedby', () => {
+      render(
+        <>
+          <Spinbutton aria-label="Quantity" aria-describedby="desc" />
+          <p id="desc">Enter the number of items</p>
+        </>
+      );
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-describedby', 'desc');
+    });
+  });
+});

--- a/src/patterns/spinbutton/Spinbutton.test.vue.ts
+++ b/src/patterns/spinbutton/Spinbutton.test.vue.ts
@@ -1,0 +1,612 @@
+import { render, screen } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+import Spinbutton from './Spinbutton.vue';
+
+describe('Spinbutton (Vue)', () => {
+  // 🔴 High Priority: ARIA Attributes
+  describe('ARIA Attributes', () => {
+    it('has role="spinbutton"', () => {
+      render(Spinbutton, {
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+    });
+
+    it('has aria-valuenow set to current value', () => {
+      render(Spinbutton, {
+        props: { defaultValue: 5 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '5');
+    });
+
+    it('has aria-valuenow set to 0 when no defaultValue', () => {
+      render(Spinbutton, {
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('has aria-valuemin when min is defined', () => {
+      render(Spinbutton, {
+        props: { min: 0 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuemin', '0');
+    });
+
+    it('does not have aria-valuemin when min is undefined', () => {
+      render(Spinbutton, {
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).not.toHaveAttribute('aria-valuemin');
+    });
+
+    it('has aria-valuemax when max is defined', () => {
+      render(Spinbutton, {
+        props: { max: 100 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuemax', '100');
+    });
+
+    it('does not have aria-valuemax when max is undefined', () => {
+      render(Spinbutton, {
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).not.toHaveAttribute('aria-valuemax');
+    });
+
+    it('has aria-valuetext when valueText provided', () => {
+      render(Spinbutton, {
+        props: { defaultValue: 5, valueText: '5 items' },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuetext', '5 items');
+    });
+
+    it('does not have aria-valuetext when not provided', () => {
+      render(Spinbutton, {
+        props: { defaultValue: 5 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).not.toHaveAttribute('aria-valuetext');
+    });
+
+    it('uses format for aria-valuetext', () => {
+      render(Spinbutton, {
+        props: { defaultValue: 5, format: '{value} items' },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuetext', '5 items');
+    });
+
+    it('has aria-disabled="true" when disabled', () => {
+      render(Spinbutton, {
+        props: { disabled: true },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('does not have aria-disabled when not disabled', () => {
+      render(Spinbutton, {
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).not.toHaveAttribute('aria-disabled');
+    });
+
+    it('has aria-readonly="true" when readOnly', () => {
+      render(Spinbutton, {
+        props: { readOnly: true },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-readonly', 'true');
+    });
+  });
+
+  // 🔴 High Priority: Accessible Name
+  describe('Accessible Name', () => {
+    it('has accessible name via aria-label', () => {
+      render(Spinbutton, {
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      expect(screen.getByRole('spinbutton', { name: 'Quantity' })).toBeInTheDocument();
+    });
+
+    it('has accessible name via aria-labelledby', () => {
+      render(Spinbutton, {
+        attrs: {
+          'aria-labelledby': 'spinbutton-label',
+        },
+        global: {
+          stubs: {
+            teleport: true,
+          },
+        },
+      });
+      // Note: aria-labelledby test requires the label element in the DOM
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-labelledby', 'spinbutton-label');
+    });
+
+    it('has accessible name via visible label', () => {
+      render(Spinbutton, {
+        props: { label: 'Quantity' },
+      });
+      expect(screen.getByRole('spinbutton', { name: 'Quantity' })).toBeInTheDocument();
+    });
+  });
+
+  // 🔴 High Priority: Keyboard Interaction
+  describe('Keyboard Interaction', () => {
+    it('increases value by step on ArrowUp', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 5, step: 1 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '6');
+    });
+
+    it('decreases value by step on ArrowDown', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 5, step: 1 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowDown}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '4');
+    });
+
+    it('sets min value on Home when min is defined', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 50, min: 0 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{Home}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('Home key has no effect when min is undefined', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 50 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{Home}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '50');
+    });
+
+    it('sets max value on End when max is defined', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 50, max: 100 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{End}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '100');
+    });
+
+    it('End key has no effect when max is undefined', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 50 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{End}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '50');
+    });
+
+    it('increases value by large step on PageUp', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 50, step: 1 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{PageUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '60');
+    });
+
+    it('decreases value by large step on PageDown', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 50, step: 1 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{PageDown}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '40');
+    });
+
+    it('does not exceed max on ArrowUp', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 100, max: 100 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '100');
+    });
+
+    it('does not go below min on ArrowDown', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 0, min: 0 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowDown}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('does not change value when disabled', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 5, disabled: true },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      spinbutton.focus();
+      await user.keyboard('{ArrowUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '5');
+    });
+
+    it('does not change value on ArrowUp/Down when readOnly', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 5, readOnly: true },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '5');
+    });
+  });
+
+  // 🔴 High Priority: Focus Management
+  describe('Focus Management', () => {
+    it('has tabindex="0" on input', () => {
+      render(Spinbutton, {
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('tabindex', '0');
+    });
+
+    it('has tabindex="-1" when disabled', () => {
+      render(Spinbutton, {
+        props: { disabled: true },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('buttons have tabindex="-1"', () => {
+      render(Spinbutton, {
+        props: { showButtons: true },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const buttons = screen.getAllByRole('button');
+      buttons.forEach((button) => {
+        expect(button).toHaveAttribute('tabindex', '-1');
+      });
+    });
+
+    it('focus stays on spinbutton after increment button click', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 5 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      const incrementButton = screen.getByLabelText(/increment/i);
+
+      await user.click(spinbutton);
+      await user.click(incrementButton);
+
+      expect(spinbutton).toHaveFocus();
+    });
+  });
+
+  // 🟡 Medium Priority: Button Interaction
+  describe('Button Interaction', () => {
+    it('increases value on increment button click', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 5 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      const incrementButton = screen.getByLabelText(/increment/i);
+
+      await user.click(incrementButton);
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '6');
+    });
+
+    it('decreases value on decrement button click', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 5 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      const decrementButton = screen.getByLabelText(/decrement/i);
+
+      await user.click(decrementButton);
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '4');
+    });
+
+    it('hides buttons when showButtons is false', () => {
+      render(Spinbutton, {
+        props: { showButtons: false },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      expect(screen.queryByLabelText(/increment/i)).not.toBeInTheDocument();
+      expect(screen.queryByLabelText(/decrement/i)).not.toBeInTheDocument();
+    });
+  });
+
+  // 🟡 Medium Priority: Text Input
+  describe('Text Input', () => {
+    it('accepts direct text input', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 5 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.clear(spinbutton);
+      await user.type(spinbutton, '42');
+      await user.tab();
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '42');
+    });
+
+    it('reverts to previous value on invalid input', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 5 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.clear(spinbutton);
+      await user.type(spinbutton, 'abc');
+      await user.tab();
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '5');
+    });
+
+    it('clamps value to max on valid input exceeding max', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 5, max: 10 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.clear(spinbutton);
+      await user.type(spinbutton, '999');
+      await user.tab();
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '10');
+    });
+  });
+
+  // 🟡 Medium Priority: Accessibility
+  describe('Accessibility', () => {
+    it('has no axe violations', async () => {
+      const { container } = render(Spinbutton, {
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with visible label', async () => {
+      const { container } = render(Spinbutton, {
+        props: { label: 'Quantity' },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations when disabled', async () => {
+      const { container } = render(Spinbutton, {
+        props: { disabled: true },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  // 🟡 Medium Priority: Callbacks
+  describe('Callbacks', () => {
+    it('emits valueChange on keyboard interaction', async () => {
+      const user = userEvent.setup();
+      const { emitted } = render(Spinbutton, {
+        props: { defaultValue: 5 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowUp}');
+
+      expect(emitted().valueChange).toBeTruthy();
+      expect(emitted().valueChange[0]).toEqual([6]);
+    });
+
+    it('emits valueChange on button click', async () => {
+      const user = userEvent.setup();
+      const { emitted } = render(Spinbutton, {
+        props: { defaultValue: 5 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const incrementButton = screen.getByLabelText(/increment/i);
+
+      await user.click(incrementButton);
+
+      expect(emitted().valueChange).toBeTruthy();
+      expect(emitted().valueChange[0]).toEqual([6]);
+    });
+  });
+
+  // 🟡 Medium Priority: Edge Cases
+  describe('Edge Cases', () => {
+    it('handles decimal step values correctly', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 0.5, step: 0.1 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '0.6');
+    });
+
+    it('handles negative values', () => {
+      render(Spinbutton, {
+        props: { defaultValue: -5 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '-5');
+    });
+
+    it('allows value beyond range when min/max undefined', async () => {
+      const user = userEvent.setup();
+      render(Spinbutton, {
+        props: { defaultValue: 1000 },
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+
+      await user.click(spinbutton);
+      await user.keyboard('{ArrowUp}');
+
+      expect(spinbutton).toHaveAttribute('aria-valuenow', '1001');
+    });
+  });
+
+  // 🟡 Medium Priority: Visual Display
+  describe('Visual Display', () => {
+    it('displays visible label when label provided', () => {
+      render(Spinbutton, {
+        props: { label: 'Quantity' },
+      });
+      expect(screen.getByText('Quantity')).toBeInTheDocument();
+    });
+
+    it('has inputmode="numeric"', () => {
+      render(Spinbutton, {
+        attrs: { 'aria-label': 'Quantity' },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('inputmode', 'numeric');
+    });
+  });
+
+  // 🟢 Low Priority: HTML Attribute Inheritance
+  describe('HTML Attribute Inheritance', () => {
+    it('applies className to container', () => {
+      render(Spinbutton, {
+        attrs: {
+          'aria-label': 'Quantity',
+          class: 'custom-spinbutton',
+        },
+      });
+      const container = screen.getByRole('spinbutton').closest('.apg-spinbutton');
+      expect(container).toHaveClass('custom-spinbutton');
+    });
+
+    it('sets id attribute on spinbutton element', () => {
+      render(Spinbutton, {
+        attrs: {
+          'aria-label': 'Quantity',
+          id: 'my-spinbutton',
+        },
+      });
+      const spinbutton = screen.getByRole('spinbutton');
+      expect(spinbutton).toHaveAttribute('id', 'my-spinbutton');
+    });
+
+    it('passes through data-testid', () => {
+      render(Spinbutton, {
+        attrs: {
+          'aria-label': 'Quantity',
+          'data-testid': 'custom-spinbutton',
+        },
+      });
+      expect(screen.getByTestId('custom-spinbutton')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/patterns/spinbutton/Spinbutton.tsx
+++ b/src/patterns/spinbutton/Spinbutton.tsx
@@ -1,0 +1,307 @@
+import { useId, useRef, useState } from 'react';
+import { cn } from '@/lib/utils';
+
+// Label: one of these required (exclusive)
+type LabelProps =
+  | { label: string; 'aria-label'?: never; 'aria-labelledby'?: never }
+  | { label?: never; 'aria-label': string; 'aria-labelledby'?: never }
+  | { label?: never; 'aria-label'?: never; 'aria-labelledby': string };
+
+// ValueText: exclusive with format
+type ValueTextProps =
+  | { valueText: string; format?: never }
+  | { valueText?: never; format?: string }
+  | { valueText?: never; format?: never };
+
+type SpinbuttonBaseProps = {
+  defaultValue?: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  largeStep?: number;
+  disabled?: boolean;
+  readOnly?: boolean;
+  showButtons?: boolean;
+  onValueChange?: (value: number) => void;
+  className?: string;
+  id?: string;
+  'aria-describedby'?: string;
+  'aria-invalid'?: boolean;
+  'data-testid'?: string;
+};
+
+export type SpinbuttonProps = SpinbuttonBaseProps & LabelProps & ValueTextProps;
+
+// Clamp value to range (only if min/max defined)
+const clamp = (value: number, min?: number, max?: number): number => {
+  let result = value;
+  if (min !== undefined) result = Math.max(min, result);
+  if (max !== undefined) result = Math.min(max, result);
+  return result;
+};
+
+// Ensure step is valid (positive number)
+const ensureValidStep = (step: number): number => {
+  return step > 0 ? step : 1;
+};
+
+// Round to step with floating-point precision handling
+const roundToStep = (value: number, step: number, min?: number): number => {
+  const validStep = ensureValidStep(step);
+  const base = min ?? 0;
+  const steps = Math.round((value - base) / validStep);
+  const result = base + steps * validStep;
+  // Handle floating-point precision (e.g., 0.1 + 0.2 = 0.30000000000000004)
+  const decimals = (validStep.toString().split('.')[1] || '').length;
+  return Number(result.toFixed(decimals));
+};
+
+// Format value text
+const formatValueText = (format: string, value: number, min?: number, max?: number): string => {
+  return format
+    .replace('{value}', String(value))
+    .replace('{min}', min !== undefined ? String(min) : '')
+    .replace('{max}', max !== undefined ? String(max) : '');
+};
+
+export function Spinbutton(props: SpinbuttonProps) {
+  const {
+    defaultValue = 0,
+    min,
+    max,
+    step = 1,
+    largeStep,
+    disabled = false,
+    readOnly = false,
+    showButtons = true,
+    onValueChange,
+    className,
+    id,
+    'aria-describedby': ariaDescribedby,
+    'aria-invalid': ariaInvalid,
+    'data-testid': dataTestId,
+    ...labelProps
+  } = props;
+
+  const generatedId = useId();
+  const labelId = `${generatedId}-label`;
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Get label-related props
+  const label = 'label' in labelProps ? labelProps.label : undefined;
+  const ariaLabel = 'aria-label' in labelProps ? labelProps['aria-label'] : undefined;
+  const ariaLabelledby =
+    'aria-labelledby' in labelProps ? labelProps['aria-labelledby'] : undefined;
+
+  // Get valueText-related props
+  const valueText = 'valueText' in props ? props.valueText : undefined;
+  const format = 'format' in props ? props.format : undefined;
+
+  // Initialize value with clamping and rounding
+  const initialValue = clamp(roundToStep(defaultValue, step, min), min, max);
+  const [value, setValue] = useState(initialValue);
+  const [inputValue, setInputValue] = useState(String(initialValue));
+  const [isComposing, setIsComposing] = useState(false);
+
+  const effectiveLargeStep = largeStep ?? step * 10;
+
+  // Compute aria-valuetext
+  const getAriaValueText = (): string | undefined => {
+    if (valueText) return valueText;
+    if (format) return formatValueText(format, value, min, max);
+    return undefined;
+  };
+  const computedValueText = getAriaValueText();
+
+  // Update value and call callback
+  const updateValue = (newValue: number) => {
+    const clampedValue = clamp(roundToStep(newValue, step, min), min, max);
+    if (clampedValue !== value) {
+      setValue(clampedValue);
+      setInputValue(String(clampedValue));
+      onValueChange?.(clampedValue);
+    }
+  };
+
+  // Handle keyboard events
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (disabled) return;
+
+    let newValue = value;
+    let handled = false;
+
+    switch (event.key) {
+      case 'ArrowUp':
+        if (!readOnly) {
+          newValue = value + step;
+          handled = true;
+        }
+        break;
+      case 'ArrowDown':
+        if (!readOnly) {
+          newValue = value - step;
+          handled = true;
+        }
+        break;
+      case 'Home':
+        if (min !== undefined) {
+          newValue = min;
+          handled = true;
+        }
+        break;
+      case 'End':
+        if (max !== undefined) {
+          newValue = max;
+          handled = true;
+        }
+        break;
+      case 'PageUp':
+        if (!readOnly) {
+          newValue = value + effectiveLargeStep;
+          handled = true;
+        }
+        break;
+      case 'PageDown':
+        if (!readOnly) {
+          newValue = value - effectiveLargeStep;
+          handled = true;
+        }
+        break;
+      default:
+        return;
+    }
+
+    if (handled) {
+      event.preventDefault();
+      updateValue(newValue);
+    }
+  };
+
+  // Handle text input change
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newInputValue = event.target.value;
+    setInputValue(newInputValue);
+
+    if (!isComposing) {
+      const parsed = parseFloat(newInputValue);
+      if (!isNaN(parsed)) {
+        const clampedValue = clamp(roundToStep(parsed, step, min), min, max);
+        if (clampedValue !== value) {
+          setValue(clampedValue);
+          onValueChange?.(clampedValue);
+        }
+      }
+    }
+  };
+
+  // Handle blur - validate and finalize input
+  const handleBlur = () => {
+    const parsed = parseFloat(inputValue);
+
+    if (isNaN(parsed)) {
+      // Revert to previous valid value
+      setInputValue(String(value));
+    } else {
+      // Clamp and round the value
+      const newValue = clamp(roundToStep(parsed, step, min), min, max);
+      if (newValue !== value) {
+        setValue(newValue);
+        onValueChange?.(newValue);
+      }
+      setInputValue(String(newValue));
+    }
+  };
+
+  // IME composition handlers
+  const handleCompositionStart = () => setIsComposing(true);
+  const handleCompositionEnd = () => {
+    setIsComposing(false);
+    // Validate and update after composition ends
+    const parsed = parseFloat(inputValue);
+    if (!isNaN(parsed)) {
+      const clampedValue = clamp(roundToStep(parsed, step, min), min, max);
+      setValue(clampedValue);
+      onValueChange?.(clampedValue);
+    }
+  };
+
+  // Button handlers
+  const handleIncrement = (event: React.MouseEvent) => {
+    event.preventDefault();
+    if (disabled || readOnly) return;
+    updateValue(value + step);
+    inputRef.current?.focus();
+  };
+
+  const handleDecrement = (event: React.MouseEvent) => {
+    event.preventDefault();
+    if (disabled || readOnly) return;
+    updateValue(value - step);
+    inputRef.current?.focus();
+  };
+
+  return (
+    <div className={cn('apg-spinbutton', disabled && 'apg-spinbutton--disabled', className)}>
+      {label && (
+        <span className="apg-spinbutton-label" id={labelId}>
+          {label}
+        </span>
+      )}
+      <div className="apg-spinbutton-controls">
+        {showButtons && (
+          <button
+            type="button"
+            tabIndex={-1}
+            aria-label="Decrement"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={handleDecrement}
+            disabled={disabled}
+            className="apg-spinbutton-button apg-spinbutton-decrement"
+          >
+            −
+          </button>
+        )}
+        <input
+          ref={inputRef}
+          type="text"
+          role="spinbutton"
+          id={id}
+          tabIndex={disabled ? -1 : 0}
+          inputMode="numeric"
+          value={inputValue}
+          readOnly={readOnly}
+          aria-valuenow={value}
+          aria-valuemin={min}
+          aria-valuemax={max}
+          aria-valuetext={computedValueText}
+          aria-label={ariaLabel}
+          aria-labelledby={label ? labelId : ariaLabelledby}
+          aria-describedby={ariaDescribedby}
+          aria-disabled={disabled || undefined}
+          aria-readonly={readOnly || undefined}
+          aria-invalid={ariaInvalid}
+          data-testid={dataTestId}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          onBlur={handleBlur}
+          onCompositionStart={handleCompositionStart}
+          onCompositionEnd={handleCompositionEnd}
+          className="apg-spinbutton-input"
+        />
+        {showButtons && (
+          <button
+            type="button"
+            tabIndex={-1}
+            aria-label="Increment"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={handleIncrement}
+            disabled={disabled}
+            className="apg-spinbutton-button apg-spinbutton-increment"
+          >
+            +
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/patterns/spinbutton/Spinbutton.vue
+++ b/src/patterns/spinbutton/Spinbutton.vue
@@ -1,0 +1,306 @@
+<template>
+  <div :class="cn('apg-spinbutton', disabled && 'apg-spinbutton--disabled', $attrs.class)">
+    <span v-if="label" :id="labelId" class="apg-spinbutton-label">
+      {{ label }}
+    </span>
+    <div class="apg-spinbutton-controls">
+      <button
+        v-if="showButtons"
+        type="button"
+        :tabindex="-1"
+        aria-label="Decrement"
+        :disabled="disabled"
+        class="apg-spinbutton-button apg-spinbutton-decrement"
+        @mousedown.prevent
+        @click="handleDecrement"
+      >
+        −
+      </button>
+      <input
+        ref="inputRef"
+        type="text"
+        role="spinbutton"
+        :id="$attrs.id as string | undefined"
+        :tabindex="disabled ? -1 : 0"
+        inputmode="numeric"
+        :value="inputValue"
+        :readonly="readOnly"
+        :aria-valuenow="value"
+        :aria-valuemin="min"
+        :aria-valuemax="max"
+        :aria-valuetext="ariaValueText"
+        :aria-label="label ? undefined : ($attrs['aria-label'] as string | undefined)"
+        :aria-labelledby="ariaLabelledby"
+        :aria-describedby="$attrs['aria-describedby'] as string | undefined"
+        :aria-disabled="disabled || undefined"
+        :aria-readonly="readOnly || undefined"
+        :aria-invalid="$attrs['aria-invalid'] as boolean | undefined"
+        :data-testid="$attrs['data-testid'] as string | undefined"
+        class="apg-spinbutton-input"
+        @input="handleInput"
+        @keydown="handleKeyDown"
+        @blur="handleBlur"
+        @compositionstart="handleCompositionStart"
+        @compositionend="handleCompositionEnd"
+      />
+      <button
+        v-if="showButtons"
+        type="button"
+        :tabindex="-1"
+        aria-label="Increment"
+        :disabled="disabled"
+        class="apg-spinbutton-button apg-spinbutton-increment"
+        @mousedown.prevent
+        @click="handleIncrement"
+      >
+        +
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, useId } from 'vue';
+import { cn } from '@/lib/utils';
+
+defineOptions({
+  inheritAttrs: false,
+});
+
+export interface SpinbuttonProps {
+  /** Default value */
+  defaultValue?: number;
+  /** Minimum value (undefined = no limit) */
+  min?: number;
+  /** Maximum value (undefined = no limit) */
+  max?: number;
+  /** Step increment (default: 1) */
+  step?: number;
+  /** Large step for PageUp/PageDown */
+  largeStep?: number;
+  /** Whether spinbutton is disabled */
+  disabled?: boolean;
+  /** Whether spinbutton is read-only */
+  readOnly?: boolean;
+  /** Show increment/decrement buttons (default: true) */
+  showButtons?: boolean;
+  /** Visible label text */
+  label?: string;
+  /** Human-readable value text for aria-valuetext */
+  valueText?: string;
+  /** Format pattern for dynamic value display (e.g., "{value} items") */
+  format?: string;
+}
+
+const props = withDefaults(defineProps<SpinbuttonProps>(), {
+  defaultValue: 0,
+  min: undefined,
+  max: undefined,
+  step: 1,
+  largeStep: undefined,
+  disabled: false,
+  readOnly: false,
+  showButtons: true,
+  label: undefined,
+  valueText: undefined,
+  format: undefined,
+});
+
+const emit = defineEmits<{
+  valueChange: [value: number];
+}>();
+
+// Utility functions
+const clamp = (val: number, minVal?: number, maxVal?: number): number => {
+  let result = val;
+  if (minVal !== undefined) result = Math.max(minVal, result);
+  if (maxVal !== undefined) result = Math.min(maxVal, result);
+  return result;
+};
+
+// Ensure step is valid (positive number)
+const ensureValidStep = (stepVal: number): number => {
+  return stepVal > 0 ? stepVal : 1;
+};
+
+const roundToStep = (val: number, stepVal: number, minVal?: number): number => {
+  const validStep = ensureValidStep(stepVal);
+  const base = minVal ?? 0;
+  const steps = Math.round((val - base) / validStep);
+  const result = base + steps * validStep;
+  const decimalPlaces = (validStep.toString().split('.')[1] || '').length;
+  return Number(result.toFixed(decimalPlaces));
+};
+
+// Format value helper
+const formatValueText = (val: number, formatStr: string | undefined): string => {
+  if (!formatStr) return String(val);
+  return formatStr
+    .replace('{value}', String(val))
+    .replace('{min}', props.min !== undefined ? String(props.min) : '')
+    .replace('{max}', props.max !== undefined ? String(props.max) : '');
+};
+
+// Refs
+const inputRef = ref<HTMLInputElement | null>(null);
+const labelId = useId();
+const isComposing = ref(false);
+
+// State
+const initialValue = clamp(
+  roundToStep(props.defaultValue, props.step, props.min),
+  props.min,
+  props.max
+);
+const value = ref(initialValue);
+const inputValue = ref(String(initialValue));
+
+// Computed
+const effectiveLargeStep = computed(() => props.largeStep ?? props.step * 10);
+
+const ariaValueText = computed(() => {
+  if (props.valueText) return props.valueText;
+  if (props.format) return formatValueText(value.value, props.format);
+  return undefined;
+});
+
+const ariaLabelledby = computed(() => {
+  const attrLabelledby = (
+    getCurrentInstance()?.attrs as { 'aria-labelledby'?: string } | undefined
+  )?.['aria-labelledby'];
+  if (attrLabelledby) return attrLabelledby;
+  if (props.label) return labelId;
+  return undefined;
+});
+
+// Helper to get current instance for attrs
+import { getCurrentInstance } from 'vue';
+
+// Update value and emit
+const updateValue = (newValue: number) => {
+  const clampedValue = clamp(roundToStep(newValue, props.step, props.min), props.min, props.max);
+  if (clampedValue !== value.value) {
+    value.value = clampedValue;
+    inputValue.value = String(clampedValue);
+    emit('valueChange', clampedValue);
+  }
+};
+
+// Keyboard handler
+const handleKeyDown = (event: KeyboardEvent) => {
+  if (props.disabled) return;
+
+  let newValue = value.value;
+  let handled = false;
+
+  switch (event.key) {
+    case 'ArrowUp':
+      if (!props.readOnly) {
+        newValue = value.value + props.step;
+        handled = true;
+      }
+      break;
+    case 'ArrowDown':
+      if (!props.readOnly) {
+        newValue = value.value - props.step;
+        handled = true;
+      }
+      break;
+    case 'Home':
+      if (props.min !== undefined) {
+        newValue = props.min;
+        handled = true;
+      }
+      break;
+    case 'End':
+      if (props.max !== undefined) {
+        newValue = props.max;
+        handled = true;
+      }
+      break;
+    case 'PageUp':
+      if (!props.readOnly) {
+        newValue = value.value + effectiveLargeStep.value;
+        handled = true;
+      }
+      break;
+    case 'PageDown':
+      if (!props.readOnly) {
+        newValue = value.value - effectiveLargeStep.value;
+        handled = true;
+      }
+      break;
+    default:
+      return;
+  }
+
+  if (handled) {
+    event.preventDefault();
+    updateValue(newValue);
+  }
+};
+
+// Text input handler
+const handleInput = (event: Event) => {
+  const target = event.target as HTMLInputElement;
+  inputValue.value = target.value;
+
+  if (!isComposing.value) {
+    const parsed = parseFloat(target.value);
+    if (!isNaN(parsed)) {
+      const clampedValue = clamp(roundToStep(parsed, props.step, props.min), props.min, props.max);
+      if (clampedValue !== value.value) {
+        value.value = clampedValue;
+        emit('valueChange', clampedValue);
+      }
+    }
+  }
+};
+
+// Blur handler
+const handleBlur = () => {
+  const parsed = parseFloat(inputValue.value);
+
+  if (isNaN(parsed)) {
+    // Revert to previous valid value
+    inputValue.value = String(value.value);
+  } else {
+    const newValue = clamp(roundToStep(parsed, props.step, props.min), props.min, props.max);
+    if (newValue !== value.value) {
+      value.value = newValue;
+      emit('valueChange', newValue);
+    }
+    inputValue.value = String(newValue);
+  }
+};
+
+// IME composition handlers
+const handleCompositionStart = () => {
+  isComposing.value = true;
+};
+
+const handleCompositionEnd = () => {
+  isComposing.value = false;
+  const parsed = parseFloat(inputValue.value);
+  if (!isNaN(parsed)) {
+    const clampedValue = clamp(roundToStep(parsed, props.step, props.min), props.min, props.max);
+    value.value = clampedValue;
+    emit('valueChange', clampedValue);
+  }
+};
+
+// Button handlers
+const handleIncrement = (event: MouseEvent) => {
+  event.preventDefault();
+  if (props.disabled || props.readOnly) return;
+  updateValue(value.value + props.step);
+  inputRef.value?.focus();
+};
+
+const handleDecrement = (event: MouseEvent) => {
+  event.preventDefault();
+  if (props.disabled || props.readOnly) return;
+  updateValue(value.value - props.step);
+  inputRef.value?.focus();
+};
+</script>

--- a/src/patterns/spinbutton/SpinbuttonWithLabel.test.svelte
+++ b/src/patterns/spinbutton/SpinbuttonWithLabel.test.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import Spinbutton from './Spinbutton.svelte';
+</script>
+
+<div>
+  <span id="spinbutton-label">Item Count</span>
+  <Spinbutton aria-labelledby="spinbutton-label" />
+</div>

--- a/src/patterns/spinbutton/TestingDocs.astro
+++ b/src/patterns/spinbutton/TestingDocs.astro
@@ -1,0 +1,382 @@
+---
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+---
+
+<div class="prose dark:prose-invert max-w-none">
+  <p class="text-muted-foreground mb-4">
+    Tests verify APG compliance for ARIA attributes, keyboard interactions, text input handling, and
+    accessibility requirements.
+  </p>
+
+  <h3 class="mb-3 text-lg font-medium">Test Categories</h3>
+
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
+    High Priority: ARIA Attributes
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">Test</th>
+          <th class="py-2 text-left">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>role="spinbutton"</code></td>
+          <td class="py-2">Element has the spinbutton role</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>aria-valuenow</code></td>
+          <td class="py-2">Current value is correctly set and updated</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>aria-valuemin</code></td>
+          <td class="py-2">Minimum value is set only when min is defined</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>aria-valuemax</code></td>
+          <td class="py-2">Maximum value is set only when max is defined</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>aria-valuetext</code></td>
+          <td class="py-2">Human-readable text is set when provided</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>aria-disabled</code></td>
+          <td class="py-2">Disabled state is reflected when set</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>aria-readonly</code></td>
+          <td class="py-2">Read-only state is reflected when set</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
+    High Priority: Accessible Name
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">Test</th>
+          <th class="py-2 text-left">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>aria-label</code></td>
+          <td class="py-2">Accessible name via aria-label attribute</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>aria-labelledby</code></td>
+          <td class="py-2">Accessible name via external element reference</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>visible label</code></td>
+          <td class="py-2">Visible label provides accessible name</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
+    High Priority: Keyboard Interaction
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">Test</th>
+          <th class="py-2 text-left">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Arrow Up</code></td>
+          <td class="py-2">Increases value by one step</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Arrow Down</code></td>
+          <td class="py-2">Decreases value by one step</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Home</code></td>
+          <td class="py-2">Sets value to minimum (only when min defined)</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>End</code></td>
+          <td class="py-2">Sets value to maximum (only when max defined)</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Page Up/Down</code></td>
+          <td class="py-2">Increases/decreases value by large step</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Boundary clamping</code></td>
+          <td class="py-2">Value does not exceed min/max limits</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Disabled state</code></td>
+          <td class="py-2">Keyboard has no effect when disabled</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Read-only state</code></td>
+          <td class="py-2">Arrow keys blocked, Home/End allowed</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
+    High Priority: Button Interaction
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">Test</th>
+          <th class="py-2 text-left">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Increment click</code></td>
+          <td class="py-2">Clicking increment button increases value</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Decrement click</code></td>
+          <td class="py-2">Clicking decrement button decreases value</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Button labels</code></td>
+          <td class="py-2">Buttons have accessible labels</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Disabled/read-only</code></td>
+          <td class="py-2">Buttons blocked when disabled or read-only</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
+    High Priority: Focus Management
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">Test</th>
+          <th class="py-2 text-left">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>tabindex="0"</code></td>
+          <td class="py-2">Input is focusable</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>tabindex="-1"</code></td>
+          <td class="py-2">Input is not focusable when disabled</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Button tabindex</code></td>
+          <td class="py-2">Buttons have tabindex="-1" (not in tab order)</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-yellow-500"></span>
+    Medium Priority: Text Input
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">Test</th>
+          <th class="py-2 text-left">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>inputmode="numeric"</code></td>
+          <td class="py-2">Uses numeric keyboard on mobile</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Valid input</code></td>
+          <td class="py-2">aria-valuenow updates on valid text input</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Invalid input</code></td>
+          <td class="py-2">Reverts to previous value on blur with invalid input</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Clamp on blur</code></td>
+          <td class="py-2">Value normalized to step and min/max on blur</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-yellow-500"></span>
+    Medium Priority: IME Composition
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">Test</th>
+          <th class="py-2 text-left">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>During composition</code></td>
+          <td class="py-2">Value not updated during IME composition</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>On composition end</code></td>
+          <td class="py-2">Value updates when composition completes</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-yellow-500"></span>
+    Medium Priority: Edge Cases
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">Test</th>
+          <th class="py-2 text-left">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>decimal values</code></td>
+          <td class="py-2">Handles decimal step values correctly</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>no min/max</code></td>
+          <td class="py-2">Allows unbounded values when no min/max</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>clamp to min</code></td>
+          <td class="py-2">defaultValue below min is clamped to min</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>clamp to max</code></td>
+          <td class="py-2">defaultValue above max is clamped to max</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-yellow-500"></span>
+    Medium Priority: Callbacks
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">Test</th>
+          <th class="py-2 text-left">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>onValueChange</code></td>
+          <td class="py-2">Callback is called with new value on change</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-green-500"></span>
+    Low Priority: HTML Attribute Inheritance
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">Test</th>
+          <th class="py-2 text-left">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>className</code></td>
+          <td class="py-2">Custom class is applied to container</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>id</code></td>
+          <td class="py-2">ID attribute is set correctly</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>data-*</code></td>
+          <td class="py-2">Data attributes are passed through</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h3 class="mb-3 text-lg font-medium">Testing Tools</h3>
+  <ul class="mb-6 list-disc space-y-2 pl-6">
+    <li>
+      <strong>React:</strong>
+      <ExternalLink
+        href="https://testing-library.com/docs/react-testing-library/intro/"
+        class="text-primary hover:underline"
+      >
+        React Testing Library
+      </ExternalLink>
+    </li>
+    <li>
+      <strong>Vue:</strong>
+      <ExternalLink
+        href="https://testing-library.com/docs/vue-testing-library/intro/"
+        class="text-primary hover:underline"
+      >
+        Vue Testing Library
+      </ExternalLink>
+    </li>
+    <li>
+      <strong>Svelte:</strong>
+      <ExternalLink
+        href="https://testing-library.com/docs/svelte-testing-library/intro/"
+        class="text-primary hover:underline"
+      >
+        Svelte Testing Library
+      </ExternalLink>
+    </li>
+    <li>
+      <strong>Astro:</strong> Vitest with JSDOM for Web Component unit tests
+    </li>
+    <li>
+      <strong>Accessibility:</strong>
+      <ExternalLink
+        href="https://github.com/dequelabs/axe-core"
+        class="text-primary hover:underline"
+      >
+        axe-core
+      </ExternalLink>
+    </li>
+  </ul>
+</div>

--- a/src/patterns/spinbutton/llm.md
+++ b/src/patterns/spinbutton/llm.md
@@ -1,0 +1,413 @@
+# Spinbutton Pattern - AI Implementation Guide
+
+> APG Reference: https://www.w3.org/WAI/ARIA/apg/patterns/spinbutton/
+
+## Overview
+
+A spinbutton allows users to select a value from a discrete set or range. Contains a text field displaying the current value with optional increment/decrement buttons. Supports direct text input and keyboard navigation.
+
+## Native HTML vs Custom Implementation
+
+**Prefer native `<input type="number">`** when possible - provides implicit semantics.
+
+| Use Case | Recommended |
+| --- | --- |
+| Simple numeric input | Native `<input type="number">` |
+| Custom styling needed | Custom `role="spinbutton"` |
+| Consistent keyboard behavior | Custom (browser varies) |
+| `aria-valuetext` needed | Custom implementation |
+
+## ARIA Requirements
+
+### Roles
+
+| Role | Element | Required | Description |
+| --- | --- | --- | --- |
+| `spinbutton` | Input element | Yes | Identifies the element as a spinbutton |
+
+### Properties
+
+| Attribute | Element | Values | Required | Notes |
+| --- | --- | --- | --- | --- |
+| `aria-valuemin` | spinbutton | number | No | Only set when min is defined |
+| `aria-valuemax` | spinbutton | number | No | Only set when max is defined |
+| `aria-label` | spinbutton | string | Conditional | When no visible label |
+| `aria-labelledby` | spinbutton | ID ref | Conditional | When visible label exists |
+| `aria-readonly` | spinbutton | `true` | No | When readOnly is true |
+| `aria-disabled` | spinbutton | `true` | No | When disabled is true |
+
+**Label Requirement**: One of `label`, `aria-label`, or `aria-labelledby` is required.
+
+### States
+
+| Attribute | Element | Values | Required | Change Trigger |
+| --- | --- | --- | --- | --- |
+| `aria-valuenow` | spinbutton | number | Yes | Value change (keyboard/button/input) |
+| `aria-valuetext` | spinbutton | string | No | Value change (when format provided) |
+| `aria-invalid` | spinbutton | `true`/`false` | No | When value is out of range |
+
+**IME Handling**: During IME composition (`compositionstart` to `compositionend`), `aria-valuenow` retains the previous valid value.
+
+## Keyboard Support
+
+| Key | Action |
+| --- | --- |
+| `ArrowUp` | Increase value by step |
+| `ArrowDown` | Decrease value by step |
+| `Home` | Set to minimum value (if defined) |
+| `End` | Set to maximum value (if defined) |
+| `Page Up` | Increase by large step (default: step × 10) |
+| `Page Down` | Decrease by large step (default: step × 10) |
+| Text editing keys | Direct value input |
+
+**Note**: When `min`/`max` are undefined, `Home`/`End` keys have no effect.
+
+## Focus Management
+
+- Single focusable element: the input with `role="spinbutton"`
+- `tabindex="0"` on input element
+- `tabindex="-1"` when disabled
+- Increment/decrement buttons have `tabindex="-1"` (not in tab order)
+- **Button click does NOT move focus**: Focus stays on spinbutton after button interaction
+
+## Test Checklist
+
+### High Priority: ARIA
+
+- [ ] `role="spinbutton"` exists on input
+- [ ] `aria-valuenow` set to current value
+- [ ] `aria-valuemin` only set when min is defined
+- [ ] `aria-valuemax` only set when max is defined
+- [ ] Accessible name required (label/aria-label/aria-labelledby)
+- [ ] `aria-valuetext` set when valueText/format provided
+- [ ] `aria-disabled="true"` when disabled
+- [ ] `aria-readonly="true"` when readOnly
+- [ ] `aria-invalid="true"` when value out of range
+
+### High Priority: Keyboard
+
+- [ ] `ArrowUp` increases value by step
+- [ ] `ArrowDown` decreases value by step
+- [ ] `Home` sets value to min (only when min defined)
+- [ ] `End` sets value to max (only when max defined)
+- [ ] `Page Up` increases by large step
+- [ ] `Page Down` decreases by large step
+- [ ] Value stops at min/max boundaries (no wrapping)
+- [ ] Keys have no effect when disabled
+- [ ] Keys have no effect when readOnly (except navigation)
+
+### High Priority: Focus
+
+- [ ] Input is focusable (tabindex="0")
+- [ ] Input not focusable when disabled (tabindex="-1")
+- [ ] Buttons have tabindex="-1"
+- [ ] Focus stays on input after button click
+
+### Medium Priority: Text Input
+
+- [ ] Direct text input accepted
+- [ ] Value validated on blur
+- [ ] Invalid input reverts to previous value
+- [ ] Value clamped to range on valid input (when min/max defined)
+- [ ] Decimal step values work correctly
+
+### Medium Priority: IME
+
+- [ ] `aria-valuenow` keeps previous value during composition
+- [ ] `onValueChange` not called during composition
+- [ ] `onValueChange` called on compositionend
+
+### Medium Priority: Buttons
+
+- [ ] Increment button increases value
+- [ ] Decrement button decreases value
+- [ ] Increment button has `aria-label` or hidden from AT
+- [ ] Decrement button has `aria-label` or hidden from AT
+- [ ] Buttons work when showButtons=true
+- [ ] Keyboard still works when showButtons=false
+
+### Medium Priority: Accessibility
+
+- [ ] No axe-core violations
+- [ ] No axe violations when disabled
+- [ ] No axe violations when readOnly
+
+### Low Priority: Props
+
+- [ ] `className` applied to container
+- [ ] `data-*` attributes pass through
+- [ ] `onValueChange` callback fires on change
+- [ ] `defaultValue` sets initial value
+
+## Implementation Notes
+
+### Props Design
+
+```typescript
+// Label: one of these required (exclusive)
+type LabelProps =
+  | { label: string; 'aria-label'?: never; 'aria-labelledby'?: never }
+  | { label?: never; 'aria-label': string; 'aria-labelledby'?: never }
+  | { label?: never; 'aria-label'?: never; 'aria-labelledby': string };
+
+// ValueText: exclusive with format
+type ValueTextProps =
+  | { valueText: string; format?: never }
+  | { valueText?: never; format?: string }
+  | { valueText?: never; format?: never };
+
+type SpinbuttonBaseProps = {
+  defaultValue?: number;
+  min?: number;           // default: undefined (no limit)
+  max?: number;           // default: undefined (no limit)
+  step?: number;          // default: 1
+  largeStep?: number;     // default: step * 10
+  disabled?: boolean;
+  readOnly?: boolean;
+  showButtons?: boolean;  // default: true
+  onValueChange?: (value: number) => void;
+  className?: string;
+  id?: string;
+  'aria-describedby'?: string;
+  'aria-invalid'?: boolean;
+};
+
+export type SpinbuttonProps = SpinbuttonBaseProps & LabelProps & ValueTextProps;
+```
+
+### Structure
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ <div class="apg-spinbutton">                                │
+│ ┌─────────────────────────────────────────────────────────┐ │
+│ │ <span class="apg-spinbutton-label" id="label-id">       │ │
+│ │   Quantity                                              │ │
+│ │ </span>                                                 │ │
+│ └─────────────────────────────────────────────────────────┘ │
+│ ┌─────────────────────────────────────────────────────────┐ │
+│ │ <div class="apg-spinbutton-controls">  ← focus ring here│ │
+│ │   <button tabindex="-1" aria-label="Decrement">−</button│ │
+│ │   <input                                                │ │
+│ │     role="spinbutton"                                   │ │
+│ │     tabindex="0"                                        │ │
+│ │     aria-valuenow="5"                                   │ │
+│ │     aria-valuemin="0"      (only if min defined)        │ │
+│ │     aria-valuemax="100"    (only if max defined)        │ │
+│ │     aria-labelledby="label-id"                          │ │
+│ │     inputmode="numeric"                                 │ │
+│ │   />                                                    │ │
+│ │   <button tabindex="-1" aria-label="Increment">+</button│ │
+│ │ </div>                                                  │ │
+│ └─────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Focus Ring**: The focus ring appears on the entire `.apg-spinbutton-controls` container (using `:has()` selector) rather than just the input, providing clearer visual feedback that includes the buttons.
+
+### Value Calculation
+
+```typescript
+// Clamp value to range (only if min/max defined)
+const clamp = (value: number, min?: number, max?: number) => {
+  let result = value;
+  if (min !== undefined) result = Math.max(min, result);
+  if (max !== undefined) result = Math.min(max, result);
+  return result;
+};
+
+// Guard against invalid step values
+const ensureValidStep = (step: number): number => {
+  return step > 0 ? step : 1;
+};
+
+// Round to step (with precision handling)
+const roundToStep = (value: number, step: number, min?: number) => {
+  const validStep = ensureValidStep(step);
+  const base = min ?? 0;
+  const steps = Math.round((value - base) / validStep);
+  const result = base + steps * validStep;
+  // Handle floating-point precision
+  const decimals = (validStep.toString().split('.')[1] || '').length;
+  return Number(result.toFixed(decimals));
+};
+```
+
+### Keyboard Handler
+
+```typescript
+const handleKeyDown = (event: KeyboardEvent) => {
+  if (disabled || (readOnly && !['Home', 'End'].includes(event.key))) return;
+
+  let newValue = value;
+  const effectiveLargeStep = largeStep ?? step * 10;
+
+  switch (event.key) {
+    case 'ArrowUp':
+      newValue = value + step;
+      event.preventDefault();
+      break;
+    case 'ArrowDown':
+      newValue = value - step;
+      event.preventDefault();
+      break;
+    case 'Home':
+      if (min !== undefined) {
+        newValue = min;
+        event.preventDefault();
+      }
+      break;
+    case 'End':
+      if (max !== undefined) {
+        newValue = max;
+        event.preventDefault();
+      }
+      break;
+    case 'PageUp':
+      newValue = value + effectiveLargeStep;
+      event.preventDefault();
+      break;
+    case 'PageDown':
+      newValue = value - effectiveLargeStep;
+      event.preventDefault();
+      break;
+    default:
+      return;
+  }
+
+  setValue(clamp(roundToStep(newValue, step, min), min, max));
+};
+```
+
+### IME Handling
+
+```typescript
+const [isComposing, setIsComposing] = useState(false);
+
+const handleCompositionStart = () => setIsComposing(true);
+const handleCompositionEnd = () => {
+  setIsComposing(false);
+  // Validate and update value
+  validateAndUpdate(inputValue);
+};
+
+const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+  setInputValue(e.target.value);
+  if (!isComposing) {
+    // Update aria-valuenow immediately for non-IME input
+    const parsed = parseFloat(e.target.value);
+    if (!isNaN(parsed)) {
+      const newValue = clamp(roundToStep(parsed, step, min), min, max);
+      setValue(newValue);
+      onValueChange?.(newValue);
+    }
+  }
+};
+```
+
+### Common Pitfalls
+
+1. **Missing accessible name**: Always require label, aria-label, or aria-labelledby
+2. **Unconditional aria-valuemin/max**: Only set when min/max props are defined
+3. **IME input handling**: Don't update aria-valuenow during composition
+4. **Button focus steal**: Buttons must not receive focus on click - use `mousedown.preventDefault()` to prevent focus shift
+5. **Floating-point precision**: Round to step to avoid 0.1 + 0.2 = 0.30000000000000004
+6. **Home/End without bounds**: These keys should have no effect when min/max undefined
+7. **Invalid step values**: Guard against `step <= 0` which causes division errors in `roundToStep`. Use `ensureValidStep(step)` to default to 1
+8. **Redundant callbacks**: Only fire `onValueChange` when the value actually changes, not on every input
+9. **Label exclusivity**: When visible `label` exists, set `aria-label` to undefined to avoid conflicts
+
+## Example Test Code (React + Testing Library)
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe, toHaveNoViolations } from 'jest-axe';
+
+expect.extend(toHaveNoViolations);
+
+// Role test
+it('has role="spinbutton"', () => {
+  render(<Spinbutton aria-label="Quantity" />);
+  expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+});
+
+// ARIA values test
+it('has aria-valuenow set to current value', () => {
+  render(<Spinbutton defaultValue={5} aria-label="Quantity" />);
+  expect(screen.getByRole('spinbutton')).toHaveAttribute('aria-valuenow', '5');
+});
+
+// No aria-valuemin when undefined
+it('does not have aria-valuemin when min is undefined', () => {
+  render(<Spinbutton aria-label="Quantity" />);
+  expect(screen.getByRole('spinbutton')).not.toHaveAttribute('aria-valuemin');
+});
+
+// Keyboard: ArrowUp
+it('increases value on ArrowUp', async () => {
+  const user = userEvent.setup();
+  render(<Spinbutton defaultValue={5} step={1} aria-label="Quantity" />);
+  const spinbutton = screen.getByRole('spinbutton');
+
+  await user.click(spinbutton);
+  await user.keyboard('{ArrowUp}');
+
+  expect(spinbutton).toHaveAttribute('aria-valuenow', '6');
+});
+
+// Boundary test with max
+it('does not exceed max on ArrowUp', async () => {
+  const user = userEvent.setup();
+  render(<Spinbutton defaultValue={10} max={10} aria-label="Quantity" />);
+  const spinbutton = screen.getByRole('spinbutton');
+
+  await user.click(spinbutton);
+  await user.keyboard('{ArrowUp}');
+
+  expect(spinbutton).toHaveAttribute('aria-valuenow', '10');
+});
+
+// Home key without min (no effect)
+it('Home key has no effect when min is undefined', async () => {
+  const user = userEvent.setup();
+  render(<Spinbutton defaultValue={50} aria-label="Quantity" />);
+  const spinbutton = screen.getByRole('spinbutton');
+
+  await user.click(spinbutton);
+  await user.keyboard('{Home}');
+
+  expect(spinbutton).toHaveAttribute('aria-valuenow', '50');
+});
+
+// Disabled test
+it('does not change value when disabled', async () => {
+  const user = userEvent.setup();
+  render(<Spinbutton defaultValue={5} disabled aria-label="Quantity" />);
+  const spinbutton = screen.getByRole('spinbutton');
+
+  spinbutton.focus();
+  await user.keyboard('{ArrowUp}');
+
+  expect(spinbutton).toHaveAttribute('aria-valuenow', '5');
+});
+
+// Button focus test
+it('focus stays on spinbutton after increment button click', async () => {
+  const user = userEvent.setup();
+  render(<Spinbutton defaultValue={5} aria-label="Quantity" />);
+  const spinbutton = screen.getByRole('spinbutton');
+
+  await user.click(spinbutton);
+  await user.click(screen.getByRole('button', { name: /increment/i }));
+
+  expect(spinbutton).toHaveFocus();
+});
+
+// axe test
+it('has no axe violations', async () => {
+  const { container } = render(<Spinbutton aria-label="Quantity" />);
+  const results = await axe(container);
+  expect(results).toHaveNoViolations();
+});
+```

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -14,6 +14,7 @@
 @import './patterns/link.css';
 @import './patterns/meter.css';
 @import './patterns/slider.css';
+@import './patterns/spinbutton.css';
 @import 'tw-animate-css';
 
 @custom-variant dark (&:is(.dark *));

--- a/src/styles/patterns/spinbutton.css
+++ b/src/styles/patterns/spinbutton.css
@@ -1,0 +1,210 @@
+/* =============================================================================
+   SPINBUTTON COMPONENT STYLES
+   ============================================================================= */
+
+/* Web Components wrapper (Astro) */
+apg-spinbutton {
+  display: contents;
+}
+
+/* Spinbutton Base */
+.apg-spinbutton {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+/* Spinbutton Label */
+.apg-spinbutton-label {
+  font-weight: 500;
+  color: var(--foreground);
+}
+
+/* Controls Container */
+.apg-spinbutton-controls {
+  display: inline-flex;
+  align-items: stretch;
+  border: 1px solid var(--border);
+  border-radius: 0.375rem;
+  overflow: hidden;
+  background: var(--background);
+}
+
+/* Focus ring on controls container when input is focused */
+.apg-spinbutton-controls:has(.apg-spinbutton-input:focus-visible) {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+/* Spinbutton Input */
+.apg-spinbutton-input {
+  width: 4rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+  color: var(--foreground);
+  background: transparent;
+  border: none;
+  outline: none;
+}
+
+/* Focus style is handled by parent .apg-spinbutton-controls:has(:focus-visible) */
+
+.apg-spinbutton-input::placeholder {
+  color: var(--muted-foreground);
+}
+
+/* Spinbutton Buttons */
+.apg-spinbutton-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  padding: 0;
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--foreground);
+  background: var(--muted);
+  border: none;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease-out,
+    color 0.15s ease-out;
+}
+
+.apg-spinbutton-button:hover:not(:disabled) {
+  background: var(--accent);
+  color: var(--accent-foreground);
+}
+
+.apg-spinbutton-button:active:not(:disabled) {
+  background: color-mix(in oklch, var(--accent) 80%, var(--foreground));
+}
+
+/* Button Borders */
+.apg-spinbutton-decrement {
+  border-right: 1px solid var(--border);
+}
+
+.apg-spinbutton-increment {
+  border-left: 1px solid var(--border);
+}
+
+/* =============================================================================
+   DISABLED STATE
+   ============================================================================= */
+
+.apg-spinbutton--disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.apg-spinbutton--disabled .apg-spinbutton-input {
+  cursor: not-allowed;
+}
+
+.apg-spinbutton--disabled .apg-spinbutton-button {
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+/* =============================================================================
+   READ-ONLY STATE
+   ============================================================================= */
+
+.apg-spinbutton-input[readonly] {
+  background: var(--muted);
+}
+
+/* =============================================================================
+   DARK MODE
+   ============================================================================= */
+
+/* Dark mode - adjust muted background for better visibility */
+.dark .apg-spinbutton-button {
+  background: color-mix(in oklch, var(--muted) 80%, var(--background));
+}
+
+.dark .apg-spinbutton-input[readonly] {
+  background: color-mix(in oklch, var(--muted) 80%, var(--background));
+}
+
+/* =============================================================================
+   ACCESSIBILITY ENHANCEMENTS
+   ============================================================================= */
+
+/* High Contrast Mode Support */
+@media (prefers-contrast: high) {
+  .apg-spinbutton-controls {
+    border-width: 2px;
+    border-color: var(--foreground);
+  }
+
+  .apg-spinbutton-input {
+    font-weight: 700;
+  }
+
+  .apg-spinbutton-button {
+    border-width: 2px;
+    font-weight: 700;
+  }
+
+  .apg-spinbutton-label {
+    font-weight: 700;
+  }
+}
+
+/* Reduced Motion Support */
+@media (prefers-reduced-motion: reduce) {
+  .apg-spinbutton-button {
+    transition: none;
+  }
+}
+
+/* Windows High Contrast Mode (Forced Colors) */
+@media (forced-colors: active) {
+  .apg-spinbutton-controls {
+    border: 2px solid ButtonBorder;
+    forced-color-adjust: none;
+  }
+
+  .apg-spinbutton-input {
+    color: ButtonText;
+    background: Field;
+    forced-color-adjust: none;
+  }
+
+  .apg-spinbutton-controls:has(.apg-spinbutton-input:focus-visible) {
+    outline: 2px solid Highlight;
+    outline-offset: 2px;
+  }
+
+  .apg-spinbutton-button {
+    color: ButtonText;
+    background: ButtonFace;
+    border-color: ButtonBorder;
+    forced-color-adjust: none;
+  }
+
+  .apg-spinbutton-button:hover:not(:disabled) {
+    background: Highlight;
+    color: HighlightText;
+  }
+
+  .apg-spinbutton-label {
+    color: ButtonText;
+  }
+
+  .apg-spinbutton--disabled .apg-spinbutton-controls {
+    border-color: GrayText;
+  }
+
+  .apg-spinbutton--disabled .apg-spinbutton-input {
+    color: GrayText;
+  }
+
+  .apg-spinbutton--disabled .apg-spinbutton-button {
+    color: GrayText;
+  }
+}


### PR DESCRIPTION
## Summary

- Implement WAI-ARIA APG Spinbutton pattern across React, Vue, Svelte, and Astro
- Add comprehensive keyboard navigation (Arrow Up/Down, Home/End, Page Up/Down)
- Support direct text input with validation and IME composition handling
- Include optional increment/decrement buttons with focus management
- Add llm.md for AI coding assistants

## Improvements from Codex Review

- Guard against `step=0` or negative values with `ensureValidStep()`
- Fix event listener memory leak in Astro Web Component (bound handler references)
- Prevent redundant `onValueChange` callbacks when value hasn't changed
- Add `mousedown.preventDefault` to prevent focus ring flickering on button clicks
- Focus ring displays on entire controls container (APG style)

## Additional Changes

- Add coding guideline to CLAUDE.md: avoid nested ternary operators
- Refactor nested ternaries to use early returns for better readability

## Test plan

- [x] All 239 unit tests pass
- [x] Manual testing of keyboard navigation
- [x] Manual testing of button interactions
- [x] Visual verification of focus ring styling
- [ ] Screen reader testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)