### PR TITLE
feat: add Japanese guide page

### DIFF
--- a/src/pages/ja/guide/index.astro
+++ b/src/pages/ja/guide/index.astro
@@ -18,8 +18,8 @@ const locale = 'ja';
     <section class="mb-12">
       <h2 class="mb-4 text-2xl font-semibold">AI コーディングアシスタントとの連携</h2>
       <p class="text-muted-foreground mb-4">
-        各パターンには AI 向けの定義ファイル（<code
-          class="bg-muted rounded px-1.5 py-0.5 text-sm">llm.md</code
+        各パターンには AI 向けの定義ファイル（<code class="bg-muted rounded px-1.5 py-0.5 text-sm"
+          >llm.md</code
         >）が含まれており、Claude、Cursor、GitHub Copilot などの AI
         コーディングアシスタントで類似コンポーネントを実装する際のコンテキストとして利用できます。
       </p>
@@ -39,8 +39,7 @@ const locale = 'ja';
         <div class="border-border rounded-lg border p-4">
           <h4 class="mb-2 font-medium">1. プロンプトにコピー&ペースト</h4>
           <p class="text-muted-foreground mb-3 text-sm">
-            内容をコピーして、AI
-            にコンポーネント実装を依頼する際のプロンプトに含めます。
+            内容をコピーして、AI にコンポーネント実装を依頼する際のプロンプトに含めます。
           </p>
           <div class="bg-muted rounded-md p-3">
             <pre
@@ -152,9 +151,7 @@ const locale = 'ja';
         <Tile variant="floating" href={withBase('/ja/patterns/switch/react/')}>
           <TileContent>
             <TileTitle>Switch</TileTitle>
-            <TileDescription>
-              aria-checked 状態を持つオン・オフトグルです。
-            </TileDescription>
+            <TileDescription> aria-checked 状態を持つオン・オフトグルです。 </TileDescription>
           </TileContent>
         </Tile>
         <Tile variant="floating" href={withBase('/ja/patterns/tabs/react/')}>
@@ -176,9 +173,7 @@ const locale = 'ja';
         <Tile variant="floating" href={withBase('/ja/patterns/tooltip/react/')}>
           <TileContent>
             <TileTitle>Tooltip</TileTitle>
-            <TileDescription>
-              要素の説明を表示するコンテキストポップアップです。
-            </TileDescription>
+            <TileDescription> 要素の説明を表示するコンテキストポップアップです。 </TileDescription>
           </TileContent>
         </Tile>
       </div>


### PR DESCRIPTION
- Create /ja/guide/index.astro with Japanese translation
- Translate all sections including AI assistant usage guide
- Add Japanese descriptions for all available patterns
- Maintain consistent structure with English version