### PR TITLE
Fix carousel image loading in production

### DIFF
--- a/src/pages/ja/patterns/carousel/react/index.astro
+++ b/src/pages/ja/patterns/carousel/react/index.astro
@@ -14,6 +14,7 @@ import { useTranslation } from '@/i18n';
 
 const locale = 'ja';
 const t = useTranslation(locale);
+const basePath = import.meta.env.BASE_URL;
 
 const tocItems = [
   { id: 'demo', text: t('pattern.demo') },
@@ -63,7 +64,7 @@ const tocItems = [
         タブインジケータ、前へ/次へボタン、またはキーボードの矢印キーで操作できます。
       </p>
       <div class="border-border bg-background rounded-lg border p-6">
-        <CarouselDemo client:load />
+        <CarouselDemo client:load basePath={basePath} />
       </div>
     </div>
 
@@ -75,7 +76,7 @@ const tocItems = [
         設定を尊重します。
       </p>
       <div class="border-border bg-background rounded-lg border p-6">
-        <CarouselDemo client:load variant="auto-rotate" />
+        <CarouselDemo client:load variant="auto-rotate" basePath={basePath} />
       </div>
     </div>
   </section>

--- a/src/pages/ja/patterns/carousel/svelte/index.astro
+++ b/src/pages/ja/patterns/carousel/svelte/index.astro
@@ -14,6 +14,7 @@ import { useTranslation } from '@/i18n';
 
 const locale = 'ja';
 const t = useTranslation(locale);
+const basePath = import.meta.env.BASE_URL;
 
 const tocItems = [
   { id: 'demo', text: t('pattern.demo') },
@@ -63,7 +64,7 @@ const tocItems = [
         タブインジケータ、前へ/次へボタン、またはキーボードの矢印キーで操作できます。
       </p>
       <div class="border-border bg-background rounded-lg border p-6">
-        <CarouselDemo client:load />
+        <CarouselDemo client:load basePath={basePath} />
       </div>
     </div>
 
@@ -75,7 +76,7 @@ const tocItems = [
         設定を尊重します。
       </p>
       <div class="border-border bg-background rounded-lg border p-6">
-        <CarouselDemo client:load variant="auto-rotate" />
+        <CarouselDemo client:load variant="auto-rotate" basePath={basePath} />
       </div>
     </div>
   </section>

--- a/src/pages/ja/patterns/carousel/vue/index.astro
+++ b/src/pages/ja/patterns/carousel/vue/index.astro
@@ -14,6 +14,7 @@ import { useTranslation } from '@/i18n';
 
 const locale = 'ja';
 const t = useTranslation(locale);
+const basePath = import.meta.env.BASE_URL;
 
 const tocItems = [
   { id: 'demo', text: t('pattern.demo') },
@@ -63,7 +64,7 @@ const tocItems = [
         タブインジケータ、前へ/次へボタン、またはキーボードの矢印キーで操作できます。
       </p>
       <div class="border-border bg-background rounded-lg border p-6">
-        <CarouselDemo client:load />
+        <CarouselDemo client:load basePath={basePath} />
       </div>
     </div>
 
@@ -75,7 +76,7 @@ const tocItems = [
         設定を尊重します。
       </p>
       <div class="border-border bg-background rounded-lg border p-6">
-        <CarouselDemo client:load variant="auto-rotate" />
+        <CarouselDemo client:load variant="auto-rotate" basePath={basePath} />
       </div>
     </div>
   </section>

--- a/src/pages/patterns/carousel/react/index.astro
+++ b/src/pages/patterns/carousel/react/index.astro
@@ -11,6 +11,8 @@ import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/carousel/Carousel.tsx?raw';
 import testCode from '@patterns/carousel/Carousel.test.tsx?raw';
 
+const basePath = import.meta.env.BASE_URL;
+
 const tocItems = [
   { id: 'demo', text: 'Demo' },
   { id: 'accessibility-features', text: 'Accessibility Features' },
@@ -54,7 +56,7 @@ const tocItems = [
         Navigate using the tab indicators, previous/next buttons, or keyboard arrows.
       </p>
       <div class="border-border bg-background rounded-lg border p-6">
-        <CarouselDemo client:load />
+        <CarouselDemo client:load basePath={basePath} />
       </div>
     </div>
 
@@ -66,7 +68,7 @@ const tocItems = [
         pause button. Respects prefers-reduced-motion.
       </p>
       <div class="border-border bg-background rounded-lg border p-6">
-        <CarouselDemo client:load variant="auto-rotate" />
+        <CarouselDemo client:load variant="auto-rotate" basePath={basePath} />
       </div>
     </div>
   </section>

--- a/src/pages/patterns/carousel/svelte/index.astro
+++ b/src/pages/patterns/carousel/svelte/index.astro
@@ -11,6 +11,8 @@ import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/carousel/Carousel.svelte?raw';
 import testCode from '@patterns/carousel/Carousel.test.svelte.ts?raw';
 
+const basePath = import.meta.env.BASE_URL;
+
 const tocItems = [
   { id: 'demo', text: 'Demo' },
   { id: 'accessibility-features', text: 'Accessibility Features' },
@@ -54,7 +56,7 @@ const tocItems = [
         Navigate using the tab indicators, previous/next buttons, or keyboard arrows.
       </p>
       <div class="border-border bg-background rounded-lg border p-6">
-        <CarouselDemo client:load />
+        <CarouselDemo client:load basePath={basePath} />
       </div>
     </div>
 
@@ -66,7 +68,7 @@ const tocItems = [
         pause button. Respects prefers-reduced-motion.
       </p>
       <div class="border-border bg-background rounded-lg border p-6">
-        <CarouselDemo client:load variant="auto-rotate" />
+        <CarouselDemo client:load variant="auto-rotate" basePath={basePath} />
       </div>
     </div>
   </section>

--- a/src/pages/patterns/carousel/vue/index.astro
+++ b/src/pages/patterns/carousel/vue/index.astro
@@ -11,6 +11,8 @@ import Heading from '@/components/ui/Heading.astro';
 import sourceCode from '@patterns/carousel/Carousel.vue?raw';
 import testCode from '@patterns/carousel/Carousel.test.vue.ts?raw';
 
+const basePath = import.meta.env.BASE_URL;
+
 const tocItems = [
   { id: 'demo', text: 'Demo' },
   { id: 'accessibility-features', text: 'Accessibility Features' },
@@ -54,7 +56,7 @@ const tocItems = [
         Navigate using the tab indicators, previous/next buttons, or keyboard arrows.
       </p>
       <div class="border-border bg-background rounded-lg border p-6">
-        <CarouselDemo client:load />
+        <CarouselDemo client:load basePath={basePath} />
       </div>
     </div>
 
@@ -66,7 +68,7 @@ const tocItems = [
         pause button. Respects prefers-reduced-motion.
       </p>
       <div class="border-border bg-background rounded-lg border p-6">
-        <CarouselDemo client:load variant="auto-rotate" />
+        <CarouselDemo client:load variant="auto-rotate" basePath={basePath} />
       </div>
     </div>
   </section>

--- a/src/patterns/carousel/CarouselDemo.astro
+++ b/src/patterns/carousel/CarouselDemo.astro
@@ -7,24 +7,24 @@ export interface Props {
 
 const { variant = 'default' } = Astro.props;
 
+const basePath = import.meta.env.BASE_URL;
+const base = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;
+
 const demoSlides = [
   {
     id: 'slide1',
     label: 'Featured Product',
-    content:
-      '<img src="/images/carousel/slide-1.svg" alt="Featured Product - Discover our latest offering" class="apg-carousel-image" />',
+    content: `<img src="${base}/images/carousel/slide-1.svg" alt="Featured Product - Discover our latest offering" class="apg-carousel-image" />`,
   },
   {
     id: 'slide2',
     label: 'New Arrivals',
-    content:
-      '<img src="/images/carousel/slide-2.svg" alt="New Arrivals - Check out the newest additions" class="apg-carousel-image" />',
+    content: `<img src="${base}/images/carousel/slide-2.svg" alt="New Arrivals - Check out the newest additions" class="apg-carousel-image" />`,
   },
   {
     id: 'slide3',
     label: 'Special Offer',
-    content:
-      '<img src="/images/carousel/slide-3.svg" alt="Special Offer - Limited time discount" class="apg-carousel-image" />',
+    content: `<img src="${base}/images/carousel/slide-3.svg" alt="Special Offer - Limited time discount" class="apg-carousel-image" />`,
   },
 ];
 
@@ -32,26 +32,22 @@ const autoRotateSlides = [
   {
     id: 'auto1',
     label: 'Breaking News',
-    content:
-      '<img src="/images/carousel/slide-4.svg" alt="Breaking News - Stay updated with the latest" class="apg-carousel-image" />',
+    content: `<img src="${base}/images/carousel/slide-4.svg" alt="Breaking News - Stay updated with the latest" class="apg-carousel-image" />`,
   },
   {
     id: 'auto2',
     label: 'Weather Update',
-    content:
-      '<img src="/images/carousel/slide-5.svg" alt="Weather Update - Sunny skies expected" class="apg-carousel-image" />',
+    content: `<img src="${base}/images/carousel/slide-5.svg" alt="Weather Update - Sunny skies expected" class="apg-carousel-image" />`,
   },
   {
     id: 'auto3',
     label: 'Sports Highlights',
-    content:
-      '<img src="/images/carousel/slide-6.svg" alt="Sports Highlights - Catch up on game results" class="apg-carousel-image" />',
+    content: `<img src="${base}/images/carousel/slide-6.svg" alt="Sports Highlights - Catch up on game results" class="apg-carousel-image" />`,
   },
   {
     id: 'auto4',
     label: 'Entertainment',
-    content:
-      '<img src="/images/carousel/slide-7.svg" alt="Entertainment - New releases and trending" class="apg-carousel-image" />',
+    content: `<img src="${base}/images/carousel/slide-7.svg" alt="Entertainment - New releases and trending" class="apg-carousel-image" />`,
   },
 ];
 ---

--- a/src/patterns/carousel/CarouselDemo.svelte
+++ b/src/patterns/carousel/CarouselDemo.svelte
@@ -3,57 +3,53 @@
 
   interface Props {
     variant?: 'default' | 'auto-rotate';
+    basePath?: string;
   }
 
-  let { variant = 'default' }: Props = $props();
+  let { variant = 'default', basePath = '' }: Props = $props();
 
-  const demoSlides = [
+  const base = $derived(basePath.endsWith('/') ? basePath.slice(0, -1) : basePath);
+
+  const demoSlides = $derived([
     {
       id: 'slide1',
       label: 'Featured Product',
-      content:
-        '<img src="/images/carousel/slide-1.svg" alt="Featured Product - Discover our latest offering" class="apg-carousel-image" />',
+      content: `<img src="${base}/images/carousel/slide-1.svg" alt="Featured Product - Discover our latest offering" class="apg-carousel-image" />`,
     },
     {
       id: 'slide2',
       label: 'New Arrivals',
-      content:
-        '<img src="/images/carousel/slide-2.svg" alt="New Arrivals - Check out the newest additions" class="apg-carousel-image" />',
+      content: `<img src="${base}/images/carousel/slide-2.svg" alt="New Arrivals - Check out the newest additions" class="apg-carousel-image" />`,
     },
     {
       id: 'slide3',
       label: 'Special Offer',
-      content:
-        '<img src="/images/carousel/slide-3.svg" alt="Special Offer - Limited time discount" class="apg-carousel-image" />',
+      content: `<img src="${base}/images/carousel/slide-3.svg" alt="Special Offer - Limited time discount" class="apg-carousel-image" />`,
     },
-  ];
+  ]);
 
-  const autoRotateSlides = [
+  const autoRotateSlides = $derived([
     {
       id: 'auto1',
       label: 'Breaking News',
-      content:
-        '<img src="/images/carousel/slide-4.svg" alt="Breaking News - Stay updated with the latest" class="apg-carousel-image" />',
+      content: `<img src="${base}/images/carousel/slide-4.svg" alt="Breaking News - Stay updated with the latest" class="apg-carousel-image" />`,
     },
     {
       id: 'auto2',
       label: 'Weather Update',
-      content:
-        '<img src="/images/carousel/slide-5.svg" alt="Weather Update - Sunny skies expected" class="apg-carousel-image" />',
+      content: `<img src="${base}/images/carousel/slide-5.svg" alt="Weather Update - Sunny skies expected" class="apg-carousel-image" />`,
     },
     {
       id: 'auto3',
       label: 'Sports Highlights',
-      content:
-        '<img src="/images/carousel/slide-6.svg" alt="Sports Highlights - Catch up on game results" class="apg-carousel-image" />',
+      content: `<img src="${base}/images/carousel/slide-6.svg" alt="Sports Highlights - Catch up on game results" class="apg-carousel-image" />`,
     },
     {
       id: 'auto4',
       label: 'Entertainment',
-      content:
-        '<img src="/images/carousel/slide-7.svg" alt="Entertainment - New releases and trending" class="apg-carousel-image" />',
+      content: `<img src="${base}/images/carousel/slide-7.svg" alt="Entertainment - New releases and trending" class="apg-carousel-image" />`,
     },
-  ];
+  ]);
 </script>
 
 {#if variant === 'auto-rotate'}

--- a/src/patterns/carousel/CarouselDemo.tsx
+++ b/src/patterns/carousel/CarouselDemo.tsx
@@ -1,97 +1,104 @@
 import { Carousel } from './Carousel';
 
-const demoSlides = [
-  {
-    id: 'slide1',
-    label: 'Featured Product',
-    content: (
-      <img
-        src="/images/carousel/slide-1.svg"
-        alt="Featured Product - Discover our latest offering"
-        className="apg-carousel-image"
-      />
-    ),
-  },
-  {
-    id: 'slide2',
-    label: 'New Arrivals',
-    content: (
-      <img
-        src="/images/carousel/slide-2.svg"
-        alt="New Arrivals - Check out the newest additions"
-        className="apg-carousel-image"
-      />
-    ),
-  },
-  {
-    id: 'slide3',
-    label: 'Special Offer',
-    content: (
-      <img
-        src="/images/carousel/slide-3.svg"
-        alt="Special Offer - Limited time discount"
-        className="apg-carousel-image"
-      />
-    ),
-  },
-];
+function createDemoSlides(basePath: string) {
+  const base = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;
+  return [
+    {
+      id: 'slide1',
+      label: 'Featured Product',
+      content: (
+        <img
+          src={`${base}/images/carousel/slide-1.svg`}
+          alt="Featured Product - Discover our latest offering"
+          className="apg-carousel-image"
+        />
+      ),
+    },
+    {
+      id: 'slide2',
+      label: 'New Arrivals',
+      content: (
+        <img
+          src={`${base}/images/carousel/slide-2.svg`}
+          alt="New Arrivals - Check out the newest additions"
+          className="apg-carousel-image"
+        />
+      ),
+    },
+    {
+      id: 'slide3',
+      label: 'Special Offer',
+      content: (
+        <img
+          src={`${base}/images/carousel/slide-3.svg`}
+          alt="Special Offer - Limited time discount"
+          className="apg-carousel-image"
+        />
+      ),
+    },
+  ];
+}
 
-const autoRotateSlides = [
-  {
-    id: 'auto1',
-    label: 'Breaking News',
-    content: (
-      <img
-        src="/images/carousel/slide-4.svg"
-        alt="Breaking News - Stay updated with the latest"
-        className="apg-carousel-image"
-      />
-    ),
-  },
-  {
-    id: 'auto2',
-    label: 'Weather Update',
-    content: (
-      <img
-        src="/images/carousel/slide-5.svg"
-        alt="Weather Update - Sunny skies expected"
-        className="apg-carousel-image"
-      />
-    ),
-  },
-  {
-    id: 'auto3',
-    label: 'Sports Highlights',
-    content: (
-      <img
-        src="/images/carousel/slide-6.svg"
-        alt="Sports Highlights - Catch up on game results"
-        className="apg-carousel-image"
-      />
-    ),
-  },
-  {
-    id: 'auto4',
-    label: 'Entertainment',
-    content: (
-      <img
-        src="/images/carousel/slide-7.svg"
-        alt="Entertainment - New releases and trending"
-        className="apg-carousel-image"
-      />
-    ),
-  },
-];
+function createAutoRotateSlides(basePath: string) {
+  const base = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;
+  return [
+    {
+      id: 'auto1',
+      label: 'Breaking News',
+      content: (
+        <img
+          src={`${base}/images/carousel/slide-4.svg`}
+          alt="Breaking News - Stay updated with the latest"
+          className="apg-carousel-image"
+        />
+      ),
+    },
+    {
+      id: 'auto2',
+      label: 'Weather Update',
+      content: (
+        <img
+          src={`${base}/images/carousel/slide-5.svg`}
+          alt="Weather Update - Sunny skies expected"
+          className="apg-carousel-image"
+        />
+      ),
+    },
+    {
+      id: 'auto3',
+      label: 'Sports Highlights',
+      content: (
+        <img
+          src={`${base}/images/carousel/slide-6.svg`}
+          alt="Sports Highlights - Catch up on game results"
+          className="apg-carousel-image"
+        />
+      ),
+    },
+    {
+      id: 'auto4',
+      label: 'Entertainment',
+      content: (
+        <img
+          src={`${base}/images/carousel/slide-7.svg`}
+          alt="Entertainment - New releases and trending"
+          className="apg-carousel-image"
+        />
+      ),
+    },
+  ];
+}
 
 export interface CarouselDemoProps {
   variant?: 'default' | 'auto-rotate';
+  basePath?: string;
 }
 
-export function CarouselDemo({ variant = 'default' }: CarouselDemoProps) {
+export function CarouselDemo({ variant = 'default', basePath = '' }: CarouselDemoProps) {
   if (variant === 'auto-rotate') {
     return (
       <Carousel
-        slides={autoRotateSlides}
+        slides={createAutoRotateSlides(basePath)}
         aria-label="News highlights"
         autoRotate
         rotationInterval={5000}
@@ -101,7 +108,11 @@ export function CarouselDemo({ variant = 'default' }: CarouselDemoProps) {
   }
 
   return (
-    <Carousel slides={demoSlides} aria-label="Featured content" data-testid="carousel-manual" />
+    <Carousel
+      slides={createDemoSlides(basePath)}
+      aria-label="Featured content"
+      data-testid="carousel-manual"
+    />
   );
 }
 

--- a/src/patterns/carousel/CarouselDemo.vue
+++ b/src/patterns/carousel/CarouselDemo.vue
@@ -16,57 +16,57 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue';
 import Carousel from './Carousel.vue';
 
-defineProps<{
+const props = defineProps<{
   variant?: 'default' | 'auto-rotate';
+  basePath?: string;
 }>();
 
-const demoSlides = [
+const base = computed(() => {
+  const path = props.basePath || '';
+  return path.endsWith('/') ? path.slice(0, -1) : path;
+});
+
+const demoSlides = computed(() => [
   {
     id: 'slide1',
     label: 'Featured Product',
-    content:
-      '<img src="/images/carousel/slide-1.svg" alt="Featured Product - Discover our latest offering" class="apg-carousel-image" />',
+    content: `<img src="${base.value}/images/carousel/slide-1.svg" alt="Featured Product - Discover our latest offering" class="apg-carousel-image" />`,
   },
   {
     id: 'slide2',
     label: 'New Arrivals',
-    content:
-      '<img src="/images/carousel/slide-2.svg" alt="New Arrivals - Check out the newest additions" class="apg-carousel-image" />',
+    content: `<img src="${base.value}/images/carousel/slide-2.svg" alt="New Arrivals - Check out the newest additions" class="apg-carousel-image" />`,
   },
   {
     id: 'slide3',
     label: 'Special Offer',
-    content:
-      '<img src="/images/carousel/slide-3.svg" alt="Special Offer - Limited time discount" class="apg-carousel-image" />',
+    content: `<img src="${base.value}/images/carousel/slide-3.svg" alt="Special Offer - Limited time discount" class="apg-carousel-image" />`,
   },
-];
+]);
 
-const autoRotateSlides = [
+const autoRotateSlides = computed(() => [
   {
     id: 'auto1',
     label: 'Breaking News',
-    content:
-      '<img src="/images/carousel/slide-4.svg" alt="Breaking News - Stay updated with the latest" class="apg-carousel-image" />',
+    content: `<img src="${base.value}/images/carousel/slide-4.svg" alt="Breaking News - Stay updated with the latest" class="apg-carousel-image" />`,
   },
   {
     id: 'auto2',
     label: 'Weather Update',
-    content:
-      '<img src="/images/carousel/slide-5.svg" alt="Weather Update - Sunny skies expected" class="apg-carousel-image" />',
+    content: `<img src="${base.value}/images/carousel/slide-5.svg" alt="Weather Update - Sunny skies expected" class="apg-carousel-image" />`,
   },
   {
     id: 'auto3',
     label: 'Sports Highlights',
-    content:
-      '<img src="/images/carousel/slide-6.svg" alt="Sports Highlights - Catch up on game results" class="apg-carousel-image" />',
+    content: `<img src="${base.value}/images/carousel/slide-6.svg" alt="Sports Highlights - Catch up on game results" class="apg-carousel-image" />`,
   },
   {
     id: 'auto4',
     label: 'Entertainment',
-    content:
-      '<img src="/images/carousel/slide-7.svg" alt="Entertainment - New releases and trending" class="apg-carousel-image" />',
+    content: `<img src="${base.value}/images/carousel/slide-7.svg" alt="Entertainment - New releases and trending" class="apg-carousel-image" />`,
   },
-];
+]);
 </script>


### PR DESCRIPTION
Image paths in carousel demos were using absolute paths like `/images/carousel/slide-*.svg` which fail on GitHub Pages where the site is deployed to a subdirectory `/apg-patterns-examples`.

- Add basePath prop to CarouselDemo components (React, Vue, Svelte)
- Use import.meta.env.BASE_URL in CarouselDemo.astro
- Pass basePath from page files to demo components
- Normalize base path to avoid double slashes

