### PR TITLE
feat(landmarks): add APG landmarks pattern for all frameworks

### DIFF
--- a/e2e/landmarks.spec.ts
+++ b/e2e/landmarks.spec.ts
@@ -1,0 +1,245 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+/**
+ * E2E Tests for Landmarks Pattern
+ *
+ * These tests verify the landmark structure and accessibility
+ * across all framework implementations.
+ *
+ * Note: Tests use isolated demo pages (/patterns/landmarks/{framework}/demo/) that render
+ * only the LandmarkDemo component without the site layout. This ensures proper
+ * landmark semantics are preserved (e.g., <header> retains its implicit banner role).
+ *
+ * Note: Landmarks are static structural elements without JavaScript
+ * interaction, so these tests primarily verify:
+ * - Correct landmark roles are present
+ * - Proper labeling of landmarks
+ * - No accessibility violations
+ */
+
+const frameworks = ['react', 'vue', 'svelte', 'astro'] as const;
+
+for (const framework of frameworks) {
+  test.describe(`Landmarks (${framework})`, () => {
+    test.beforeEach(async ({ page }) => {
+      // Use isolated demo page without site layout
+      await page.goto(`patterns/landmarks/${framework}/demo/`);
+      await page.waitForLoadState('networkidle');
+    });
+
+    test.describe('Landmark Roles', () => {
+      test('demo has banner landmark', async ({ page }) => {
+        const demo = page.locator('.apg-landmark-demo');
+        const banner = demo.getByRole('banner');
+        await expect(banner).toBeVisible();
+      });
+
+      test('demo has navigation landmark', async ({ page }) => {
+        const demo = page.locator('.apg-landmark-demo');
+        const navs = demo.getByRole('navigation');
+        await expect(navs.first()).toBeVisible();
+      });
+
+      test('demo has main landmark', async ({ page }) => {
+        const demo = page.locator('.apg-landmark-demo');
+        const main = demo.getByRole('main');
+        await expect(main).toBeVisible();
+      });
+
+      test('demo has contentinfo landmark', async ({ page }) => {
+        const demo = page.locator('.apg-landmark-demo');
+        const contentinfo = demo.getByRole('contentinfo');
+        await expect(contentinfo).toBeVisible();
+      });
+
+      test('demo has complementary landmark', async ({ page }) => {
+        const demo = page.locator('.apg-landmark-demo');
+        const aside = demo.getByRole('complementary');
+        await expect(aside).toBeVisible();
+      });
+
+      test('demo has region landmark', async ({ page }) => {
+        const demo = page.locator('.apg-landmark-demo');
+        const region = demo.getByRole('region');
+        await expect(region).toBeVisible();
+      });
+
+      test('demo has search landmark', async ({ page }) => {
+        const demo = page.locator('.apg-landmark-demo');
+        const search = demo.getByRole('search');
+        await expect(search).toBeVisible();
+      });
+
+      test('demo has form landmark', async ({ page }) => {
+        const demo = page.locator('.apg-landmark-demo');
+        const form = demo.getByRole('form');
+        await expect(form).toBeVisible();
+      });
+
+      test('demo has exactly one main landmark', async ({ page }) => {
+        const demo = page.locator('.apg-landmark-demo');
+        const mains = demo.getByRole('main');
+        await expect(mains).toHaveCount(1);
+      });
+
+      test('demo has exactly one banner landmark', async ({ page }) => {
+        const demo = page.locator('.apg-landmark-demo');
+        const banners = demo.getByRole('banner');
+        await expect(banners).toHaveCount(1);
+      });
+
+      test('demo has exactly one contentinfo landmark', async ({ page }) => {
+        const demo = page.locator('.apg-landmark-demo');
+        const contentinfos = demo.getByRole('contentinfo');
+        await expect(contentinfos).toHaveCount(1);
+      });
+    });
+
+    test.describe('Landmark Labeling', () => {
+      test('navigation landmarks have unique accessible names', async ({ page }) => {
+        const demo = page.locator('.apg-landmark-demo');
+        const navs = demo.getByRole('navigation');
+        const count = await navs.count();
+
+        if (count > 1) {
+          const names: string[] = [];
+          for (let i = 0; i < count; i++) {
+            const nav = navs.nth(i);
+            const name = await nav.getAttribute('aria-label');
+            if (name) names.push(name);
+          }
+          const uniqueNames = new Set(names);
+          expect(uniqueNames.size).toBe(count);
+        }
+      });
+
+      test('region landmark has accessible name', async ({ page }) => {
+        const demo = page.locator('.apg-landmark-demo');
+        const region = demo.getByRole('region');
+        // Match any non-empty accessible name
+        await expect(region).toHaveAccessibleName(/.+/);
+      });
+
+      test('search landmark has accessible name', async ({ page }) => {
+        const demo = page.locator('.apg-landmark-demo');
+        const search = demo.getByRole('search');
+        await expect(search).toHaveAccessibleName(/.+/);
+      });
+
+      test('form landmark has accessible name', async ({ page }) => {
+        const demo = page.locator('.apg-landmark-demo');
+        const form = demo.getByRole('form');
+        await expect(form).toHaveAccessibleName(/.+/);
+      });
+
+      test('complementary landmark has accessible name', async ({ page }) => {
+        const demo = page.locator('.apg-landmark-demo');
+        const aside = demo.getByRole('complementary');
+        await expect(aside).toHaveAccessibleName(/.+/);
+      });
+    });
+
+    test.describe('Accessibility', () => {
+      test('has no axe-core violations', async ({ page }) => {
+        // Focus on the landmark demo area
+        const demo = page.locator('.apg-landmark-demo');
+        await expect(demo).toBeVisible();
+
+        const accessibilityScanResults = await new AxeBuilder({ page })
+          .include('.apg-landmark-demo')
+          .analyze();
+
+        expect(accessibilityScanResults.violations).toEqual([]);
+      });
+    });
+
+    test.describe('Visual Labels', () => {
+      test('landmark labels are visible when showLabels is enabled', async ({ page }) => {
+        // Look for the toggle button or check if labels are visible
+        const labels = page.locator('.apg-landmark-label');
+
+        // If the demo shows labels by default
+        const labelCount = await labels.count();
+        if (labelCount > 0) {
+          // Check at least some labels are visible
+          await expect(labels.first()).toBeVisible();
+        }
+      });
+    });
+
+    test.describe('Accessibility Tree Structure', () => {
+      test('main landmark contains region, search, form, and complementary', async ({ page }) => {
+        const demo = page.locator('.apg-landmark-demo');
+        const main = demo.getByRole('main');
+
+        // Verify main contains expected child landmarks
+        await expect(main.getByRole('region')).toBeVisible();
+        await expect(main.getByRole('search')).toBeVisible();
+        await expect(main.getByRole('form')).toBeVisible();
+        await expect(main.getByRole('complementary')).toBeVisible();
+      });
+
+      test('banner contains main navigation', async ({ page }) => {
+        const demo = page.locator('.apg-landmark-demo');
+        const banner = demo.getByRole('banner');
+
+        // Verify banner contains navigation with "Main" label
+        const mainNav = banner.getByRole('navigation', { name: 'Main' });
+        await expect(mainNav).toBeVisible();
+
+        // Verify navigation has links
+        await expect(mainNav.getByRole('link', { name: 'Home' })).toBeVisible();
+        await expect(mainNav.getByRole('link', { name: 'About' })).toBeVisible();
+        await expect(mainNav.getByRole('link', { name: 'Contact' })).toBeVisible();
+      });
+
+      test('contentinfo contains footer navigation', async ({ page }) => {
+        const demo = page.locator('.apg-landmark-demo');
+        const contentinfo = demo.getByRole('contentinfo');
+
+        // Verify contentinfo contains navigation with "Footer" label
+        const footerNav = contentinfo.getByRole('navigation', { name: 'Footer' });
+        await expect(footerNav).toBeVisible();
+
+        // Verify navigation has links
+        await expect(footerNav.getByRole('link', { name: 'Privacy' })).toBeVisible();
+        await expect(footerNav.getByRole('link', { name: 'Terms' })).toBeVisible();
+        await expect(footerNav.getByRole('link', { name: 'Sitemap' })).toBeVisible();
+      });
+    });
+  });
+}
+
+// Cross-framework consistency tests
+test.describe('Landmarks - Cross-framework Consistency', () => {
+  test('all frameworks render same landmark structure', async ({ page }) => {
+    const landmarkCounts: Record<string, Record<string, number>> = {};
+
+    for (const framework of frameworks) {
+      // Use isolated demo page without site layout
+      await page.goto(`patterns/landmarks/${framework}/demo/`);
+      await page.waitForLoadState('networkidle');
+
+      // Scope all queries to the demo component
+      const demo = page.locator('.apg-landmark-demo');
+
+      landmarkCounts[framework] = {
+        banner: await demo.getByRole('banner').count(),
+        navigation: await demo.getByRole('navigation').count(),
+        main: await demo.getByRole('main').count(),
+        contentinfo: await demo.getByRole('contentinfo').count(),
+        complementary: await demo.getByRole('complementary').count(),
+        region: await demo.getByRole('region').count(),
+        search: await demo.getByRole('search').count(),
+        form: await demo.getByRole('form').count(),
+      };
+    }
+
+    // All frameworks should have the same counts
+    const reactCounts = landmarkCounts['react'];
+    for (const framework of frameworks) {
+      expect(landmarkCounts[framework]).toEqual(reactCounts);
+    }
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.6",
+        "@axe-core/playwright": "^4.11.0",
         "@playwright/test": "^1.57.0",
         "@sveltejs/vite-plugin-svelte": "^6.2.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -469,6 +470,29 @@
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.5.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.0.tgz",
+      "integrity": "sha512-70vBT/Ylqpm65RQz2iCG2o0JJCEG/WCNyefTr2xcOcr1CoSee60gNQYUMZZ7YukoKkFLv26I/jjlsvwwp532oQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.0"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright/node_modules/axe-core": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.6",
+    "@axe-core/playwright": "^4.11.0",
     "@playwright/test": "^1.57.0",
     "@sveltejs/vite-plugin-svelte": "^6.2.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/src/lib/patterns.ts
+++ b/src/lib/patterns.ts
@@ -138,7 +138,7 @@ export const PATTERNS: Pattern[] = [
     description: 'A set of eight roles that identify the major sections of a page.',
     icon: '🗺️',
     complexity: 'Low',
-    status: 'planned',
+    status: 'available',
   },
   {
     id: 'link',

--- a/src/pages/ja/patterns/landmarks/astro/index.astro
+++ b/src/pages/ja/patterns/landmarks/astro/index.astro
@@ -1,0 +1,137 @@
+---
+import PatternLayout from '../../../../../layouts/PatternLayout.astro';
+import LandmarkDemo from '@patterns/landmarks/LandmarkDemo.astro';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
+import AccessibilityDocs from '@patterns/landmarks/AccessibilityDocs.ja.astro';
+import TestingDocs from '@patterns/landmarks/TestingDocs.ja.astro';
+import NativeHtmlNotice from '@patterns/landmarks/NativeHtmlNotice.ja.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/landmarks/LandmarkDemo.astro?raw';
+import testCode from '@patterns/landmarks/LandmarkDemo.test.astro.ts?raw';
+import { useTranslation } from '@/i18n';
+
+const locale = 'ja';
+const t = useTranslation(locale);
+
+const tocItems = [
+  { id: 'demo', text: t('pattern.demo') },
+  { id: 'native-html', text: 'Native HTML' },
+  { id: 'accessibility-features', text: t('pattern.accessibility') },
+  { id: 'source-code', text: t('pattern.sourceCode') },
+  { id: 'testing', text: t('pattern.testing') },
+  { id: 'resources', text: t('pattern.resources') },
+];
+---
+
+<PatternLayout
+  title="ランドマーク - Astro"
+  pattern="landmarks"
+  framework="astro"
+  tocItems={tocItems}
+  locale={locale}
+>
+  <header class="mb-8">
+    <h1 class="mb-4 text-3xl font-bold">Landmarks</h1>
+    <p class="text-muted-foreground text-lg">
+      ページの主要セクションを識別する8つのARIAランドマークロールのセット。支援技術ユーザーのナビゲーションを効率化します。
+    </p>
+    <AiGuideBadge pattern="landmarks" />
+  </header>
+
+  <!-- Framework Selector -->
+  <FrameworkTabs pattern="landmarks" currentFramework="astro" locale={locale} />
+
+  <!-- Demo Section -->
+  <section class="mb-12">
+    <Heading level={2} id="demo" class="mb-4 text-xl font-semibold">{t('pattern.demo')}</Heading>
+    <p class="text-muted-foreground mb-4">
+      このデモでは8つのランドマーク領域を色分けされたボーダーで視覚化しています。各ランドマークにはロールを識別するためのラベルが表示されています。
+    </p>
+    <div class="border-border bg-background rounded-lg border p-6">
+      <LandmarkDemo showLabels={true} />
+    </div>
+  </section>
+
+  <!-- Native HTML Section -->
+  <section class="mb-12">
+    <Heading level={2} id="native-html" class="mb-4 text-xl font-semibold">Native HTML</Heading>
+    <NativeHtmlNotice />
+  </section>
+
+  <!-- Accessibility Section -->
+  <section class="mb-12">
+    <Heading level={2} id="accessibility-features" class="mb-4 text-xl font-semibold"
+      >{t('pattern.accessibility')}</Heading
+    >
+    <AccessibilityDocs />
+  </section>
+
+  <!-- Source Code Section -->
+  <section class="mb-12">
+    <Heading level={2} id="source-code" class="mb-4 text-xl font-semibold"
+      >{t('pattern.sourceCode')}</Heading
+    >
+    <CodeBlock
+      collapsible
+      collapsedLines={5}
+      code={sourceCode}
+      lang="astro"
+      title="LandmarkDemo.astro"
+    />
+  </section>
+
+  <!-- Testing Section -->
+  <section class="mb-12">
+    <Heading level={2} id="testing" class="mb-4 text-xl font-semibold"
+      >{t('pattern.testing')}</Heading
+    >
+    <TestingDocs />
+    <div class="mt-6">
+      <CodeBlock
+        collapsible
+        collapsedLines={5}
+        code={testCode}
+        lang="typescript"
+        title="LandmarkDemo.test.astro.ts"
+      />
+    </div>
+  </section>
+
+  <!-- Resources -->
+  <section>
+    <Heading level={2} id="resources" class="mb-4 text-xl font-semibold"
+      >{t('pattern.resources')}</Heading
+    >
+    <ul class="list-disc space-y-2 pl-6">
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: ランドマークパターン
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: ランドマーク領域
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/landmark_role"
+          class="text-primary hover:underline"
+        >
+          MDN: ARIA ランドマークロール
+        </ExternalLink>
+      </li>
+      <AiGuideResourceItem pattern="landmarks" />
+    </ul>
+  </section>
+</PatternLayout>

--- a/src/pages/ja/patterns/landmarks/react/index.astro
+++ b/src/pages/ja/patterns/landmarks/react/index.astro
@@ -1,0 +1,137 @@
+---
+import PatternLayout from '../../../../../layouts/PatternLayout.astro';
+import { LandmarkDemo } from '@patterns/landmarks/LandmarkDemo';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
+import AccessibilityDocs from '@patterns/landmarks/AccessibilityDocs.ja.astro';
+import TestingDocs from '@patterns/landmarks/TestingDocs.ja.astro';
+import NativeHtmlNotice from '@patterns/landmarks/NativeHtmlNotice.ja.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/landmarks/LandmarkDemo.tsx?raw';
+import testCode from '@patterns/landmarks/LandmarkDemo.test.tsx?raw';
+import { useTranslation } from '@/i18n';
+
+const locale = 'ja';
+const t = useTranslation(locale);
+
+const tocItems = [
+  { id: 'demo', text: t('pattern.demo') },
+  { id: 'native-html', text: 'Native HTML' },
+  { id: 'accessibility-features', text: t('pattern.accessibility') },
+  { id: 'source-code', text: t('pattern.sourceCode') },
+  { id: 'testing', text: t('pattern.testing') },
+  { id: 'resources', text: t('pattern.resources') },
+];
+---
+
+<PatternLayout
+  title="ランドマーク - React"
+  pattern="landmarks"
+  framework="react"
+  tocItems={tocItems}
+  locale={locale}
+>
+  <header class="mb-8">
+    <h1 class="mb-4 text-3xl font-bold">Landmarks</h1>
+    <p class="text-muted-foreground text-lg">
+      ページの主要セクションを識別する8つのARIAランドマークロールのセット。支援技術ユーザーのナビゲーションを効率化します。
+    </p>
+    <AiGuideBadge pattern="landmarks" />
+  </header>
+
+  <!-- Framework Selector -->
+  <FrameworkTabs pattern="landmarks" currentFramework="react" locale={locale} />
+
+  <!-- Demo Section -->
+  <section class="mb-12">
+    <Heading level={2} id="demo" class="mb-4 text-xl font-semibold">{t('pattern.demo')}</Heading>
+    <p class="text-muted-foreground mb-4">
+      このデモでは8つのランドマーク領域を色分けされたボーダーで視覚化しています。各ランドマークにはロールを識別するためのラベルが表示されています。
+    </p>
+    <div class="border-border bg-background rounded-lg border p-6">
+      <LandmarkDemo showLabels={true} />
+    </div>
+  </section>
+
+  <!-- Native HTML Section -->
+  <section class="mb-12">
+    <Heading level={2} id="native-html" class="mb-4 text-xl font-semibold">Native HTML</Heading>
+    <NativeHtmlNotice />
+  </section>
+
+  <!-- Accessibility Section -->
+  <section class="mb-12">
+    <Heading level={2} id="accessibility-features" class="mb-4 text-xl font-semibold"
+      >{t('pattern.accessibility')}</Heading
+    >
+    <AccessibilityDocs />
+  </section>
+
+  <!-- Source Code Section -->
+  <section class="mb-12">
+    <Heading level={2} id="source-code" class="mb-4 text-xl font-semibold"
+      >{t('pattern.sourceCode')}</Heading
+    >
+    <CodeBlock
+      collapsible
+      collapsedLines={5}
+      code={sourceCode}
+      lang="tsx"
+      title="LandmarkDemo.tsx"
+    />
+  </section>
+
+  <!-- Testing Section -->
+  <section class="mb-12">
+    <Heading level={2} id="testing" class="mb-4 text-xl font-semibold"
+      >{t('pattern.testing')}</Heading
+    >
+    <TestingDocs />
+    <div class="mt-6">
+      <CodeBlock
+        collapsible
+        collapsedLines={5}
+        code={testCode}
+        lang="tsx"
+        title="LandmarkDemo.test.tsx"
+      />
+    </div>
+  </section>
+
+  <!-- Resources -->
+  <section>
+    <Heading level={2} id="resources" class="mb-4 text-xl font-semibold"
+      >{t('pattern.resources')}</Heading
+    >
+    <ul class="list-disc space-y-2 pl-6">
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: ランドマークパターン
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: ランドマーク領域
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/landmark_role"
+          class="text-primary hover:underline"
+        >
+          MDN: ARIA ランドマークロール
+        </ExternalLink>
+      </li>
+      <AiGuideResourceItem pattern="landmarks" />
+    </ul>
+  </section>
+</PatternLayout>

--- a/src/pages/ja/patterns/landmarks/svelte/index.astro
+++ b/src/pages/ja/patterns/landmarks/svelte/index.astro
@@ -1,0 +1,137 @@
+---
+import PatternLayout from '../../../../../layouts/PatternLayout.astro';
+import LandmarkDemo from '@patterns/landmarks/LandmarkDemo.svelte';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
+import AccessibilityDocs from '@patterns/landmarks/AccessibilityDocs.ja.astro';
+import TestingDocs from '@patterns/landmarks/TestingDocs.ja.astro';
+import NativeHtmlNotice from '@patterns/landmarks/NativeHtmlNotice.ja.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/landmarks/LandmarkDemo.svelte?raw';
+import testCode from '@patterns/landmarks/LandmarkDemo.test.svelte.ts?raw';
+import { useTranslation } from '@/i18n';
+
+const locale = 'ja';
+const t = useTranslation(locale);
+
+const tocItems = [
+  { id: 'demo', text: t('pattern.demo') },
+  { id: 'native-html', text: 'Native HTML' },
+  { id: 'accessibility-features', text: t('pattern.accessibility') },
+  { id: 'source-code', text: t('pattern.sourceCode') },
+  { id: 'testing', text: t('pattern.testing') },
+  { id: 'resources', text: t('pattern.resources') },
+];
+---
+
+<PatternLayout
+  title="ランドマーク - Svelte"
+  pattern="landmarks"
+  framework="svelte"
+  tocItems={tocItems}
+  locale={locale}
+>
+  <header class="mb-8">
+    <h1 class="mb-4 text-3xl font-bold">Landmarks</h1>
+    <p class="text-muted-foreground text-lg">
+      ページの主要セクションを識別する8つのARIAランドマークロールのセット。支援技術ユーザーのナビゲーションを効率化します。
+    </p>
+    <AiGuideBadge pattern="landmarks" />
+  </header>
+
+  <!-- Framework Selector -->
+  <FrameworkTabs pattern="landmarks" currentFramework="svelte" locale={locale} />
+
+  <!-- Demo Section -->
+  <section class="mb-12">
+    <Heading level={2} id="demo" class="mb-4 text-xl font-semibold">{t('pattern.demo')}</Heading>
+    <p class="text-muted-foreground mb-4">
+      このデモでは8つのランドマーク領域を色分けされたボーダーで視覚化しています。各ランドマークにはロールを識別するためのラベルが表示されています。
+    </p>
+    <div class="border-border bg-background rounded-lg border p-6">
+      <LandmarkDemo showLabels={true} />
+    </div>
+  </section>
+
+  <!-- Native HTML Section -->
+  <section class="mb-12">
+    <Heading level={2} id="native-html" class="mb-4 text-xl font-semibold">Native HTML</Heading>
+    <NativeHtmlNotice />
+  </section>
+
+  <!-- Accessibility Section -->
+  <section class="mb-12">
+    <Heading level={2} id="accessibility-features" class="mb-4 text-xl font-semibold"
+      >{t('pattern.accessibility')}</Heading
+    >
+    <AccessibilityDocs />
+  </section>
+
+  <!-- Source Code Section -->
+  <section class="mb-12">
+    <Heading level={2} id="source-code" class="mb-4 text-xl font-semibold"
+      >{t('pattern.sourceCode')}</Heading
+    >
+    <CodeBlock
+      collapsible
+      collapsedLines={5}
+      code={sourceCode}
+      lang="svelte"
+      title="LandmarkDemo.svelte"
+    />
+  </section>
+
+  <!-- Testing Section -->
+  <section class="mb-12">
+    <Heading level={2} id="testing" class="mb-4 text-xl font-semibold"
+      >{t('pattern.testing')}</Heading
+    >
+    <TestingDocs />
+    <div class="mt-6">
+      <CodeBlock
+        collapsible
+        collapsedLines={5}
+        code={testCode}
+        lang="typescript"
+        title="LandmarkDemo.test.svelte.ts"
+      />
+    </div>
+  </section>
+
+  <!-- Resources -->
+  <section>
+    <Heading level={2} id="resources" class="mb-4 text-xl font-semibold"
+      >{t('pattern.resources')}</Heading
+    >
+    <ul class="list-disc space-y-2 pl-6">
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: ランドマークパターン
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: ランドマーク領域
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/landmark_role"
+          class="text-primary hover:underline"
+        >
+          MDN: ARIA ランドマークロール
+        </ExternalLink>
+      </li>
+      <AiGuideResourceItem pattern="landmarks" />
+    </ul>
+  </section>
+</PatternLayout>

--- a/src/pages/ja/patterns/landmarks/vue/index.astro
+++ b/src/pages/ja/patterns/landmarks/vue/index.astro
@@ -1,0 +1,137 @@
+---
+import PatternLayout from '../../../../../layouts/PatternLayout.astro';
+import LandmarkDemo from '@patterns/landmarks/LandmarkDemo.vue';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
+import AccessibilityDocs from '@patterns/landmarks/AccessibilityDocs.ja.astro';
+import TestingDocs from '@patterns/landmarks/TestingDocs.ja.astro';
+import NativeHtmlNotice from '@patterns/landmarks/NativeHtmlNotice.ja.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/landmarks/LandmarkDemo.vue?raw';
+import testCode from '@patterns/landmarks/LandmarkDemo.test.vue.ts?raw';
+import { useTranslation } from '@/i18n';
+
+const locale = 'ja';
+const t = useTranslation(locale);
+
+const tocItems = [
+  { id: 'demo', text: t('pattern.demo') },
+  { id: 'native-html', text: 'Native HTML' },
+  { id: 'accessibility-features', text: t('pattern.accessibility') },
+  { id: 'source-code', text: t('pattern.sourceCode') },
+  { id: 'testing', text: t('pattern.testing') },
+  { id: 'resources', text: t('pattern.resources') },
+];
+---
+
+<PatternLayout
+  title="ランドマーク - Vue"
+  pattern="landmarks"
+  framework="vue"
+  tocItems={tocItems}
+  locale={locale}
+>
+  <header class="mb-8">
+    <h1 class="mb-4 text-3xl font-bold">Landmarks</h1>
+    <p class="text-muted-foreground text-lg">
+      ページの主要セクションを識別する8つのARIAランドマークロールのセット。支援技術ユーザーのナビゲーションを効率化します。
+    </p>
+    <AiGuideBadge pattern="landmarks" />
+  </header>
+
+  <!-- Framework Selector -->
+  <FrameworkTabs pattern="landmarks" currentFramework="vue" locale={locale} />
+
+  <!-- Demo Section -->
+  <section class="mb-12">
+    <Heading level={2} id="demo" class="mb-4 text-xl font-semibold">{t('pattern.demo')}</Heading>
+    <p class="text-muted-foreground mb-4">
+      このデモでは8つのランドマーク領域を色分けされたボーダーで視覚化しています。各ランドマークにはロールを識別するためのラベルが表示されています。
+    </p>
+    <div class="border-border bg-background rounded-lg border p-6">
+      <LandmarkDemo showLabels={true} />
+    </div>
+  </section>
+
+  <!-- Native HTML Section -->
+  <section class="mb-12">
+    <Heading level={2} id="native-html" class="mb-4 text-xl font-semibold">Native HTML</Heading>
+    <NativeHtmlNotice />
+  </section>
+
+  <!-- Accessibility Section -->
+  <section class="mb-12">
+    <Heading level={2} id="accessibility-features" class="mb-4 text-xl font-semibold"
+      >{t('pattern.accessibility')}</Heading
+    >
+    <AccessibilityDocs />
+  </section>
+
+  <!-- Source Code Section -->
+  <section class="mb-12">
+    <Heading level={2} id="source-code" class="mb-4 text-xl font-semibold"
+      >{t('pattern.sourceCode')}</Heading
+    >
+    <CodeBlock
+      collapsible
+      collapsedLines={5}
+      code={sourceCode}
+      lang="vue"
+      title="LandmarkDemo.vue"
+    />
+  </section>
+
+  <!-- Testing Section -->
+  <section class="mb-12">
+    <Heading level={2} id="testing" class="mb-4 text-xl font-semibold"
+      >{t('pattern.testing')}</Heading
+    >
+    <TestingDocs />
+    <div class="mt-6">
+      <CodeBlock
+        collapsible
+        collapsedLines={5}
+        code={testCode}
+        lang="typescript"
+        title="LandmarkDemo.test.vue.ts"
+      />
+    </div>
+  </section>
+
+  <!-- Resources -->
+  <section>
+    <Heading level={2} id="resources" class="mb-4 text-xl font-semibold"
+      >{t('pattern.resources')}</Heading
+    >
+    <ul class="list-disc space-y-2 pl-6">
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: ランドマークパターン
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: ランドマーク領域
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/landmark_role"
+          class="text-primary hover:underline"
+        >
+          MDN: ARIA ランドマークロール
+        </ExternalLink>
+      </li>
+      <AiGuideResourceItem pattern="landmarks" />
+    </ul>
+  </section>
+</PatternLayout>

--- a/src/pages/patterns/landmarks/astro/demo/index.astro
+++ b/src/pages/patterns/landmarks/astro/demo/index.astro
@@ -1,0 +1,28 @@
+---
+/**
+ * Demo-only Page: LandmarkDemo (Astro)
+ *
+ * This page renders the LandmarkDemo component in isolation without
+ * the site layout. This ensures proper landmark semantics are preserved
+ * (e.g., <header> retains its implicit banner role).
+ *
+ * Used for:
+ * - E2E testing with correct landmark structure
+ * - Standalone demo viewing
+ */
+import '@/styles/global.css';
+import LandmarkDemo from '@patterns/landmarks/LandmarkDemo.astro';
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Demo: Landmarks (Astro)</title>
+  </head>
+  <body>
+    <LandmarkDemo showLabels={true} />
+  </body>
+</html>

--- a/src/pages/patterns/landmarks/astro/index.astro
+++ b/src/pages/patterns/landmarks/astro/index.astro
@@ -1,0 +1,124 @@
+---
+import PatternLayout from '../../../../layouts/PatternLayout.astro';
+import LandmarkDemo from '@patterns/landmarks/LandmarkDemo.astro';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
+import AccessibilityDocs from '@patterns/landmarks/AccessibilityDocs.astro';
+import TestingDocs from '@patterns/landmarks/TestingDocs.astro';
+import NativeHtmlNotice from '@patterns/landmarks/NativeHtmlNotice.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/landmarks/LandmarkDemo.astro?raw';
+import testCode from '@patterns/landmarks/LandmarkDemo.test.astro.ts?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'native-html', text: 'Native HTML' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
+---
+
+<PatternLayout title="Landmarks - Astro" pattern="landmarks" framework="astro" tocItems={tocItems}>
+  <header class="mb-8">
+    <h1 class="mb-4 text-3xl font-bold">Landmarks</h1>
+    <p class="text-muted-foreground text-lg">
+      A set of eight ARIA landmark roles that identify the major sections of a page for assistive
+      technology users.
+    </p>
+    <AiGuideBadge pattern="landmarks" />
+  </header>
+
+  <!-- Framework Selector -->
+  <FrameworkTabs pattern="landmarks" currentFramework="astro" />
+
+  <!-- Demo Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Demo</Heading>
+    <p class="text-muted-foreground mb-4">
+      This demo visualizes the 8 landmark regions with distinct colored borders. Each landmark is
+      labeled to help identify its role.
+    </p>
+    <div class="border-border bg-background rounded-lg border p-6">
+      <LandmarkDemo showLabels={true} />
+    </div>
+    <p class="text-muted-foreground mt-2 text-sm">
+      <a href="./demo/" class="text-primary hover:underline">Open demo only →</a>
+    </p>
+  </section>
+
+  <!-- Native HTML Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Native HTML</Heading>
+    <NativeHtmlNotice />
+  </section>
+
+  <!-- Accessibility Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Accessibility Features</Heading>
+    <AccessibilityDocs />
+  </section>
+
+  <!-- Source Code Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Source Code</Heading>
+    <CodeBlock
+      collapsible
+      collapsedLines={5}
+      code={sourceCode}
+      lang="astro"
+      title="LandmarkDemo.astro"
+    />
+  </section>
+
+  <!-- Testing Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Testing</Heading>
+    <TestingDocs />
+    <div class="mt-6">
+      <CodeBlock
+        collapsible
+        collapsedLines={5}
+        code={testCode}
+        lang="typescript"
+        title="LandmarkDemo.test.astro.ts"
+      />
+    </div>
+  </section>
+
+  <!-- Resources -->
+  <section>
+    <Heading level={2} class="mb-4 text-xl font-semibold">Resources</Heading>
+    <ul class="list-disc space-y-2 pl-6">
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Landmarks Pattern
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Landmark Regions
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/landmark_role"
+          class="text-primary hover:underline"
+        >
+          MDN: ARIA Landmark Roles
+        </ExternalLink>
+      </li>
+      <AiGuideResourceItem pattern="landmarks" />
+    </ul>
+  </section>
+</PatternLayout>

--- a/src/pages/patterns/landmarks/react/demo/index.astro
+++ b/src/pages/patterns/landmarks/react/demo/index.astro
@@ -1,0 +1,28 @@
+---
+/**
+ * Demo-only Page: LandmarkDemo (React)
+ *
+ * This page renders the LandmarkDemo component in isolation without
+ * the site layout. This ensures proper landmark semantics are preserved
+ * (e.g., <header> retains its implicit banner role).
+ *
+ * Used for:
+ * - E2E testing with correct landmark structure
+ * - Standalone demo viewing
+ */
+import '@/styles/global.css';
+import LandmarkDemo from '@patterns/landmarks/LandmarkDemo.tsx';
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Demo: Landmarks (React)</title>
+  </head>
+  <body>
+    <LandmarkDemo client:load showLabels={true} />
+  </body>
+</html>

--- a/src/pages/patterns/landmarks/react/index.astro
+++ b/src/pages/patterns/landmarks/react/index.astro
@@ -1,0 +1,124 @@
+---
+import PatternLayout from '../../../../layouts/PatternLayout.astro';
+import { LandmarkDemo } from '@patterns/landmarks/LandmarkDemo';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
+import AccessibilityDocs from '@patterns/landmarks/AccessibilityDocs.astro';
+import TestingDocs from '@patterns/landmarks/TestingDocs.astro';
+import NativeHtmlNotice from '@patterns/landmarks/NativeHtmlNotice.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/landmarks/LandmarkDemo.tsx?raw';
+import testCode from '@patterns/landmarks/LandmarkDemo.test.tsx?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'native-html', text: 'Native HTML' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
+---
+
+<PatternLayout title="Landmarks - React" pattern="landmarks" framework="react" tocItems={tocItems}>
+  <header class="mb-8">
+    <h1 class="mb-4 text-3xl font-bold">Landmarks</h1>
+    <p class="text-muted-foreground text-lg">
+      A set of eight ARIA landmark roles that identify the major sections of a page for assistive
+      technology users.
+    </p>
+    <AiGuideBadge pattern="landmarks" />
+  </header>
+
+  <!-- Framework Selector -->
+  <FrameworkTabs pattern="landmarks" currentFramework="react" />
+
+  <!-- Demo Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Demo</Heading>
+    <p class="text-muted-foreground mb-4">
+      This demo visualizes the 8 landmark regions with distinct colored borders. Each landmark is
+      labeled to help identify its role.
+    </p>
+    <div class="border-border bg-background rounded-lg border p-6">
+      <LandmarkDemo showLabels={true} />
+    </div>
+    <p class="text-muted-foreground mt-2 text-sm">
+      <a href="./demo/" class="text-primary hover:underline">Open demo only →</a>
+    </p>
+  </section>
+
+  <!-- Native HTML Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Native HTML</Heading>
+    <NativeHtmlNotice />
+  </section>
+
+  <!-- Accessibility Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Accessibility Features</Heading>
+    <AccessibilityDocs />
+  </section>
+
+  <!-- Source Code Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Source Code</Heading>
+    <CodeBlock
+      collapsible
+      collapsedLines={5}
+      code={sourceCode}
+      lang="tsx"
+      title="LandmarkDemo.tsx"
+    />
+  </section>
+
+  <!-- Testing Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Testing</Heading>
+    <TestingDocs />
+    <div class="mt-6">
+      <CodeBlock
+        collapsible
+        collapsedLines={5}
+        code={testCode}
+        lang="tsx"
+        title="LandmarkDemo.test.tsx"
+      />
+    </div>
+  </section>
+
+  <!-- Resources -->
+  <section>
+    <Heading level={2} class="mb-4 text-xl font-semibold">Resources</Heading>
+    <ul class="list-disc space-y-2 pl-6">
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Landmarks Pattern
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Landmark Regions
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/landmark_role"
+          class="text-primary hover:underline"
+        >
+          MDN: ARIA Landmark Roles
+        </ExternalLink>
+      </li>
+      <AiGuideResourceItem pattern="landmarks" />
+    </ul>
+  </section>
+</PatternLayout>

--- a/src/pages/patterns/landmarks/svelte/demo/index.astro
+++ b/src/pages/patterns/landmarks/svelte/demo/index.astro
@@ -1,0 +1,29 @@
+---
+/**
+ * Demo-only Page: LandmarkDemo (Svelte)
+ *
+ * This page renders the LandmarkDemo component in isolation without
+ * the site layout. This ensures proper landmark semantics are preserved
+ * (e.g., <header> retains its implicit banner role).
+ *
+ * Used for:
+ * - E2E testing with correct landmark structure
+ * - Standalone demo viewing
+ */
+import '@/styles/global.css';
+import LandmarkDemo from '@patterns/landmarks/LandmarkDemo.svelte';
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Demo: Landmarks (Svelte)</title>
+  </head>
+  <body>
+    <!-- No client:load needed - LandmarkDemo is a static component -->
+    <LandmarkDemo showLabels={true} />
+  </body>
+</html>

--- a/src/pages/patterns/landmarks/svelte/index.astro
+++ b/src/pages/patterns/landmarks/svelte/index.astro
@@ -1,0 +1,129 @@
+---
+import PatternLayout from '../../../../layouts/PatternLayout.astro';
+import LandmarkDemo from '@patterns/landmarks/LandmarkDemo.svelte';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
+import AccessibilityDocs from '@patterns/landmarks/AccessibilityDocs.astro';
+import TestingDocs from '@patterns/landmarks/TestingDocs.astro';
+import NativeHtmlNotice from '@patterns/landmarks/NativeHtmlNotice.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/landmarks/LandmarkDemo.svelte?raw';
+import testCode from '@patterns/landmarks/LandmarkDemo.test.svelte.ts?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'native-html', text: 'Native HTML' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
+---
+
+<PatternLayout
+  title="Landmarks - Svelte"
+  pattern="landmarks"
+  framework="svelte"
+  tocItems={tocItems}
+>
+  <header class="mb-8">
+    <h1 class="mb-4 text-3xl font-bold">Landmarks</h1>
+    <p class="text-muted-foreground text-lg">
+      A set of eight ARIA landmark roles that identify the major sections of a page for assistive
+      technology users.
+    </p>
+    <AiGuideBadge pattern="landmarks" />
+  </header>
+
+  <!-- Framework Selector -->
+  <FrameworkTabs pattern="landmarks" currentFramework="svelte" />
+
+  <!-- Demo Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Demo</Heading>
+    <p class="text-muted-foreground mb-4">
+      This demo visualizes the 8 landmark regions with distinct colored borders. Each landmark is
+      labeled to help identify its role.
+    </p>
+    <div class="border-border bg-background rounded-lg border p-6">
+      <LandmarkDemo showLabels={true} />
+    </div>
+    <p class="text-muted-foreground mt-2 text-sm">
+      <a href="./demo/" class="text-primary hover:underline">Open demo only →</a>
+    </p>
+  </section>
+
+  <!-- Native HTML Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Native HTML</Heading>
+    <NativeHtmlNotice />
+  </section>
+
+  <!-- Accessibility Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Accessibility Features</Heading>
+    <AccessibilityDocs />
+  </section>
+
+  <!-- Source Code Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Source Code</Heading>
+    <CodeBlock
+      collapsible
+      collapsedLines={5}
+      code={sourceCode}
+      lang="svelte"
+      title="LandmarkDemo.svelte"
+    />
+  </section>
+
+  <!-- Testing Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Testing</Heading>
+    <TestingDocs />
+    <div class="mt-6">
+      <CodeBlock
+        collapsible
+        collapsedLines={5}
+        code={testCode}
+        lang="typescript"
+        title="LandmarkDemo.test.svelte.ts"
+      />
+    </div>
+  </section>
+
+  <!-- Resources -->
+  <section>
+    <Heading level={2} class="mb-4 text-xl font-semibold">Resources</Heading>
+    <ul class="list-disc space-y-2 pl-6">
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Landmarks Pattern
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Landmark Regions
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/landmark_role"
+          class="text-primary hover:underline"
+        >
+          MDN: ARIA Landmark Roles
+        </ExternalLink>
+      </li>
+      <AiGuideResourceItem pattern="landmarks" />
+    </ul>
+  </section>
+</PatternLayout>

--- a/src/pages/patterns/landmarks/vue/demo/index.astro
+++ b/src/pages/patterns/landmarks/vue/demo/index.astro
@@ -1,0 +1,28 @@
+---
+/**
+ * Demo-only Page: LandmarkDemo (Vue)
+ *
+ * This page renders the LandmarkDemo component in isolation without
+ * the site layout. This ensures proper landmark semantics are preserved
+ * (e.g., <header> retains its implicit banner role).
+ *
+ * Used for:
+ * - E2E testing with correct landmark structure
+ * - Standalone demo viewing
+ */
+import '@/styles/global.css';
+import LandmarkDemo from '@patterns/landmarks/LandmarkDemo.vue';
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Demo: Landmarks (Vue)</title>
+  </head>
+  <body>
+    <LandmarkDemo client:load showLabels={true} />
+  </body>
+</html>

--- a/src/pages/patterns/landmarks/vue/index.astro
+++ b/src/pages/patterns/landmarks/vue/index.astro
@@ -1,0 +1,124 @@
+---
+import PatternLayout from '../../../../layouts/PatternLayout.astro';
+import LandmarkDemo from '@patterns/landmarks/LandmarkDemo.vue';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
+import AccessibilityDocs from '@patterns/landmarks/AccessibilityDocs.astro';
+import TestingDocs from '@patterns/landmarks/TestingDocs.astro';
+import NativeHtmlNotice from '@patterns/landmarks/NativeHtmlNotice.astro';
+import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
+import Heading from '@/components/ui/Heading.astro';
+import sourceCode from '@patterns/landmarks/LandmarkDemo.vue?raw';
+import testCode from '@patterns/landmarks/LandmarkDemo.test.vue.ts?raw';
+
+const tocItems = [
+  { id: 'demo', text: 'Demo' },
+  { id: 'native-html', text: 'Native HTML' },
+  { id: 'accessibility-features', text: 'Accessibility Features' },
+  { id: 'source-code', text: 'Source Code' },
+  { id: 'testing', text: 'Testing' },
+  { id: 'resources', text: 'Resources' },
+];
+---
+
+<PatternLayout title="Landmarks - Vue" pattern="landmarks" framework="vue" tocItems={tocItems}>
+  <header class="mb-8">
+    <h1 class="mb-4 text-3xl font-bold">Landmarks</h1>
+    <p class="text-muted-foreground text-lg">
+      A set of eight ARIA landmark roles that identify the major sections of a page for assistive
+      technology users.
+    </p>
+    <AiGuideBadge pattern="landmarks" />
+  </header>
+
+  <!-- Framework Selector -->
+  <FrameworkTabs pattern="landmarks" currentFramework="vue" />
+
+  <!-- Demo Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Demo</Heading>
+    <p class="text-muted-foreground mb-4">
+      This demo visualizes the 8 landmark regions with distinct colored borders. Each landmark is
+      labeled to help identify its role.
+    </p>
+    <div class="border-border bg-background rounded-lg border p-6">
+      <LandmarkDemo showLabels={true} />
+    </div>
+    <p class="text-muted-foreground mt-2 text-sm">
+      <a href="./demo/" class="text-primary hover:underline">Open demo only →</a>
+    </p>
+  </section>
+
+  <!-- Native HTML Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Native HTML</Heading>
+    <NativeHtmlNotice />
+  </section>
+
+  <!-- Accessibility Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Accessibility Features</Heading>
+    <AccessibilityDocs />
+  </section>
+
+  <!-- Source Code Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Source Code</Heading>
+    <CodeBlock
+      collapsible
+      collapsedLines={5}
+      code={sourceCode}
+      lang="vue"
+      title="LandmarkDemo.vue"
+    />
+  </section>
+
+  <!-- Testing Section -->
+  <section class="mb-12">
+    <Heading level={2} class="mb-4 text-xl font-semibold">Testing</Heading>
+    <TestingDocs />
+    <div class="mt-6">
+      <CodeBlock
+        collapsible
+        collapsedLines={5}
+        code={testCode}
+        lang="typescript"
+        title="LandmarkDemo.test.vue.ts"
+      />
+    </div>
+  </section>
+
+  <!-- Resources -->
+  <section>
+    <Heading level={2} class="mb-4 text-xl font-semibold">Resources</Heading>
+    <ul class="list-disc space-y-2 pl-6">
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Landmarks Pattern
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/"
+          class="text-primary hover:underline"
+        >
+          WAI-ARIA APG: Landmark Regions
+        </ExternalLink>
+      </li>
+      <li>
+        <ExternalLink
+          href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/landmark_role"
+          class="text-primary hover:underline"
+        >
+          MDN: ARIA Landmark Roles
+        </ExternalLink>
+      </li>
+      <AiGuideResourceItem pattern="landmarks" />
+    </ul>
+  </section>
+</PatternLayout>

--- a/src/patterns/landmarks/AccessibilityDocs.astro
+++ b/src/patterns/landmarks/AccessibilityDocs.astro
@@ -1,0 +1,210 @@
+---
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+---
+
+<div class="prose dark:prose-invert max-w-none">
+  <h3 class="mb-3 text-lg font-medium">WAI-ARIA Landmark Roles</h3>
+  <p class="text-muted-foreground mb-4">
+    Landmarks identify the major sections of a page. There are 8 landmark roles that enable
+    assistive technology users to efficiently navigate page structure.
+  </p>
+
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">Role</th>
+          <th class="py-2 pr-4 text-left">HTML Element</th>
+          <th class="py-2 pr-4 text-left">Description</th>
+          <th class="py-2 text-left">Constraint</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>banner</code></td>
+          <td class="py-2 pr-4"><code>&lt;header&gt;</code></td>
+          <td class="py-2 pr-4">Site-wide header</td>
+          <td class="py-2">One per page, top-level only</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>navigation</code></td>
+          <td class="py-2 pr-4"><code>&lt;nav&gt;</code></td>
+          <td class="py-2 pr-4">Navigation links</td>
+          <td class="py-2">Multiple allowed, label when &gt;1</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>main</code></td>
+          <td class="py-2 pr-4"><code>&lt;main&gt;</code></td>
+          <td class="py-2 pr-4">Primary content</td>
+          <td class="py-2">One per page, top-level only</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>contentinfo</code></td>
+          <td class="py-2 pr-4"><code>&lt;footer&gt;</code></td>
+          <td class="py-2 pr-4">Site-wide footer</td>
+          <td class="py-2">One per page, top-level only</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>complementary</code></td>
+          <td class="py-2 pr-4"><code>&lt;aside&gt;</code></td>
+          <td class="py-2 pr-4">Supporting content</td>
+          <td class="py-2">Top-level recommended</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>region</code></td>
+          <td class="py-2 pr-4"><code>&lt;section&gt;</code></td>
+          <td class="py-2 pr-4">Named section</td>
+          <td class="py-2"><b>Requires aria-label/labelledby</b></td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>search</code></td>
+          <td class="py-2 pr-4"><code>&lt;form role="search"&gt;</code></td>
+          <td class="py-2 pr-4">Search functionality</td>
+          <td class="py-2">Use with form element</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>form</code></td>
+          <td class="py-2 pr-4"><code>&lt;form&gt;</code></td>
+          <td class="py-2 pr-4">Form area</td>
+          <td class="py-2"><b>Requires aria-label/labelledby</b></td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h3 class="mb-3 text-lg font-medium">WAI-ARIA Properties</h3>
+
+  <div class="mb-6">
+    <h4 class="mb-2 font-medium"><code>aria-label</code> / <code>aria-labelledby</code></h4>
+    <p class="text-muted-foreground mb-3">
+      Provides an accessible name for the landmark. Required when multiple landmarks of the same
+      type exist, or for <code>region</code> and <code>form</code> landmarks.
+    </p>
+    <ResponsiveTable class="mb-2">
+      <table class="w-full border-collapse">
+        <tbody>
+          <tr class="border-border border-b">
+            <td class="w-32 py-2 pr-4 font-medium">Values</td>
+            <td class="py-2">String (aria-label) or ID reference (aria-labelledby)</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4 font-medium">Required</td>
+            <td class="py-2">
+              <ul class="mb-0 list-disc pl-4">
+                <li>When multiple landmarks of same type exist</li>
+                <li>For <code>region</code> landmarks (always)</li>
+                <li>For <code>form</code> landmarks (always)</li>
+              </ul>
+            </td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4 font-medium">Example</td>
+            <td class="py-2">
+              <code>&lt;nav aria-label="Main"&gt;</code> or
+              <code>&lt;section aria-labelledby="heading-id"&gt;</code>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </div>
+
+  <h3 class="mb-3 text-lg font-medium">Keyboard Support</h3>
+  <p class="text-muted-foreground mb-4">
+    <strong>Landmarks require no keyboard interaction.</strong> They are structural elements, not interactive
+    widgets. Screen readers provide built-in landmark navigation:
+  </p>
+  <ResponsiveTable class="mb-4">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">Screen Reader</th>
+          <th class="py-2 text-left">Navigation</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4">NVDA</td>
+          <td class="py-2"
+            ><kbd class="rounded bg-gray-100 px-2 py-1 dark:bg-gray-800">D</kbd> key</td
+          >
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4">VoiceOver</td>
+          <td class="py-2">Rotor (Web navigation)</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4">JAWS</td>
+          <td class="py-2"
+            ><kbd class="rounded bg-gray-100 px-2 py-1 dark:bg-gray-800">R</kbd> key or semicolon</td
+          >
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h3 class="mb-3 text-lg font-medium">Best Practices</h3>
+  <ul class="mb-6 list-disc space-y-2 pl-6">
+    <li>
+      <strong>Use semantic HTML elements</strong> - Prefer <code>&lt;header&gt;</code>,
+      <code>&lt;nav&gt;</code>, <code>&lt;main&gt;</code>, etc. over ARIA roles
+    </li>
+    <li>
+      <strong>Label multiple landmarks</strong> - When you have more than one <code
+        >&lt;nav&gt;</code
+      > or <code>&lt;aside&gt;</code>, give each a unique accessible name
+    </li>
+    <li>
+      <strong>Limit landmark count</strong> - Too many landmarks (more than ~7) can be overwhelming for
+      assistive technology users
+    </li>
+    <li>
+      <strong>Place all content in landmarks</strong> - Content outside landmarks may be missed by users
+      navigating by landmarks
+    </li>
+    <li>
+      <strong>Top-level placement</strong> - <code>&lt;header&gt;</code> and <code
+        >&lt;footer&gt;</code
+      > only map to <code>banner</code>/<code>contentinfo</code> when they are direct children of <code
+        >&lt;body&gt;</code
+      >
+    </li>
+  </ul>
+
+  <h3 class="mb-3 text-lg font-medium">References</h3>
+  <ul class="list-disc space-y-2 pl-6">
+    <li>
+      <ExternalLink
+        href="https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/"
+        class="text-primary hover:underline"
+      >
+        WAI-ARIA APG: Landmarks Pattern
+      </ExternalLink>
+    </li>
+    <li>
+      <ExternalLink
+        href="https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/"
+        class="text-primary hover:underline"
+      >
+        WAI-ARIA APG: Landmark Regions
+      </ExternalLink>
+    </li>
+    <li>
+      <ExternalLink
+        href="https://w3c.github.io/aria/#landmark"
+        class="text-primary hover:underline"
+      >
+        W3C ARIA: Landmark Roles
+      </ExternalLink>
+    </li>
+    <li>
+      <ExternalLink
+        href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/landmark_role"
+        class="text-primary hover:underline"
+      >
+        MDN: ARIA Landmark Roles
+      </ExternalLink>
+    </li>
+  </ul>
+</div>

--- a/src/patterns/landmarks/AccessibilityDocs.ja.astro
+++ b/src/patterns/landmarks/AccessibilityDocs.ja.astro
@@ -1,0 +1,207 @@
+---
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+---
+
+<div class="prose dark:prose-invert max-w-none">
+  <h3 class="mb-3 text-lg font-medium">WAI-ARIA ランドマークロール</h3>
+  <p class="text-muted-foreground mb-4">
+    ランドマークはページの主要なセクションを識別します。8つのランドマークロールがあり、支援技術ユーザーがページ構造を効率的にナビゲートできるようになります。
+  </p>
+
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">ロール</th>
+          <th class="py-2 pr-4 text-left">HTML要素</th>
+          <th class="py-2 pr-4 text-left">説明</th>
+          <th class="py-2 text-left">制約</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>banner</code></td>
+          <td class="py-2 pr-4"><code>&lt;header&gt;</code></td>
+          <td class="py-2 pr-4">サイト全体のヘッダー</td>
+          <td class="py-2">ページに1つ、トップレベルのみ</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>navigation</code></td>
+          <td class="py-2 pr-4"><code>&lt;nav&gt;</code></td>
+          <td class="py-2 pr-4">ナビゲーションリンク</td>
+          <td class="py-2">複数可、2つ以上の場合はラベル必須</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>main</code></td>
+          <td class="py-2 pr-4"><code>&lt;main&gt;</code></td>
+          <td class="py-2 pr-4">主要コンテンツ</td>
+          <td class="py-2">ページに1つ、トップレベルのみ</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>contentinfo</code></td>
+          <td class="py-2 pr-4"><code>&lt;footer&gt;</code></td>
+          <td class="py-2 pr-4">サイト全体のフッター</td>
+          <td class="py-2">ページに1つ、トップレベルのみ</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>complementary</code></td>
+          <td class="py-2 pr-4"><code>&lt;aside&gt;</code></td>
+          <td class="py-2 pr-4">補完的コンテンツ</td>
+          <td class="py-2">トップレベル推奨</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>region</code></td>
+          <td class="py-2 pr-4"><code>&lt;section&gt;</code></td>
+          <td class="py-2 pr-4">名前付きセクション</td>
+          <td class="py-2"><b>aria-label/labelledby必須</b></td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>search</code></td>
+          <td class="py-2 pr-4"><code>&lt;form role="search"&gt;</code></td>
+          <td class="py-2 pr-4">検索機能</td>
+          <td class="py-2">form要素と併用</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>form</code></td>
+          <td class="py-2 pr-4"><code>&lt;form&gt;</code></td>
+          <td class="py-2 pr-4">フォーム領域</td>
+          <td class="py-2"><b>aria-label/labelledby必須</b></td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h3 class="mb-3 text-lg font-medium">WAI-ARIA プロパティ</h3>
+
+  <div class="mb-6">
+    <h4 class="mb-2 font-medium"><code>aria-label</code> / <code>aria-labelledby</code></h4>
+    <p class="text-muted-foreground mb-3">
+      ランドマークにアクセシブルな名前を提供します。同じ種類のランドマークが複数存在する場合、または<code
+        >region</code
+      >と<code>form</code>ランドマークには必須です。
+    </p>
+    <ResponsiveTable class="mb-2">
+      <table class="w-full border-collapse">
+        <tbody>
+          <tr class="border-border border-b">
+            <td class="w-32 py-2 pr-4 font-medium">値</td>
+            <td class="py-2">文字列（aria-label）またはID参照（aria-labelledby）</td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4 font-medium">必須条件</td>
+            <td class="py-2">
+              <ul class="mb-0 list-disc pl-4">
+                <li>同じ種類のランドマークが複数ある場合</li>
+                <li><code>region</code>ランドマーク（常に）</li>
+                <li><code>form</code>ランドマーク（常に）</li>
+              </ul>
+            </td>
+          </tr>
+          <tr class="border-border border-b">
+            <td class="py-2 pr-4 font-medium">例</td>
+            <td class="py-2">
+              <code>&lt;nav aria-label="メイン"&gt;</code> または
+              <code>&lt;section aria-labelledby="heading-id"&gt;</code>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </ResponsiveTable>
+  </div>
+
+  <h3 class="mb-3 text-lg font-medium">キーボードサポート</h3>
+  <p class="text-muted-foreground mb-4">
+    <strong>ランドマークにはキーボード操作は不要です。</strong
+    >ランドマークは構造要素であり、インタラクティブなウィジェットではありません。スクリーンリーダーは組み込みのランドマークナビゲーションを提供します：
+  </p>
+  <ResponsiveTable class="mb-4">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">スクリーンリーダー</th>
+          <th class="py-2 text-left">ナビゲーション方法</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4">NVDA</td>
+          <td class="py-2"
+            ><kbd class="rounded bg-gray-100 px-2 py-1 dark:bg-gray-800">D</kbd>キー</td
+          >
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4">VoiceOver</td>
+          <td class="py-2">ローター（Webナビゲーション）</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4">JAWS</td>
+          <td class="py-2"
+            ><kbd class="rounded bg-gray-100 px-2 py-1 dark:bg-gray-800">R</kbd
+            >キーまたはセミコロン</td
+          >
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h3 class="mb-3 text-lg font-medium">ベストプラクティス</h3>
+  <ul class="mb-6 list-disc space-y-2 pl-6">
+    <li>
+      <strong>セマンティックHTML要素を使用</strong> - ARIAロールよりも<code>&lt;header&gt;</code
+      >、<code>&lt;nav&gt;</code>、<code>&lt;main&gt;</code>などを優先
+    </li>
+    <li>
+      <strong>複数のランドマークにラベルを付ける</strong> - 複数の<code>&lt;nav&gt;</code>や<code
+        >&lt;aside&gt;</code
+      >がある場合、それぞれに一意のアクセシブルな名前を付ける
+    </li>
+    <li>
+      <strong>ランドマークの数を制限</strong> - ランドマークが多すぎる（約7以上）と支援技術ユーザーにとって煩わしくなる
+    </li>
+    <li>
+      <strong>すべてのコンテンツをランドマーク内に配置</strong> - ランドマーク外のコンテンツは、ランドマークでナビゲートするユーザーに見落とされる可能性がある
+    </li>
+    <li>
+      <strong>トップレベルに配置</strong> - <code>&lt;header&gt;</code>と<code>&lt;footer&gt;</code
+      >は<code>&lt;body&gt;</code>の直接の子の場合にのみ<code>banner</code>/<code>contentinfo</code
+      >にマップされる
+    </li>
+  </ul>
+
+  <h3 class="mb-3 text-lg font-medium">参考資料</h3>
+  <ul class="list-disc space-y-2 pl-6">
+    <li>
+      <ExternalLink
+        href="https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/"
+        class="text-primary hover:underline"
+      >
+        WAI-ARIA APG: ランドマークパターン
+      </ExternalLink>
+    </li>
+    <li>
+      <ExternalLink
+        href="https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/"
+        class="text-primary hover:underline"
+      >
+        WAI-ARIA APG: ランドマーク領域
+      </ExternalLink>
+    </li>
+    <li>
+      <ExternalLink
+        href="https://w3c.github.io/aria/#landmark"
+        class="text-primary hover:underline"
+      >
+        W3C ARIA: ランドマークロール
+      </ExternalLink>
+    </li>
+    <li>
+      <ExternalLink
+        href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/landmark_role"
+        class="text-primary hover:underline"
+      >
+        MDN: ARIA ランドマークロール
+      </ExternalLink>
+    </li>
+  </ul>
+</div>

--- a/src/patterns/landmarks/LandmarkDemo.astro
+++ b/src/patterns/landmarks/LandmarkDemo.astro
@@ -1,0 +1,126 @@
+---
+/**
+ * LandmarkDemo - Demonstrates the 8 ARIA landmark roles
+ *
+ * This component visualizes proper landmark structure for educational purposes.
+ * Since landmarks are static structural elements, no JavaScript is required.
+ *
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/
+ */
+
+interface Props {
+  /** Show landmark labels overlay */
+  showLabels?: boolean;
+  class?: string;
+}
+
+const { showLabels = false, class: className } = Astro.props;
+---
+
+<div class:list={['apg-landmark-demo', className]}>
+  <!-- Banner Landmark -->
+  <header class="apg-landmark-banner">
+    <span class:list={['apg-landmark-label', !showLabels && 'hidden']} aria-hidden="true"
+      >banner</span
+    >
+    <div class="apg-landmark-content">
+      <span class="apg-landmark-logo">Site Logo</span>
+      <!-- Navigation Landmark (Main) -->
+      <nav aria-label="Main" class="apg-landmark-navigation">
+        <span class:list={['apg-landmark-label', !showLabels && 'hidden']} aria-hidden="true"
+          >navigation</span
+        >
+        <ul class="apg-landmark-nav-list">
+          <li><a href="#home">Home</a></li>
+          <li><a href="#about">About</a></li>
+          <li><a href="#contact">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Main Landmark -->
+  <main class="apg-landmark-main">
+    <span class:list={['apg-landmark-label', !showLabels && 'hidden']} aria-hidden="true">main</span
+    >
+    <div class="apg-landmark-main-content">
+      <!-- Region Landmark -->
+      <section aria-labelledby="content-heading" class="apg-landmark-region">
+        <span class:list={['apg-landmark-label', !showLabels && 'hidden']} aria-hidden="true"
+          >region</span
+        >
+        <h2 id="content-heading" class="apg-landmark-heading">Main Content</h2>
+        <p>
+          This section demonstrates the <code>region</code> landmark. A section element only becomes a
+          region landmark when it has an accessible name via <code>aria-labelledby</code> or <code
+            >aria-label</code
+          >.
+        </p>
+
+        <!-- Search Landmark -->
+        <form role="search" aria-label="Site search" class="apg-landmark-search">
+          <span class:list={['apg-landmark-label', !showLabels && 'hidden']} aria-hidden="true"
+            >search</span
+          >
+          <label for="search-input" class="apg-landmark-search-label">Search</label>
+          <input
+            type="search"
+            id="search-input"
+            class="apg-landmark-search-input"
+            placeholder="Search..."
+          />
+          <button type="submit" class="apg-landmark-search-button">Search</button>
+        </form>
+
+        <!-- Form Landmark -->
+        <form aria-label="Contact form" class="apg-landmark-form">
+          <span class:list={['apg-landmark-label', !showLabels && 'hidden']} aria-hidden="true"
+            >form</span
+          >
+          <div class="apg-landmark-form-field">
+            <label for="name-input">Name</label>
+            <input type="text" id="name-input" class="apg-landmark-input" />
+          </div>
+          <div class="apg-landmark-form-field">
+            <label for="email-input">Email</label>
+            <input type="email" id="email-input" class="apg-landmark-input" />
+          </div>
+          <button type="submit" class="apg-landmark-submit">Submit</button>
+        </form>
+      </section>
+
+      <!-- Complementary Landmark -->
+      <aside aria-label="Related content" class="apg-landmark-complementary">
+        <span class:list={['apg-landmark-label', !showLabels && 'hidden']} aria-hidden="true"
+          >complementary</span
+        >
+        <h2 class="apg-landmark-heading">Related</h2>
+        <ul>
+          <li><a href="#related1">Related Link 1</a></li>
+          <li><a href="#related2">Related Link 2</a></li>
+        </ul>
+      </aside>
+    </div>
+  </main>
+
+  <!-- Contentinfo Landmark -->
+  <footer class="apg-landmark-contentinfo">
+    <span class:list={['apg-landmark-label', !showLabels && 'hidden']} aria-hidden="true"
+      >contentinfo</span
+    >
+    <div class="apg-landmark-content">
+      <!-- Navigation Landmark (Footer) -->
+      <nav aria-label="Footer" class="apg-landmark-navigation">
+        <span class:list={['apg-landmark-label', !showLabels && 'hidden']} aria-hidden="true"
+          >navigation</span
+        >
+        <ul class="apg-landmark-nav-list">
+          <li><a href="#privacy">Privacy</a></li>
+          <li><a href="#terms">Terms</a></li>
+          <li><a href="#sitemap">Sitemap</a></li>
+        </ul>
+      </nav>
+      <p class="apg-landmark-copyright">&copy; 2024 Example Site</p>
+    </div>
+  </footer>
+</div>

--- a/src/patterns/landmarks/LandmarkDemo.svelte
+++ b/src/patterns/landmarks/LandmarkDemo.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+  /**
+   * LandmarkDemo - Demonstrates the 8 ARIA landmark roles
+   *
+   * This component visualizes proper landmark structure for educational purposes.
+   *
+   * @see https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/
+   */
+
+  /** Show landmark labels overlay */
+  export let showLabels: boolean = false;
+  let className: string = '';
+  export { className as class };
+</script>
+
+<div class="apg-landmark-demo {className}" {...$$restProps}>
+  <!-- Banner Landmark -->
+  <header class="apg-landmark-banner">
+    <span class="apg-landmark-label" class:hidden={!showLabels} aria-hidden="true">banner</span>
+    <div class="apg-landmark-content">
+      <span class="apg-landmark-logo">Site Logo</span>
+      <!-- Navigation Landmark (Main) -->
+      <nav aria-label="Main" class="apg-landmark-navigation">
+        <span class="apg-landmark-label" class:hidden={!showLabels} aria-hidden="true"
+          >navigation</span
+        >
+        <ul class="apg-landmark-nav-list">
+          <li><a href="#home">Home</a></li>
+          <li><a href="#about">About</a></li>
+          <li><a href="#contact">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Main Landmark -->
+  <main class="apg-landmark-main">
+    <span class="apg-landmark-label" class:hidden={!showLabels} aria-hidden="true">main</span>
+    <div class="apg-landmark-main-content">
+      <!-- Region Landmark -->
+      <section aria-labelledby="content-heading" class="apg-landmark-region">
+        <span class="apg-landmark-label" class:hidden={!showLabels} aria-hidden="true">region</span>
+        <h2 id="content-heading" class="apg-landmark-heading">Main Content</h2>
+        <p>
+          This section demonstrates the <code>region</code> landmark. A section element only becomes
+          a region landmark when it has an accessible name via
+          <code>aria-labelledby</code> or <code>aria-label</code>.
+        </p>
+
+        <!-- Search Landmark -->
+        <form role="search" aria-label="Site search" class="apg-landmark-search">
+          <span class="apg-landmark-label" class:hidden={!showLabels} aria-hidden="true"
+            >search</span
+          >
+          <label for="search-input" class="apg-landmark-search-label">Search</label>
+          <input
+            type="search"
+            id="search-input"
+            class="apg-landmark-search-input"
+            placeholder="Search..."
+          />
+          <button type="submit" class="apg-landmark-search-button">Search</button>
+        </form>
+
+        <!-- Form Landmark -->
+        <form aria-label="Contact form" class="apg-landmark-form">
+          <span class="apg-landmark-label" class:hidden={!showLabels} aria-hidden="true">form</span>
+          <div class="apg-landmark-form-field">
+            <label for="name-input">Name</label>
+            <input type="text" id="name-input" class="apg-landmark-input" />
+          </div>
+          <div class="apg-landmark-form-field">
+            <label for="email-input">Email</label>
+            <input type="email" id="email-input" class="apg-landmark-input" />
+          </div>
+          <button type="submit" class="apg-landmark-submit">Submit</button>
+        </form>
+      </section>
+
+      <!-- Complementary Landmark -->
+      <aside aria-label="Related content" class="apg-landmark-complementary">
+        <span class="apg-landmark-label" class:hidden={!showLabels} aria-hidden="true"
+          >complementary</span
+        >
+        <h2 class="apg-landmark-heading">Related</h2>
+        <ul>
+          <li><a href="#related1">Related Link 1</a></li>
+          <li><a href="#related2">Related Link 2</a></li>
+        </ul>
+      </aside>
+    </div>
+  </main>
+
+  <!-- Contentinfo Landmark -->
+  <footer class="apg-landmark-contentinfo">
+    <span class="apg-landmark-label" class:hidden={!showLabels} aria-hidden="true">contentinfo</span
+    >
+    <div class="apg-landmark-content">
+      <!-- Navigation Landmark (Footer) -->
+      <nav aria-label="Footer" class="apg-landmark-navigation">
+        <span class="apg-landmark-label" class:hidden={!showLabels} aria-hidden="true"
+          >navigation</span
+        >
+        <ul class="apg-landmark-nav-list">
+          <li><a href="#privacy">Privacy</a></li>
+          <li><a href="#terms">Terms</a></li>
+          <li><a href="#sitemap">Sitemap</a></li>
+        </ul>
+      </nav>
+      <p class="apg-landmark-copyright">&copy; 2024 Example Site</p>
+    </div>
+  </footer>
+</div>

--- a/src/patterns/landmarks/LandmarkDemo.test.astro.ts
+++ b/src/patterns/landmarks/LandmarkDemo.test.astro.ts
@@ -1,0 +1,239 @@
+/**
+ * LandmarkDemo Astro Component Tests using Container API
+ *
+ * These tests verify the LandmarkDemo.astro component output using Astro's Container API.
+ * This ensures the component renders correct HTML structure and landmark elements.
+ *
+ * Note: Landmarks are static structural elements without JavaScript interaction,
+ * so Container API tests are sufficient for most verification.
+ *
+ * @see https://docs.astro.build/en/reference/container-reference/
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+import LandmarkDemo from './LandmarkDemo.astro';
+
+describe('LandmarkDemo (Astro Container API)', () => {
+  let container: AstroContainer;
+
+  beforeEach(async () => {
+    container = await AstroContainer.create();
+  });
+
+  // Helper to render and parse HTML
+  async function renderLandmarkDemo(
+    props: {
+      showLabels?: boolean;
+      class?: string;
+    } = {}
+  ): Promise<Document> {
+    const html = await container.renderToString(LandmarkDemo, { props });
+    const dom = new JSDOM(html);
+    return dom.window.document;
+  }
+
+  // 🔴 High Priority: Landmark Roles
+  describe('Landmark Roles', () => {
+    it('renders header element (banner landmark)', async () => {
+      const doc = await renderLandmarkDemo();
+      const header = doc.querySelector('header');
+      expect(header).not.toBeNull();
+    });
+
+    it('renders nav element (navigation landmark)', async () => {
+      const doc = await renderLandmarkDemo();
+      const navs = doc.querySelectorAll('nav');
+      expect(navs.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('renders main element (main landmark)', async () => {
+      const doc = await renderLandmarkDemo();
+      const main = doc.querySelector('main');
+      expect(main).not.toBeNull();
+    });
+
+    it('renders footer element (contentinfo landmark)', async () => {
+      const doc = await renderLandmarkDemo();
+      const footer = doc.querySelector('footer');
+      expect(footer).not.toBeNull();
+    });
+
+    it('renders aside element (complementary landmark)', async () => {
+      const doc = await renderLandmarkDemo();
+      const aside = doc.querySelector('aside');
+      expect(aside).not.toBeNull();
+    });
+
+    it('renders section with aria-labelledby (region landmark)', async () => {
+      const doc = await renderLandmarkDemo();
+      const section = doc.querySelector('section[aria-labelledby]');
+      expect(section).not.toBeNull();
+    });
+
+    it('renders form with role="search" (search landmark)', async () => {
+      const doc = await renderLandmarkDemo();
+      const search = doc.querySelector('form[role="search"]');
+      expect(search).not.toBeNull();
+    });
+
+    it('renders form with aria-label (form landmark)', async () => {
+      const doc = await renderLandmarkDemo();
+      // Find form that has aria-label but not role="search"
+      const forms = doc.querySelectorAll('form[aria-label]');
+      const formLandmark = Array.from(forms).find((form) => form.getAttribute('role') !== 'search');
+      expect(formLandmark).not.toBeNull();
+    });
+
+    it('renders exactly one main element', async () => {
+      const doc = await renderLandmarkDemo();
+      const mains = doc.querySelectorAll('main');
+      expect(mains.length).toBe(1);
+    });
+
+    it('renders exactly one header at top level', async () => {
+      const doc = await renderLandmarkDemo();
+      // Header should not be inside article, aside, main, nav, section
+      const headers = doc.querySelectorAll('header');
+      // Check that there's one header that's not nested in other landmarks
+      const topLevelHeaders = Array.from(headers).filter((header) => {
+        const parent = header.parentElement;
+        if (!parent) return true;
+        const parentTag = parent.tagName.toLowerCase();
+        return !['article', 'aside', 'main', 'nav', 'section'].includes(parentTag);
+      });
+      expect(topLevelHeaders.length).toBe(1);
+    });
+
+    it('renders exactly one footer at top level', async () => {
+      const doc = await renderLandmarkDemo();
+      const footers = doc.querySelectorAll('footer');
+      // Check that there's one footer that's not nested in other landmarks
+      const topLevelFooters = Array.from(footers).filter((footer) => {
+        const parent = footer.parentElement;
+        if (!parent) return true;
+        const parentTag = parent.tagName.toLowerCase();
+        return !['article', 'aside', 'main', 'nav', 'section'].includes(parentTag);
+      });
+      expect(topLevelFooters.length).toBe(1);
+    });
+  });
+
+  // 🔴 High Priority: Landmark Labeling
+  describe('Landmark Labeling', () => {
+    it('navigation elements have aria-label when multiple', async () => {
+      const doc = await renderLandmarkDemo();
+      const navs = doc.querySelectorAll('nav');
+      if (navs.length > 1) {
+        const labels = Array.from(navs).map(
+          (nav) => nav.getAttribute('aria-label') || nav.getAttribute('aria-labelledby')
+        );
+        const uniqueLabels = new Set(labels.filter(Boolean));
+        expect(uniqueLabels.size).toBe(navs.length);
+      }
+    });
+
+    it('section element has aria-labelledby attribute', async () => {
+      const doc = await renderLandmarkDemo();
+      const section = doc.querySelector('section[aria-labelledby]');
+      expect(section).not.toBeNull();
+      const labelId = section?.getAttribute('aria-labelledby');
+      expect(labelId).toBeTruthy();
+      // Check that the referenced element exists
+      const labelElement = doc.getElementById(labelId!);
+      expect(labelElement).not.toBeNull();
+    });
+
+    it('search form has aria-label attribute', async () => {
+      const doc = await renderLandmarkDemo();
+      const search = doc.querySelector('form[role="search"]');
+      expect(search?.hasAttribute('aria-label')).toBe(true);
+    });
+
+    it('form landmark has aria-label attribute', async () => {
+      const doc = await renderLandmarkDemo();
+      const forms = doc.querySelectorAll('form[aria-label]');
+      const formLandmark = Array.from(forms).find((form) => form.getAttribute('role') !== 'search');
+      expect(formLandmark).not.toBeNull();
+      expect(formLandmark?.getAttribute('aria-label')).toBeTruthy();
+    });
+
+    it('aside element has aria-label attribute', async () => {
+      const doc = await renderLandmarkDemo();
+      const aside = doc.querySelector('aside');
+      expect(aside?.hasAttribute('aria-label')).toBe(true);
+    });
+  });
+
+  // 🟢 Low Priority: Props
+  describe('Props', () => {
+    it('applies custom class to container', async () => {
+      const doc = await renderLandmarkDemo({ class: 'custom-class' });
+      const container = doc.querySelector('.apg-landmark-demo');
+      expect(container?.classList.contains('custom-class')).toBe(true);
+    });
+
+    it('shows landmark labels when showLabels is true', async () => {
+      const doc = await renderLandmarkDemo({ showLabels: true });
+      // Check for label overlay elements
+      const labels = doc.querySelectorAll('.apg-landmark-label');
+      expect(labels.length).toBeGreaterThan(0);
+    });
+
+    it('hides landmark labels by default', async () => {
+      const doc = await renderLandmarkDemo({ showLabels: false });
+      const labels = doc.querySelectorAll('.apg-landmark-label');
+      // Labels should either not exist or have hidden class
+      Array.from(labels).forEach((label) => {
+        expect(label.classList.contains('hidden')).toBe(true);
+      });
+    });
+  });
+
+  // 🟢 Low Priority: Semantic Structure
+  describe('Semantic Structure', () => {
+    it('main contains region landmark', async () => {
+      const doc = await renderLandmarkDemo();
+      const main = doc.querySelector('main');
+      const regionInMain = main?.querySelector('section[aria-labelledby]');
+      expect(regionInMain).not.toBeNull();
+    });
+
+    it('main contains complementary landmark', async () => {
+      const doc = await renderLandmarkDemo();
+      const main = doc.querySelector('main');
+      const asideInMain = main?.querySelector('aside');
+      expect(asideInMain).not.toBeNull();
+    });
+
+    it('header contains navigation', async () => {
+      const doc = await renderLandmarkDemo();
+      const header = doc.querySelector('header');
+      const navInHeader = header?.querySelector('nav');
+      expect(navInHeader).not.toBeNull();
+    });
+
+    it('footer contains navigation', async () => {
+      const doc = await renderLandmarkDemo();
+      const footer = doc.querySelector('footer');
+      const navInFooter = footer?.querySelector('nav');
+      expect(navInFooter).not.toBeNull();
+    });
+  });
+
+  // CSS Classes
+  describe('CSS Classes', () => {
+    it('has apg-landmark-demo class on container', async () => {
+      const doc = await renderLandmarkDemo();
+      const container = doc.querySelector('.apg-landmark-demo');
+      expect(container).not.toBeNull();
+    });
+
+    it('landmarks have appropriate CSS classes', async () => {
+      const doc = await renderLandmarkDemo();
+      expect(doc.querySelector('.apg-landmark-banner')).not.toBeNull();
+      expect(doc.querySelector('.apg-landmark-main')).not.toBeNull();
+      expect(doc.querySelector('.apg-landmark-contentinfo')).not.toBeNull();
+    });
+  });
+});

--- a/src/patterns/landmarks/LandmarkDemo.test.svelte.ts
+++ b/src/patterns/landmarks/LandmarkDemo.test.svelte.ts
@@ -1,0 +1,160 @@
+import { render, screen, within } from '@testing-library/svelte';
+import { axe } from 'jest-axe';
+import { describe, expect, it } from 'vitest';
+import LandmarkDemo from './LandmarkDemo.svelte';
+
+describe('LandmarkDemo (Svelte)', () => {
+  // 🔴 High Priority: Landmark Roles
+  describe('APG: Landmark Roles', () => {
+    it('has banner landmark (header)', () => {
+      render(LandmarkDemo);
+      expect(screen.getByRole('banner')).toBeInTheDocument();
+    });
+
+    it('has navigation landmark (nav)', () => {
+      render(LandmarkDemo);
+      expect(screen.getAllByRole('navigation').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('has main landmark (main)', () => {
+      render(LandmarkDemo);
+      expect(screen.getByRole('main')).toBeInTheDocument();
+    });
+
+    it('has contentinfo landmark (footer)', () => {
+      render(LandmarkDemo);
+      expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+    });
+
+    it('has complementary landmark (aside)', () => {
+      render(LandmarkDemo);
+      expect(screen.getByRole('complementary')).toBeInTheDocument();
+    });
+
+    it('has region landmark with label', () => {
+      render(LandmarkDemo);
+      const region = screen.getByRole('region');
+      expect(region).toBeInTheDocument();
+      expect(region).toHaveAccessibleName();
+    });
+
+    it('has search landmark', () => {
+      render(LandmarkDemo);
+      expect(screen.getByRole('search')).toBeInTheDocument();
+    });
+
+    it('has form landmark with label', () => {
+      render(LandmarkDemo);
+      const form = screen.getByRole('form');
+      expect(form).toBeInTheDocument();
+      expect(form).toHaveAccessibleName();
+    });
+
+    it('has exactly one main landmark', () => {
+      render(LandmarkDemo);
+      expect(screen.getAllByRole('main')).toHaveLength(1);
+    });
+
+    it('has exactly one banner landmark', () => {
+      render(LandmarkDemo);
+      expect(screen.getAllByRole('banner')).toHaveLength(1);
+    });
+
+    it('has exactly one contentinfo landmark', () => {
+      render(LandmarkDemo);
+      expect(screen.getAllByRole('contentinfo')).toHaveLength(1);
+    });
+  });
+
+  // 🔴 High Priority: Landmark Labeling
+  describe('APG: Landmark Labeling', () => {
+    it('navigation landmarks have unique labels when multiple', () => {
+      render(LandmarkDemo);
+      const navs = screen.getAllByRole('navigation');
+      if (navs.length > 1) {
+        const labels = navs.map(
+          (nav) => nav.getAttribute('aria-label') || nav.getAttribute('aria-labelledby')
+        );
+        const uniqueLabels = new Set(labels.filter(Boolean));
+        expect(uniqueLabels.size).toBe(navs.length);
+      }
+    });
+
+    it('region landmark has accessible name', () => {
+      render(LandmarkDemo);
+      const region = screen.getByRole('region');
+      const hasLabel = region.hasAttribute('aria-label') || region.hasAttribute('aria-labelledby');
+      expect(hasLabel).toBe(true);
+    });
+
+    it('form landmark has accessible name', () => {
+      render(LandmarkDemo);
+      const form = screen.getByRole('form');
+      const hasLabel = form.hasAttribute('aria-label') || form.hasAttribute('aria-labelledby');
+      expect(hasLabel).toBe(true);
+    });
+
+    it('search landmark has accessible name', () => {
+      render(LandmarkDemo);
+      const search = screen.getByRole('search');
+      const hasLabel = search.hasAttribute('aria-label') || search.hasAttribute('aria-labelledby');
+      expect(hasLabel).toBe(true);
+    });
+
+    it('complementary landmark has accessible name', () => {
+      render(LandmarkDemo);
+      const aside = screen.getByRole('complementary');
+      const hasLabel = aside.hasAttribute('aria-label') || aside.hasAttribute('aria-labelledby');
+      expect(hasLabel).toBe(true);
+    });
+  });
+
+  // 🟡 Medium Priority: Accessibility
+  describe('Accessibility', () => {
+    it('has no axe-core violations', async () => {
+      const { container } = render(LandmarkDemo);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  // 🟢 Low Priority: Props
+  describe('Props', () => {
+    it('applies class to container', () => {
+      render(LandmarkDemo, {
+        props: { class: 'custom-class', 'data-testid': 'landmark-demo' },
+      });
+      const container = screen.getByTestId('landmark-demo');
+      expect(container).toHaveClass('custom-class');
+    });
+
+    it('shows landmark labels when showLabels is true', () => {
+      render(LandmarkDemo, {
+        props: { showLabels: true },
+      });
+      expect(screen.getByText('banner')).toBeInTheDocument();
+      expect(screen.getByText('main')).toBeInTheDocument();
+      expect(screen.getByText('contentinfo')).toBeInTheDocument();
+    });
+  });
+
+  // 🟢 Low Priority: Semantic Structure
+  describe('Semantic Structure', () => {
+    it('uses semantic HTML elements', () => {
+      const { container } = render(LandmarkDemo);
+      expect(container.querySelector('header')).toBeInTheDocument();
+      expect(container.querySelector('nav')).toBeInTheDocument();
+      expect(container.querySelector('main')).toBeInTheDocument();
+      expect(container.querySelector('footer')).toBeInTheDocument();
+      expect(container.querySelector('aside')).toBeInTheDocument();
+      expect(container.querySelector('section')).toBeInTheDocument();
+    });
+
+    it('main contains primary content area', () => {
+      render(LandmarkDemo);
+      const main = screen.getByRole('main');
+      expect(within(main).getByRole('region')).toBeInTheDocument();
+      expect(within(main).getByRole('complementary')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/patterns/landmarks/LandmarkDemo.test.tsx
+++ b/src/patterns/landmarks/LandmarkDemo.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen, within } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, expect, it } from 'vitest';
+import { LandmarkDemo } from './LandmarkDemo';
+
+describe('LandmarkDemo', () => {
+  // 🔴 High Priority: Landmark Roles
+  describe('APG: Landmark Roles', () => {
+    it('has banner landmark (header)', () => {
+      render(<LandmarkDemo />);
+      expect(screen.getByRole('banner')).toBeInTheDocument();
+    });
+
+    it('has navigation landmark (nav)', () => {
+      render(<LandmarkDemo />);
+      expect(screen.getAllByRole('navigation').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('has main landmark (main)', () => {
+      render(<LandmarkDemo />);
+      expect(screen.getByRole('main')).toBeInTheDocument();
+    });
+
+    it('has contentinfo landmark (footer)', () => {
+      render(<LandmarkDemo />);
+      expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+    });
+
+    it('has complementary landmark (aside)', () => {
+      render(<LandmarkDemo />);
+      expect(screen.getByRole('complementary')).toBeInTheDocument();
+    });
+
+    it('has region landmark with label (section[aria-labelledby])', () => {
+      render(<LandmarkDemo />);
+      const region = screen.getByRole('region');
+      expect(region).toBeInTheDocument();
+      // Region must have accessible name
+      expect(region).toHaveAccessibleName();
+    });
+
+    it('has search landmark (form[role="search"])', () => {
+      render(<LandmarkDemo />);
+      expect(screen.getByRole('search')).toBeInTheDocument();
+    });
+
+    it('has form landmark with label', () => {
+      render(<LandmarkDemo />);
+      const form = screen.getByRole('form');
+      expect(form).toBeInTheDocument();
+      // Form landmark must have accessible name
+      expect(form).toHaveAccessibleName();
+    });
+
+    it('has exactly one main landmark', () => {
+      render(<LandmarkDemo />);
+      expect(screen.getAllByRole('main')).toHaveLength(1);
+    });
+
+    it('has exactly one banner landmark', () => {
+      render(<LandmarkDemo />);
+      expect(screen.getAllByRole('banner')).toHaveLength(1);
+    });
+
+    it('has exactly one contentinfo landmark', () => {
+      render(<LandmarkDemo />);
+      expect(screen.getAllByRole('contentinfo')).toHaveLength(1);
+    });
+  });
+
+  // 🔴 High Priority: Landmark Labeling
+  describe('APG: Landmark Labeling', () => {
+    it('navigation landmarks have unique labels when multiple', () => {
+      render(<LandmarkDemo />);
+      const navs = screen.getAllByRole('navigation');
+      if (navs.length > 1) {
+        const labels = navs.map(
+          (nav) => nav.getAttribute('aria-label') || nav.getAttribute('aria-labelledby')
+        );
+        const uniqueLabels = new Set(labels.filter(Boolean));
+        expect(uniqueLabels.size).toBe(navs.length);
+      }
+    });
+
+    it('region landmark has accessible name', () => {
+      render(<LandmarkDemo />);
+      const region = screen.getByRole('region');
+      // Check for aria-label or aria-labelledby
+      const hasLabel = region.hasAttribute('aria-label') || region.hasAttribute('aria-labelledby');
+      expect(hasLabel).toBe(true);
+    });
+
+    it('form landmark has accessible name', () => {
+      render(<LandmarkDemo />);
+      const form = screen.getByRole('form');
+      // Check for aria-label or aria-labelledby
+      const hasLabel = form.hasAttribute('aria-label') || form.hasAttribute('aria-labelledby');
+      expect(hasLabel).toBe(true);
+    });
+
+    it('search landmark has accessible name', () => {
+      render(<LandmarkDemo />);
+      const search = screen.getByRole('search');
+      // Check for aria-label or aria-labelledby
+      const hasLabel = search.hasAttribute('aria-label') || search.hasAttribute('aria-labelledby');
+      expect(hasLabel).toBe(true);
+    });
+
+    it('complementary landmark has accessible name', () => {
+      render(<LandmarkDemo />);
+      const aside = screen.getByRole('complementary');
+      // Check for aria-label or aria-labelledby
+      const hasLabel = aside.hasAttribute('aria-label') || aside.hasAttribute('aria-labelledby');
+      expect(hasLabel).toBe(true);
+    });
+  });
+
+  // 🟡 Medium Priority: Accessibility
+  describe('Accessibility', () => {
+    it('has no axe-core violations', async () => {
+      const { container } = render(<LandmarkDemo />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  // 🟢 Low Priority: Props
+  describe('Props', () => {
+    it('applies className to container', () => {
+      render(<LandmarkDemo className="custom-class" data-testid="landmark-demo" />);
+      const container = screen.getByTestId('landmark-demo');
+      expect(container).toHaveClass('custom-class');
+    });
+
+    it('shows landmark labels when showLabels is true', () => {
+      render(<LandmarkDemo showLabels data-testid="landmark-demo" />);
+      // When showLabels is true, landmark labels should be visible
+      // Check for label overlay elements
+      expect(screen.getByText('banner')).toBeInTheDocument();
+      expect(screen.getByText('main')).toBeInTheDocument();
+      expect(screen.getByText('contentinfo')).toBeInTheDocument();
+    });
+  });
+
+  // 🟢 Low Priority: Semantic Structure
+  describe('Semantic Structure', () => {
+    it('uses semantic HTML elements', () => {
+      const { container } = render(<LandmarkDemo />);
+      expect(container.querySelector('header')).toBeInTheDocument();
+      expect(container.querySelector('nav')).toBeInTheDocument();
+      expect(container.querySelector('main')).toBeInTheDocument();
+      expect(container.querySelector('footer')).toBeInTheDocument();
+      expect(container.querySelector('aside')).toBeInTheDocument();
+      expect(container.querySelector('section')).toBeInTheDocument();
+    });
+
+    it('main contains primary content area', () => {
+      render(<LandmarkDemo />);
+      const main = screen.getByRole('main');
+      // Main should contain the region and complementary landmarks
+      expect(within(main).getByRole('region')).toBeInTheDocument();
+      expect(within(main).getByRole('complementary')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/patterns/landmarks/LandmarkDemo.test.vue.ts
+++ b/src/patterns/landmarks/LandmarkDemo.test.vue.ts
@@ -1,0 +1,161 @@
+import { render, screen, within } from '@testing-library/vue';
+import { axe } from 'jest-axe';
+import { describe, expect, it } from 'vitest';
+import LandmarkDemo from './LandmarkDemo.vue';
+
+describe('LandmarkDemo (Vue)', () => {
+  // 🔴 High Priority: Landmark Roles
+  describe('APG: Landmark Roles', () => {
+    it('has banner landmark (header)', () => {
+      render(LandmarkDemo);
+      expect(screen.getByRole('banner')).toBeInTheDocument();
+    });
+
+    it('has navigation landmark (nav)', () => {
+      render(LandmarkDemo);
+      expect(screen.getAllByRole('navigation').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('has main landmark (main)', () => {
+      render(LandmarkDemo);
+      expect(screen.getByRole('main')).toBeInTheDocument();
+    });
+
+    it('has contentinfo landmark (footer)', () => {
+      render(LandmarkDemo);
+      expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+    });
+
+    it('has complementary landmark (aside)', () => {
+      render(LandmarkDemo);
+      expect(screen.getByRole('complementary')).toBeInTheDocument();
+    });
+
+    it('has region landmark with label', () => {
+      render(LandmarkDemo);
+      const region = screen.getByRole('region');
+      expect(region).toBeInTheDocument();
+      expect(region).toHaveAccessibleName();
+    });
+
+    it('has search landmark', () => {
+      render(LandmarkDemo);
+      expect(screen.getByRole('search')).toBeInTheDocument();
+    });
+
+    it('has form landmark with label', () => {
+      render(LandmarkDemo);
+      const form = screen.getByRole('form');
+      expect(form).toBeInTheDocument();
+      expect(form).toHaveAccessibleName();
+    });
+
+    it('has exactly one main landmark', () => {
+      render(LandmarkDemo);
+      expect(screen.getAllByRole('main')).toHaveLength(1);
+    });
+
+    it('has exactly one banner landmark', () => {
+      render(LandmarkDemo);
+      expect(screen.getAllByRole('banner')).toHaveLength(1);
+    });
+
+    it('has exactly one contentinfo landmark', () => {
+      render(LandmarkDemo);
+      expect(screen.getAllByRole('contentinfo')).toHaveLength(1);
+    });
+  });
+
+  // 🔴 High Priority: Landmark Labeling
+  describe('APG: Landmark Labeling', () => {
+    it('navigation landmarks have unique labels when multiple', () => {
+      render(LandmarkDemo);
+      const navs = screen.getAllByRole('navigation');
+      if (navs.length > 1) {
+        const labels = navs.map(
+          (nav) => nav.getAttribute('aria-label') || nav.getAttribute('aria-labelledby')
+        );
+        const uniqueLabels = new Set(labels.filter(Boolean));
+        expect(uniqueLabels.size).toBe(navs.length);
+      }
+    });
+
+    it('region landmark has accessible name', () => {
+      render(LandmarkDemo);
+      const region = screen.getByRole('region');
+      const hasLabel = region.hasAttribute('aria-label') || region.hasAttribute('aria-labelledby');
+      expect(hasLabel).toBe(true);
+    });
+
+    it('form landmark has accessible name', () => {
+      render(LandmarkDemo);
+      const form = screen.getByRole('form');
+      const hasLabel = form.hasAttribute('aria-label') || form.hasAttribute('aria-labelledby');
+      expect(hasLabel).toBe(true);
+    });
+
+    it('search landmark has accessible name', () => {
+      render(LandmarkDemo);
+      const search = screen.getByRole('search');
+      const hasLabel = search.hasAttribute('aria-label') || search.hasAttribute('aria-labelledby');
+      expect(hasLabel).toBe(true);
+    });
+
+    it('complementary landmark has accessible name', () => {
+      render(LandmarkDemo);
+      const aside = screen.getByRole('complementary');
+      const hasLabel = aside.hasAttribute('aria-label') || aside.hasAttribute('aria-labelledby');
+      expect(hasLabel).toBe(true);
+    });
+  });
+
+  // 🟡 Medium Priority: Accessibility
+  describe('Accessibility', () => {
+    it('has no axe-core violations', async () => {
+      const { container } = render(LandmarkDemo);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  // 🟢 Low Priority: Props
+  describe('Props', () => {
+    it('applies class to container', () => {
+      render(LandmarkDemo, {
+        props: { class: 'custom-class' },
+        attrs: { 'data-testid': 'landmark-demo' },
+      });
+      const container = screen.getByTestId('landmark-demo');
+      expect(container).toHaveClass('custom-class');
+    });
+
+    it('shows landmark labels when showLabels is true', () => {
+      render(LandmarkDemo, {
+        props: { showLabels: true },
+      });
+      expect(screen.getByText('banner')).toBeInTheDocument();
+      expect(screen.getByText('main')).toBeInTheDocument();
+      expect(screen.getByText('contentinfo')).toBeInTheDocument();
+    });
+  });
+
+  // 🟢 Low Priority: Semantic Structure
+  describe('Semantic Structure', () => {
+    it('uses semantic HTML elements', () => {
+      const { container } = render(LandmarkDemo);
+      expect(container.querySelector('header')).toBeInTheDocument();
+      expect(container.querySelector('nav')).toBeInTheDocument();
+      expect(container.querySelector('main')).toBeInTheDocument();
+      expect(container.querySelector('footer')).toBeInTheDocument();
+      expect(container.querySelector('aside')).toBeInTheDocument();
+      expect(container.querySelector('section')).toBeInTheDocument();
+    });
+
+    it('main contains primary content area', () => {
+      render(LandmarkDemo);
+      const main = screen.getByRole('main');
+      expect(within(main).getByRole('region')).toBeInTheDocument();
+      expect(within(main).getByRole('complementary')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/patterns/landmarks/LandmarkDemo.tsx
+++ b/src/patterns/landmarks/LandmarkDemo.tsx
@@ -1,0 +1,155 @@
+import { cn } from '@/lib/utils';
+
+export interface LandmarkDemoProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Show landmark labels overlay */
+  showLabels?: boolean;
+}
+
+/**
+ * LandmarkDemo - Demonstrates the 8 ARIA landmark roles
+ *
+ * This component visualizes proper landmark structure for educational purposes.
+ * It demonstrates:
+ * - banner (header)
+ * - navigation (nav)
+ * - main
+ * - contentinfo (footer)
+ * - complementary (aside)
+ * - region (section with label)
+ * - search (form with role="search")
+ * - form (form with label)
+ *
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/
+ */
+export const LandmarkDemo: React.FC<LandmarkDemoProps> = ({
+  showLabels = false,
+  className,
+  ...props
+}) => {
+  return (
+    <div className={cn('apg-landmark-demo', className)} {...props}>
+      {/* Banner Landmark */}
+      <header className="apg-landmark-banner">
+        <LandmarkLabel label="banner" visible={showLabels} />
+        <div className="apg-landmark-content">
+          <span className="apg-landmark-logo">Site Logo</span>
+          {/* Navigation Landmark (Main) */}
+          <nav aria-label="Main" className="apg-landmark-navigation">
+            <LandmarkLabel label="navigation" visible={showLabels} />
+            <ul className="apg-landmark-nav-list">
+              <li>
+                <a href="#home">Home</a>
+              </li>
+              <li>
+                <a href="#about">About</a>
+              </li>
+              <li>
+                <a href="#contact">Contact</a>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </header>
+
+      {/* Main Landmark */}
+      <main className="apg-landmark-main">
+        <LandmarkLabel label="main" visible={showLabels} />
+        <div className="apg-landmark-main-content">
+          {/* Region Landmark */}
+          <section aria-labelledby="content-heading" className="apg-landmark-region">
+            <LandmarkLabel label="region" visible={showLabels} />
+            <h2 id="content-heading" className="apg-landmark-heading">
+              Main Content
+            </h2>
+            <p>
+              This section demonstrates the <code>region</code> landmark. A section element only
+              becomes a region landmark when it has an accessible name via{' '}
+              <code>aria-labelledby</code> or <code>aria-label</code>.
+            </p>
+
+            {/* Search Landmark */}
+            <form role="search" aria-label="Site search" className="apg-landmark-search">
+              <LandmarkLabel label="search" visible={showLabels} />
+              <label htmlFor="search-input" className="apg-landmark-search-label">
+                Search
+              </label>
+              <input
+                type="search"
+                id="search-input"
+                className="apg-landmark-search-input"
+                placeholder="Search..."
+              />
+              <button type="submit" className="apg-landmark-search-button">
+                Search
+              </button>
+            </form>
+
+            {/* Form Landmark */}
+            <form aria-label="Contact form" className="apg-landmark-form">
+              <LandmarkLabel label="form" visible={showLabels} />
+              <div className="apg-landmark-form-field">
+                <label htmlFor="name-input">Name</label>
+                <input type="text" id="name-input" className="apg-landmark-input" />
+              </div>
+              <div className="apg-landmark-form-field">
+                <label htmlFor="email-input">Email</label>
+                <input type="email" id="email-input" className="apg-landmark-input" />
+              </div>
+              <button type="submit" className="apg-landmark-submit">
+                Submit
+              </button>
+            </form>
+          </section>
+
+          {/* Complementary Landmark */}
+          <aside aria-label="Related content" className="apg-landmark-complementary">
+            <LandmarkLabel label="complementary" visible={showLabels} />
+            <h2 className="apg-landmark-heading">Related</h2>
+            <ul>
+              <li>
+                <a href="#related1">Related Link 1</a>
+              </li>
+              <li>
+                <a href="#related2">Related Link 2</a>
+              </li>
+            </ul>
+          </aside>
+        </div>
+      </main>
+
+      {/* Contentinfo Landmark */}
+      <footer className="apg-landmark-contentinfo">
+        <LandmarkLabel label="contentinfo" visible={showLabels} />
+        <div className="apg-landmark-content">
+          {/* Navigation Landmark (Footer) */}
+          <nav aria-label="Footer" className="apg-landmark-navigation">
+            <LandmarkLabel label="navigation" visible={showLabels} />
+            <ul className="apg-landmark-nav-list">
+              <li>
+                <a href="#privacy">Privacy</a>
+              </li>
+              <li>
+                <a href="#terms">Terms</a>
+              </li>
+              <li>
+                <a href="#sitemap">Sitemap</a>
+              </li>
+            </ul>
+          </nav>
+          <p className="apg-landmark-copyright">&copy; 2024 Example Site</p>
+        </div>
+      </footer>
+    </div>
+  );
+};
+
+/** Landmark label overlay component */
+const LandmarkLabel: React.FC<{ label: string; visible: boolean }> = ({ label, visible }) => {
+  return (
+    <span className={cn('apg-landmark-label', !visible && 'hidden')} aria-hidden="true">
+      {label}
+    </span>
+  );
+};
+
+export default LandmarkDemo;

--- a/src/patterns/landmarks/LandmarkDemo.vue
+++ b/src/patterns/landmarks/LandmarkDemo.vue
@@ -1,0 +1,131 @@
+<script setup lang="ts">
+/**
+ * LandmarkDemo - Demonstrates the 8 ARIA landmark roles
+ *
+ * This component visualizes proper landmark structure for educational purposes.
+ *
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/
+ */
+
+defineOptions({
+  inheritAttrs: true,
+});
+
+interface Props {
+  /** Show landmark labels overlay */
+  showLabels?: boolean;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  showLabels: false,
+});
+</script>
+
+<template>
+  <div :class="['apg-landmark-demo', props.class]">
+    <!-- Banner Landmark -->
+    <header class="apg-landmark-banner">
+      <span :class="['apg-landmark-label', !showLabels && 'hidden']" aria-hidden="true"
+        >banner</span
+      >
+      <div class="apg-landmark-content">
+        <span class="apg-landmark-logo">Site Logo</span>
+        <!-- Navigation Landmark (Main) -->
+        <nav aria-label="Main" class="apg-landmark-navigation">
+          <span :class="['apg-landmark-label', !showLabels && 'hidden']" aria-hidden="true"
+            >navigation</span
+          >
+          <ul class="apg-landmark-nav-list">
+            <li><a href="#home">Home</a></li>
+            <li><a href="#about">About</a></li>
+            <li><a href="#contact">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <!-- Main Landmark -->
+    <main class="apg-landmark-main">
+      <span :class="['apg-landmark-label', !showLabels && 'hidden']" aria-hidden="true">main</span>
+      <div class="apg-landmark-main-content">
+        <!-- Region Landmark -->
+        <section aria-labelledby="content-heading" class="apg-landmark-region">
+          <span :class="['apg-landmark-label', !showLabels && 'hidden']" aria-hidden="true"
+            >region</span
+          >
+          <h2 id="content-heading" class="apg-landmark-heading">Main Content</h2>
+          <p>
+            This section demonstrates the <code>region</code> landmark. A section element only
+            becomes a region landmark when it has an accessible name via
+            <code>aria-labelledby</code> or <code>aria-label</code>.
+          </p>
+
+          <!-- Search Landmark -->
+          <form role="search" aria-label="Site search" class="apg-landmark-search">
+            <span :class="['apg-landmark-label', !showLabels && 'hidden']" aria-hidden="true"
+              >search</span
+            >
+            <label for="search-input" class="apg-landmark-search-label">Search</label>
+            <input
+              type="search"
+              id="search-input"
+              class="apg-landmark-search-input"
+              placeholder="Search..."
+            />
+            <button type="submit" class="apg-landmark-search-button">Search</button>
+          </form>
+
+          <!-- Form Landmark -->
+          <form aria-label="Contact form" class="apg-landmark-form">
+            <span :class="['apg-landmark-label', !showLabels && 'hidden']" aria-hidden="true"
+              >form</span
+            >
+            <div class="apg-landmark-form-field">
+              <label for="name-input">Name</label>
+              <input type="text" id="name-input" class="apg-landmark-input" />
+            </div>
+            <div class="apg-landmark-form-field">
+              <label for="email-input">Email</label>
+              <input type="email" id="email-input" class="apg-landmark-input" />
+            </div>
+            <button type="submit" class="apg-landmark-submit">Submit</button>
+          </form>
+        </section>
+
+        <!-- Complementary Landmark -->
+        <aside aria-label="Related content" class="apg-landmark-complementary">
+          <span :class="['apg-landmark-label', !showLabels && 'hidden']" aria-hidden="true"
+            >complementary</span
+          >
+          <h2 class="apg-landmark-heading">Related</h2>
+          <ul>
+            <li><a href="#related1">Related Link 1</a></li>
+            <li><a href="#related2">Related Link 2</a></li>
+          </ul>
+        </aside>
+      </div>
+    </main>
+
+    <!-- Contentinfo Landmark -->
+    <footer class="apg-landmark-contentinfo">
+      <span :class="['apg-landmark-label', !showLabels && 'hidden']" aria-hidden="true"
+        >contentinfo</span
+      >
+      <div class="apg-landmark-content">
+        <!-- Navigation Landmark (Footer) -->
+        <nav aria-label="Footer" class="apg-landmark-navigation">
+          <span :class="['apg-landmark-label', !showLabels && 'hidden']" aria-hidden="true"
+            >navigation</span
+          >
+          <ul class="apg-landmark-nav-list">
+            <li><a href="#privacy">Privacy</a></li>
+            <li><a href="#terms">Terms</a></li>
+            <li><a href="#sitemap">Sitemap</a></li>
+          </ul>
+        </nav>
+        <p class="apg-landmark-copyright">&copy; 2024 Example Site</p>
+      </div>
+    </footer>
+  </div>
+</template>

--- a/src/patterns/landmarks/NativeHtmlNotice.astro
+++ b/src/patterns/landmarks/NativeHtmlNotice.astro
@@ -1,0 +1,87 @@
+---
+import { ResponsiveTable } from '@/components/ui/table';
+---
+
+<div class="border-primary mb-8 rounded-lg border-2 p-4">
+  <h2 class="mb-2 flex items-center gap-2 text-lg font-bold">
+    <span aria-hidden="true">✅</span> Prefer Native HTML Semantic Elements
+  </h2>
+  <p class="mb-4">
+    <strong class="text-green-700 dark:text-green-400"
+      >Always use native HTML semantic elements when possible.</strong
+    >
+    They provide built-in landmark roles without needing ARIA attributes and are better supported by assistive
+    technologies.
+  </p>
+  <div class="bg-muted mb-4 rounded-md p-3">
+    <pre
+      class="m-0 overflow-x-auto text-sm"><code>&lt;header&gt;...&lt;/header&gt;      &lt;!-- banner --&gt;
+&lt;nav&gt;...&lt;/nav&gt;           &lt;!-- navigation --&gt;
+&lt;main&gt;...&lt;/main&gt;         &lt;!-- main --&gt;
+&lt;footer&gt;...&lt;/footer&gt;     &lt;!-- contentinfo --&gt;
+&lt;aside&gt;...&lt;/aside&gt;       &lt;!-- complementary --&gt;
+&lt;section aria-label="..."&gt;...&lt;/section&gt;  &lt;!-- region --&gt;</code></pre>
+  </div>
+
+  <ResponsiveTable>
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">HTML Element</th>
+          <th class="py-2 pr-4 text-left">ARIA Role</th>
+          <th class="py-2 text-left">Auto-mapping Condition</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>&lt;header&gt;</code></td>
+          <td class="py-2 pr-4"><code>banner</code></td>
+          <td class="py-2">Only when direct child of <code>&lt;body&gt;</code></td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>&lt;nav&gt;</code></td>
+          <td class="py-2 pr-4"><code>navigation</code></td>
+          <td class="py-2">Always</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>&lt;main&gt;</code></td>
+          <td class="py-2 pr-4"><code>main</code></td>
+          <td class="py-2">Always</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>&lt;footer&gt;</code></td>
+          <td class="py-2 pr-4"><code>contentinfo</code></td>
+          <td class="py-2">Only when direct child of <code>&lt;body&gt;</code></td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>&lt;aside&gt;</code></td>
+          <td class="py-2 pr-4"><code>complementary</code></td>
+          <td class="py-2">Always</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>&lt;section&gt;</code></td>
+          <td class="py-2 pr-4"><code>region</code></td>
+          <td class="py-2"
+            ><b class="text-red-700 dark:text-red-400"
+              >Only when <code>aria-label</code> or <code>aria-labelledby</code> is present</b
+            ></td
+          >
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>&lt;form&gt;</code></td>
+          <td class="py-2 pr-4"><code>form</code></td>
+          <td class="py-2"
+            ><b class="text-red-700 dark:text-red-400"
+              >Only when <code>aria-label</code> or <code>aria-labelledby</code> is present</b
+            ></td
+          >
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+  <p class="text-muted-foreground mt-3 text-xs">
+    Note: For search functionality, use <code>&lt;form role="search"&gt;</code> as the <code
+      >&lt;search&gt;</code
+    > element has limited browser support.
+  </p>
+</div>

--- a/src/patterns/landmarks/NativeHtmlNotice.ja.astro
+++ b/src/patterns/landmarks/NativeHtmlNotice.ja.astro
@@ -1,0 +1,86 @@
+---
+import { ResponsiveTable } from '@/components/ui/table';
+---
+
+<div class="border-primary mb-8 rounded-lg border-2 p-4">
+  <h2 class="mb-2 flex items-center gap-2 text-lg font-bold">
+    <span aria-hidden="true">✅</span> ネイティブHTMLセマンティック要素を優先
+  </h2>
+  <p class="mb-4">
+    <strong class="text-green-700 dark:text-green-400"
+      >可能な限りネイティブHTMLセマンティック要素を使用してください。</strong
+    >
+    これらはARIA属性なしでランドマークロールを提供し、支援技術によるサポートも優れています。
+  </p>
+  <div class="bg-muted mb-4 rounded-md p-3">
+    <pre
+      class="m-0 overflow-x-auto text-sm"><code>&lt;header&gt;...&lt;/header&gt;      &lt;!-- banner --&gt;
+&lt;nav&gt;...&lt;/nav&gt;           &lt;!-- navigation --&gt;
+&lt;main&gt;...&lt;/main&gt;         &lt;!-- main --&gt;
+&lt;footer&gt;...&lt;/footer&gt;     &lt;!-- contentinfo --&gt;
+&lt;aside&gt;...&lt;/aside&gt;       &lt;!-- complementary --&gt;
+&lt;section aria-label="..."&gt;...&lt;/section&gt;  &lt;!-- region --&gt;</code></pre>
+  </div>
+
+  <ResponsiveTable>
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">HTML要素</th>
+          <th class="py-2 pr-4 text-left">ARIAロール</th>
+          <th class="py-2 text-left">自動マッピング条件</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>&lt;header&gt;</code></td>
+          <td class="py-2 pr-4"><code>banner</code></td>
+          <td class="py-2"><code>&lt;body&gt;</code>の直接の子の場合のみ</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>&lt;nav&gt;</code></td>
+          <td class="py-2 pr-4"><code>navigation</code></td>
+          <td class="py-2">常に</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>&lt;main&gt;</code></td>
+          <td class="py-2 pr-4"><code>main</code></td>
+          <td class="py-2">常に</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>&lt;footer&gt;</code></td>
+          <td class="py-2 pr-4"><code>contentinfo</code></td>
+          <td class="py-2"><code>&lt;body&gt;</code>の直接の子の場合のみ</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>&lt;aside&gt;</code></td>
+          <td class="py-2 pr-4"><code>complementary</code></td>
+          <td class="py-2">常に</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>&lt;section&gt;</code></td>
+          <td class="py-2 pr-4"><code>region</code></td>
+          <td class="py-2"
+            ><b class="text-red-700 dark:text-red-400"
+              ><code>aria-label</code>または<code>aria-labelledby</code>がある場合のみ</b
+            ></td
+          >
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>&lt;form&gt;</code></td>
+          <td class="py-2 pr-4"><code>form</code></td>
+          <td class="py-2"
+            ><b class="text-red-700 dark:text-red-400"
+              ><code>aria-label</code>または<code>aria-labelledby</code>がある場合のみ</b
+            ></td
+          >
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+  <p class="text-muted-foreground mt-3 text-xs">
+    注：検索機能には<code>&lt;form role="search"&gt;</code>を使用してください。<code
+      >&lt;search&gt;</code
+    >要素はブラウザサポートが限定的です。
+  </p>
+</div>

--- a/src/patterns/landmarks/TestingDocs.astro
+++ b/src/patterns/landmarks/TestingDocs.astro
@@ -1,0 +1,236 @@
+---
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+---
+
+<div class="prose dark:prose-invert max-w-none">
+  <p class="text-muted-foreground mb-4">
+    Tests verify that all 8 landmark roles are present, properly labeled, and follow APG
+    constraints. Since landmarks are static structural elements, testing focuses on HTML structure
+    rather than interaction.
+  </p>
+
+  <h3 class="mb-3 text-lg font-medium">Testing Strategy</h3>
+
+  <div class="bg-muted/50 mb-6 rounded-lg p-4">
+    <h4 class="mb-2 font-medium">Unit Tests (Container API / Testing Library)</h4>
+    <p class="text-muted-foreground mb-2 text-sm">
+      Verify the component's HTML output and landmark structure. These tests ensure correct
+      rendering without requiring a browser.
+    </p>
+    <ul class="text-muted-foreground list-disc space-y-1 pl-6 text-sm">
+      <li>All 8 landmark roles are present</li>
+      <li>Semantic HTML elements are used</li>
+      <li>Proper labeling (aria-label/aria-labelledby)</li>
+      <li>Constraint validation (one main, one banner, etc.)</li>
+    </ul>
+  </div>
+
+  <div class="bg-muted/50 mb-6 rounded-lg p-4">
+    <h4 class="mb-2 font-medium">E2E Tests (Playwright)</h4>
+    <p class="text-muted-foreground mb-2 text-sm">
+      Verify landmark structure in a real browser environment and run accessibility audits.
+    </p>
+    <ul class="text-muted-foreground list-disc space-y-1 pl-6 text-sm">
+      <li>Landmark roles are exposed correctly</li>
+      <li>axe-core accessibility audit</li>
+      <li>Cross-framework consistency</li>
+    </ul>
+  </div>
+
+  <h3 class="mb-3 text-lg font-medium">Test Categories</h3>
+
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
+    High Priority: Landmark Structure
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">Test</th>
+          <th class="py-2 text-left">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>banner landmark</code></td>
+          <td class="py-2">Has header element with banner role</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>navigation landmark</code></td>
+          <td class="py-2">Has nav element(s) with navigation role</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>main landmark</code></td>
+          <td class="py-2">Has main element with main role</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>contentinfo landmark</code></td>
+          <td class="py-2">Has footer element with contentinfo role</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>complementary landmark</code></td>
+          <td class="py-2">Has aside element with complementary role</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>region landmark</code></td>
+          <td class="py-2">Has section with aria-labelledby (region role)</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>search landmark</code></td>
+          <td class="py-2">Has form with role="search"</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>form landmark</code></td>
+          <td class="py-2">Has form with aria-label (form role)</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>exactly one main</code></td>
+          <td class="py-2">Only one main landmark exists</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>exactly one banner</code></td>
+          <td class="py-2">Only one banner landmark exists</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>exactly one contentinfo</code></td>
+          <td class="py-2">Only one contentinfo landmark exists</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
+    High Priority: Landmark Labeling
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">Test</th>
+          <th class="py-2 text-left">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>navigation labels</code></td>
+          <td class="py-2">Multiple navigations have unique aria-labels</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>region label</code></td>
+          <td class="py-2">Region has aria-label or aria-labelledby</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>form label</code></td>
+          <td class="py-2">Form landmark has aria-label</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>search label</code></td>
+          <td class="py-2">Search landmark has aria-label</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>complementary label</code></td>
+          <td class="py-2">Complementary landmark has aria-label</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-yellow-500"></span>
+    Medium Priority: Accessibility
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">Test</th>
+          <th class="py-2 text-left">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>axe-core audit</code></td>
+          <td class="py-2">No WCAG 2.1 AA violations</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-green-500"></span>
+    Low Priority: Props & Structure
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">Test</th>
+          <th class="py-2 text-left">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>className prop</code></td>
+          <td class="py-2">Custom className is applied to container</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>showLabels prop</code></td>
+          <td class="py-2">Landmark labels are visible when enabled</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>semantic HTML</code></td>
+          <td class="py-2">Uses header, nav, main, footer, aside, section elements</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h3 class="mb-3 text-lg font-medium">Checklist (Manual Verification)</h3>
+  <p class="text-muted-foreground mb-4">
+    These recommendations are best verified manually or with specialized tools:
+  </p>
+  <ul class="mb-6 list-disc space-y-2 pl-6">
+    <li>All content is within landmarks (recommended but not required)</li>
+    <li>Total landmarks ≤ 7 (too many can be overwhelming)</li>
+    <li>Screen reader navigation works correctly (NVDA D key, VoiceOver rotor)</li>
+  </ul>
+
+  <h3 class="mb-3 text-lg font-medium">Testing Tools</h3>
+  <ul class="mb-6 list-disc space-y-2 pl-6">
+    <li>
+      <ExternalLink href="https://vitest.dev/" class="text-primary hover:underline"
+        >Vitest</ExternalLink
+      >
+      - Test runner for unit tests
+    </li>
+    <li>
+      <ExternalLink
+        href="https://docs.astro.build/en/reference/container-reference/"
+        class="text-primary hover:underline">Astro Container API</ExternalLink
+      >
+      - Server-side component rendering for unit tests
+    </li>
+    <li>
+      <ExternalLink href="https://playwright.dev/" class="text-primary hover:underline"
+        >Playwright</ExternalLink
+      >
+      - Browser automation for E2E tests
+    </li>
+    <li>
+      <ExternalLink href="https://www.deque.com/axe/" class="text-primary hover:underline"
+        >axe-core</ExternalLink
+      >
+      - Accessibility testing engine
+    </li>
+  </ul>
+
+  <p class="text-muted-foreground text-sm">
+    See <ExternalLink
+      href="https://github.com/masuP9/apg-patterns-examples/blob/main/.internal/testing-strategy.md"
+      class="text-primary hover:underline">testing-strategy.md</ExternalLink
+    > for full documentation.
+  </p>
+</div>

--- a/src/patterns/landmarks/TestingDocs.ja.astro
+++ b/src/patterns/landmarks/TestingDocs.ja.astro
@@ -1,0 +1,233 @@
+---
+import ExternalLink from '@/components/ui/ExternalLink.astro';
+import { ResponsiveTable } from '@/components/ui/table';
+---
+
+<div class="prose dark:prose-invert max-w-none">
+  <p class="text-muted-foreground mb-4">
+    テストでは、8つのランドマークロールがすべて存在し、適切にラベル付けされ、APGの制約に従っていることを確認します。ランドマークは静的な構造要素であるため、テストはインタラクションよりもHTML構造に焦点を当てています。
+  </p>
+
+  <h3 class="mb-3 text-lg font-medium">テスト戦略</h3>
+
+  <div class="bg-muted/50 mb-6 rounded-lg p-4">
+    <h4 class="mb-2 font-medium">ユニットテスト（Container API / Testing Library）</h4>
+    <p class="text-muted-foreground mb-2 text-sm">
+      コンポーネントのHTML出力とランドマーク構造を検証します。ブラウザなしで正しいレンダリングを確認できます。
+    </p>
+    <ul class="text-muted-foreground list-disc space-y-1 pl-6 text-sm">
+      <li>8つのランドマークロールがすべて存在</li>
+      <li>セマンティックHTML要素の使用</li>
+      <li>適切なラベル付け（aria-label/aria-labelledby）</li>
+      <li>制約の検証（mainは1つのみ、bannerは1つのみなど）</li>
+    </ul>
+  </div>
+
+  <div class="bg-muted/50 mb-6 rounded-lg p-4">
+    <h4 class="mb-2 font-medium">E2Eテスト（Playwright）</h4>
+    <p class="text-muted-foreground mb-2 text-sm">
+      実際のブラウザ環境でランドマーク構造を検証し、アクセシビリティ監査を実行します。
+    </p>
+    <ul class="text-muted-foreground list-disc space-y-1 pl-6 text-sm">
+      <li>ランドマークロールが正しく公開される</li>
+      <li>axe-coreアクセシビリティ監査</li>
+      <li>フレームワーク間の一貫性</li>
+    </ul>
+  </div>
+
+  <h3 class="mb-3 text-lg font-medium">テストカテゴリ</h3>
+
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
+    高優先度: ランドマーク構造
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">テスト</th>
+          <th class="py-2 text-left">説明</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>banner ランドマーク</code></td>
+          <td class="py-2">bannerロールを持つheader要素がある</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>navigation ランドマーク</code></td>
+          <td class="py-2">navigationロールを持つnav要素がある</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>main ランドマーク</code></td>
+          <td class="py-2">mainロールを持つmain要素がある</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>contentinfo ランドマーク</code></td>
+          <td class="py-2">contentinfoロールを持つfooter要素がある</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>complementary ランドマーク</code></td>
+          <td class="py-2">complementaryロールを持つaside要素がある</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>region ランドマーク</code></td>
+          <td class="py-2">aria-labelledbyを持つsection（regionロール）がある</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>search ランドマーク</code></td>
+          <td class="py-2">role="search"を持つformがある</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>form ランドマーク</code></td>
+          <td class="py-2">aria-label（formロール）を持つformがある</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>mainは1つのみ</code></td>
+          <td class="py-2">mainランドマークが1つだけ存在する</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>bannerは1つのみ</code></td>
+          <td class="py-2">bannerランドマークが1つだけ存在する</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>contentinfoは1つのみ</code></td>
+          <td class="py-2">contentinfoランドマークが1つだけ存在する</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
+    高優先度: ランドマークのラベル付け
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">テスト</th>
+          <th class="py-2 text-left">説明</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>navigationのラベル</code></td>
+          <td class="py-2">複数のnavigationが一意のaria-labelを持つ</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>regionのラベル</code></td>
+          <td class="py-2">regionがaria-labelまたはaria-labelledbyを持つ</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>formのラベル</code></td>
+          <td class="py-2">formランドマークがaria-labelを持つ</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>searchのラベル</code></td>
+          <td class="py-2">searchランドマークがaria-labelを持つ</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>complementaryのラベル</code></td>
+          <td class="py-2">complementaryランドマークがaria-labelを持つ</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-yellow-500"></span>
+    中優先度: アクセシビリティ
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">テスト</th>
+          <th class="py-2 text-left">説明</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>axe-core監査</code></td>
+          <td class="py-2">WCAG 2.1 AAの違反がない</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-green-500"></span>
+    低優先度: プロパティと構造
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">テスト</th>
+          <th class="py-2 text-left">説明</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>className プロパティ</code></td>
+          <td class="py-2">カスタムclassNameがコンテナに適用される</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>showLabels プロパティ</code></td>
+          <td class="py-2">有効時にランドマークラベルが表示される</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>セマンティックHTML</code></td>
+          <td class="py-2">header、nav、main、footer、aside、section要素を使用</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h3 class="mb-3 text-lg font-medium">チェックリスト（手動検証）</h3>
+  <p class="text-muted-foreground mb-4">
+    これらの推奨事項は手動または専用ツールで検証するのが最適です：
+  </p>
+  <ul class="mb-6 list-disc space-y-2 pl-6">
+    <li>すべてのコンテンツがランドマーク内にある（推奨だが必須ではない）</li>
+    <li>ランドマークの総数が7以下（多すぎると煩雑になる）</li>
+    <li>スクリーンリーダーナビゲーションが正しく動作する（NVDA D キー、VoiceOver ローター）</li>
+  </ul>
+
+  <h3 class="mb-3 text-lg font-medium">テストツール</h3>
+  <ul class="mb-6 list-disc space-y-2 pl-6">
+    <li>
+      <ExternalLink href="https://vitest.dev/" class="text-primary hover:underline"
+        >Vitest</ExternalLink
+      >
+      - ユニットテスト用テストランナー
+    </li>
+    <li>
+      <ExternalLink
+        href="https://docs.astro.build/en/reference/container-reference/"
+        class="text-primary hover:underline">Astro Container API</ExternalLink
+      >
+      - ユニットテスト用サーバーサイドコンポーネントレンダリング
+    </li>
+    <li>
+      <ExternalLink href="https://playwright.dev/" class="text-primary hover:underline"
+        >Playwright</ExternalLink
+      >
+      - E2Eテスト用ブラウザ自動化
+    </li>
+    <li>
+      <ExternalLink href="https://www.deque.com/axe/" class="text-primary hover:underline"
+        >axe-core</ExternalLink
+      >
+      - アクセシビリティテストエンジン
+    </li>
+  </ul>
+
+  <p class="text-muted-foreground text-sm">
+    詳細は<ExternalLink
+      href="https://github.com/masuP9/apg-patterns-examples/blob/main/.internal/testing-strategy.md"
+      class="text-primary hover:underline">testing-strategy.md</ExternalLink
+    >を参照してください。
+  </p>
+</div>

--- a/src/patterns/landmarks/llm.md
+++ b/src/patterns/landmarks/llm.md
@@ -1,0 +1,165 @@
+# Landmarks Pattern - AI Implementation Guide
+
+> APG Reference: https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/
+
+## Overview
+
+Landmarks identify the major sections of a page. There are eight landmark roles that enable assistive technology users to efficiently navigate page structure.
+
+## ARIA Requirements
+
+### Roles
+
+| Role            | HTML Element            | Description                      | Constraint                          |
+| --------------- | ----------------------- | -------------------------------- | ----------------------------------- |
+| `banner`        | `<header>`              | Site-wide header                 | One per page, top-level only        |
+| `navigation`    | `<nav>`                 | Navigation links                 | Multiple allowed, label when >1     |
+| `main`          | `<main>`                | Primary content                  | One per page, top-level only        |
+| `contentinfo`   | `<footer>`              | Site-wide footer                 | One per page, top-level only        |
+| `complementary` | `<aside>`               | Supporting content               | Top-level recommended               |
+| `region`        | `<section>`             | Named section                    | **Requires aria-label/labelledby**  |
+| `search`        | `<form role="search">`  | Search functionality             | Use with form element               |
+| `form`          | `<form>`                | Form area                        | **Requires aria-label/labelledby**  |
+
+### Properties (Static Attributes)
+
+| Attribute          | Target          | Values     | Required    | Notes                               |
+| ------------------ | --------------- | ---------- | ----------- | ----------------------------------- |
+| `aria-label`       | All landmarks   | String     | Conditional | When multiple of same type, or region/form |
+| `aria-labelledby`  | All landmarks   | ID ref     | Conditional | Reference visible heading           |
+
+### States (Dynamic Attributes)
+
+None - Landmarks are static structural elements.
+
+## HTML Element Auto-Mapping
+
+| HTML Element  | ARIA Role       | Auto-mapping Condition                           |
+| ------------- | --------------- | ------------------------------------------------ |
+| `<header>`    | `banner`        | Only when direct child of `<body>`               |
+| `<nav>`       | `navigation`    | Always                                           |
+| `<main>`      | `main`          | Always                                           |
+| `<footer>`    | `contentinfo`   | Only when direct child of `<body>`               |
+| `<aside>`     | `complementary` | Always                                           |
+| `<section>`   | `region`        | **Only when aria-label/labelledby is present**   |
+| `<form>`      | `form`          | **Only when aria-label/labelledby is present**   |
+
+## Keyboard Support
+
+**None** - Landmarks are not interactive elements. Screen readers provide built-in landmark navigation (e.g., NVDA `D` key, VoiceOver rotor).
+
+## Focus Management
+
+Not applicable - Landmarks are not focusable.
+
+## Test Checklist
+
+### High Priority: Landmark Structure
+
+- [ ] Has banner landmark (`<header>` or `role="banner"`)
+- [ ] Has navigation landmark (`<nav>` or `role="navigation"`)
+- [ ] Has main landmark (`<main>` or `role="main"`)
+- [ ] Has contentinfo landmark (`<footer>` or `role="contentinfo"`)
+- [ ] Has search landmark (`<form role="search">`)
+- [ ] Has form landmark with accessible name
+- [ ] Has exactly one main landmark
+- [ ] Banner is at top level (not inside article/aside/main/nav/section)
+- [ ] Contentinfo is at top level
+
+### High Priority: Labeling
+
+- [ ] Navigation landmarks have unique labels when multiple
+- [ ] Complementary landmarks have unique labels when multiple
+- [ ] Region landmarks have accessible name (aria-label or aria-labelledby)
+- [ ] Form landmarks have accessible name
+
+### Medium Priority: Accessibility
+
+- [ ] No axe-core violations (WCAG 2.1 AA)
+
+### Checklist (Recommendations, Not Test Requirements)
+
+- [ ] All content is within landmarks (recommended but not required)
+- [ ] Total landmarks ≤ 7 (too many can be overwhelming)
+
+## Implementation Notes
+
+```
+Structure Diagram:
+┌─────────────────────────────────────────────────────────────┐
+│ <header> role="banner"                                       │
+│ ┌─────────────────────────────────────────────────────────┐ │
+│ │ <nav aria-label="Main"> role="navigation"               │ │
+│ └─────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────┐
+│ <main> role="main"                                           │
+│ ┌─────────────────────┐ ┌─────────────────────────────────┐ │
+│ │ <section            │ │ <aside aria-label="Related">    │ │
+│ │   aria-labelledby>  │ │   role="complementary"          │ │
+│ │   role="region"     │ │                                 │ │
+│ └─────────────────────┘ └─────────────────────────────────┘ │
+│ ┌─────────────────────────────────────────────────────────┐ │
+│ │ <form role="search" aria-label="Site search">           │ │
+│ └─────────────────────────────────────────────────────────┘ │
+│ ┌─────────────────────────────────────────────────────────┐ │
+│ │ <form aria-label="Contact form"> role="form"            │ │
+│ └─────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────┐
+│ <footer> role="contentinfo"                                  │
+│ ┌─────────────────────────────────────────────────────────┐ │
+│ │ <nav aria-label="Footer"> role="navigation"             │ │
+│ └─────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────┘
+
+Key Points:
+- Prefer semantic HTML elements over ARIA roles
+- header/footer only map to banner/contentinfo at body level
+- section without label is NOT a region landmark
+- form without label is NOT a form landmark
+- <search> element has limited browser support, use <form role="search">
+```
+
+## Example Test Code (React + Testing Library)
+
+```typescript
+import { render, screen } from '@testing-library/react';
+
+// Has banner landmark
+it('has banner landmark', () => {
+  render(<LandmarkDemo />);
+  expect(screen.getByRole('banner')).toBeInTheDocument();
+});
+
+// Has navigation landmarks with unique labels
+it('has navigation landmarks with unique labels', () => {
+  render(<LandmarkDemo />);
+  const navs = screen.getAllByRole('navigation');
+  const labels = navs.map(nav =>
+    nav.getAttribute('aria-label') ||
+    nav.querySelector('[aria-labelledby]')?.id
+  );
+  const uniqueLabels = new Set(labels);
+  expect(uniqueLabels.size).toBe(navs.length);
+});
+
+// Has exactly one main landmark
+it('has exactly one main landmark', () => {
+  render(<LandmarkDemo />);
+  expect(screen.getAllByRole('main')).toHaveLength(1);
+});
+
+// Region has accessible name
+it('region has accessible name', () => {
+  render(<LandmarkDemo />);
+  const region = screen.getByRole('region');
+  expect(region).toHaveAccessibleName();
+});
+
+// Search landmark exists
+it('has search landmark', () => {
+  render(<LandmarkDemo />);
+  expect(screen.getByRole('search')).toBeInTheDocument();
+});
+```

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -19,6 +19,7 @@
 @import './patterns/treeview.css';
 @import './patterns/table.css';
 @import './patterns/carousel.css';
+@import './patterns/landmarks.css';
 @import 'tw-animate-css';
 
 @custom-variant dark (&:is(.dark *));

--- a/src/styles/patterns/landmarks.css
+++ b/src/styles/patterns/landmarks.css
@@ -1,0 +1,374 @@
+/**
+ * Landmarks Pattern Styles
+ *
+ * These styles visualize the landmark structure for educational purposes.
+ * Each landmark has a distinct border color to help identify the regions.
+ */
+
+/* Container */
+.apg-landmark-demo {
+  --landmark-border-radius: 0.5rem;
+  --landmark-padding: 1rem;
+  --landmark-gap: 1rem;
+
+  display: flex;
+  flex-direction: column;
+  gap: var(--landmark-gap);
+  font-family: system-ui, sans-serif;
+}
+
+/* Landmark Label Overlay */
+.apg-landmark-label {
+  position: absolute;
+  top: 0.25rem;
+  left: 0.25rem;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.2;
+  color: white;
+  background-color: oklch(0.3 0 0 / 80%);
+  border-radius: 0.25rem;
+  z-index: 10;
+  pointer-events: none;
+}
+
+.apg-landmark-label.hidden {
+  display: none;
+}
+
+/* Common Landmark Styles */
+.apg-landmark-banner,
+.apg-landmark-main,
+.apg-landmark-contentinfo,
+.apg-landmark-navigation,
+.apg-landmark-region,
+.apg-landmark-complementary,
+.apg-landmark-search,
+.apg-landmark-form {
+  position: relative;
+  border-radius: var(--landmark-border-radius);
+  border-width: 2px;
+  border-style: dashed;
+}
+
+/* Banner (header) */
+.apg-landmark-banner {
+  padding: var(--landmark-padding);
+  border-color: oklch(0.7 0.15 30); /* Orange */
+  background-color: oklch(0.95 0.02 30);
+}
+
+.dark .apg-landmark-banner {
+  background-color: oklch(0.25 0.02 30);
+}
+
+.apg-landmark-banner .apg-landmark-label {
+  background-color: oklch(0.45 0.15 30);
+}
+
+/* Main */
+.apg-landmark-main {
+  padding: var(--landmark-padding);
+  border-color: oklch(0.6 0.2 145); /* Green */
+  background-color: oklch(0.95 0.02 145);
+}
+
+.dark .apg-landmark-main {
+  background-color: oklch(0.25 0.02 145);
+}
+
+.apg-landmark-main .apg-landmark-label {
+  background-color: oklch(0.4 0.15 145);
+}
+
+/* Contentinfo (footer) */
+.apg-landmark-contentinfo {
+  padding: var(--landmark-padding);
+  border-color: oklch(0.6 0.15 280); /* Purple */
+  background-color: oklch(0.95 0.02 280);
+}
+
+.dark .apg-landmark-contentinfo {
+  background-color: oklch(0.25 0.02 280);
+}
+
+.apg-landmark-contentinfo .apg-landmark-label {
+  background-color: oklch(0.4 0.15 280);
+}
+
+/* Navigation */
+.apg-landmark-navigation {
+  padding: 0.75rem;
+  border-color: oklch(0.65 0.2 230); /* Blue */
+  background-color: oklch(0.97 0.01 230);
+}
+
+.dark .apg-landmark-navigation {
+  background-color: oklch(0.2 0.02 230);
+}
+
+.apg-landmark-navigation .apg-landmark-label {
+  background-color: oklch(0.4 0.18 230);
+}
+
+/* Region (section with label) */
+.apg-landmark-region {
+  padding: var(--landmark-padding);
+  border-color: oklch(0.65 0.15 60); /* Yellow */
+  background-color: oklch(0.97 0.02 60);
+}
+
+.dark .apg-landmark-region {
+  background-color: oklch(0.22 0.02 60);
+}
+
+.apg-landmark-region .apg-landmark-label {
+  background-color: oklch(0.4 0.12 70);
+}
+
+/* Complementary (aside) */
+.apg-landmark-complementary {
+  padding: var(--landmark-padding);
+  border-color: oklch(0.65 0.18 180); /* Teal */
+  background-color: oklch(0.97 0.02 180);
+}
+
+.dark .apg-landmark-complementary {
+  background-color: oklch(0.22 0.02 180);
+}
+
+.apg-landmark-complementary .apg-landmark-label {
+  background-color: oklch(0.4 0.15 180);
+}
+
+/* Search */
+.apg-landmark-search {
+  padding: var(--landmark-padding);
+  border-color: oklch(0.6 0.2 330); /* Pink */
+  background-color: oklch(0.97 0.02 330);
+}
+
+.dark .apg-landmark-search {
+  background-color: oklch(0.22 0.02 330);
+}
+
+.apg-landmark-search .apg-landmark-label {
+  background-color: oklch(0.4 0.18 330);
+}
+
+/* Form */
+.apg-landmark-form {
+  padding: var(--landmark-padding);
+  border-color: oklch(0.55 0.18 15); /* Red */
+  background-color: oklch(0.97 0.02 15);
+}
+
+.dark .apg-landmark-form {
+  background-color: oklch(0.22 0.02 15);
+}
+
+.apg-landmark-form .apg-landmark-label {
+  background-color: oklch(0.4 0.15 15);
+}
+
+/* Layout */
+.apg-landmark-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.apg-landmark-main-content {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--landmark-gap);
+}
+
+@media (min-width: 768px) {
+  .apg-landmark-main-content {
+    grid-template-columns: 2fr 1fr;
+  }
+
+  .apg-landmark-region {
+    grid-column: 1;
+  }
+
+  .apg-landmark-complementary {
+    grid-column: 2;
+    grid-row: 1 / 2;
+  }
+}
+
+/* Logo */
+.apg-landmark-logo {
+  font-weight: 700;
+  font-size: 1.25rem;
+  color: var(--foreground);
+}
+
+/* Navigation List */
+.apg-landmark-nav-list {
+  display: flex;
+  gap: 1rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.apg-landmark-nav-list a {
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.apg-landmark-nav-list a:hover {
+  text-decoration: underline;
+}
+
+/* Headings */
+.apg-landmark-heading {
+  margin: 0 0 0.75rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+/* Search Form */
+.apg-landmark-search {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.apg-landmark-search-label {
+  font-weight: 500;
+}
+
+.apg-landmark-search-input {
+  flex: 1;
+  min-width: 150px;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 0.375rem;
+  background-color: var(--background);
+  color: var(--foreground);
+}
+
+.apg-landmark-search-input:focus {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.apg-landmark-search-button {
+  padding: 0.5rem 1rem;
+  background-color: var(--primary);
+  color: var(--primary-foreground);
+  border: none;
+  border-radius: 0.375rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.apg-landmark-search-button:hover {
+  opacity: 0.9;
+}
+
+.apg-landmark-search-button:focus {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+/* Contact Form */
+.apg-landmark-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.apg-landmark-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.apg-landmark-form-field label {
+  font-weight: 500;
+  font-size: 0.875rem;
+}
+
+.apg-landmark-input {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 0.375rem;
+  background-color: var(--background);
+  color: var(--foreground);
+}
+
+.apg-landmark-input:focus {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.apg-landmark-submit {
+  align-self: flex-start;
+  padding: 0.5rem 1rem;
+  background-color: var(--primary);
+  color: var(--primary-foreground);
+  border: none;
+  border-radius: 0.375rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.apg-landmark-submit:hover {
+  opacity: 0.9;
+}
+
+.apg-landmark-submit:focus {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+/* Copyright */
+.apg-landmark-copyright {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--foreground);
+}
+
+/* Complementary List */
+.apg-landmark-complementary ul {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+.apg-landmark-complementary li {
+  margin-bottom: 0.25rem;
+}
+
+.apg-landmark-complementary a {
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.apg-landmark-complementary a:hover {
+  text-decoration: underline;
+}
+
+/* Region Content */
+.apg-landmark-region p {
+  margin: 0 0 1rem;
+  line-height: 1.6;
+}
+
+.apg-landmark-region code {
+  padding: 0.125rem 0.375rem;
+  background-color: var(--muted);
+  border-radius: 0.25rem;
+  font-size: 0.875em;
+}

--- a/vitest.astro.config.ts
+++ b/vitest.astro.config.ts
@@ -22,6 +22,7 @@ export default getViteConfig({
       'src/patterns/table/Table.test.astro.ts',
       'src/patterns/checkbox/Checkbox.test.astro.ts',
       'src/patterns/carousel/Carousel.test.astro.ts',
+      'src/patterns/landmarks/LandmarkDemo.test.astro.ts',
     ],
   },
 });


### PR DESCRIPTION
## Summary
- Implement the 8 ARIA landmark roles (banner, navigation, main, contentinfo, complementary, region, search, form) for React, Vue, Svelte, and Astro
- Add demo-only pages at `/patterns/landmarks/{framework}/demo/` for E2E testing with correct landmark semantics
- Include comprehensive unit tests (4 frameworks) and E2E tests (85 tests) with axe-core accessibility validation
- Add bilingual documentation (English/Japanese) with accessibility docs, testing docs, and AI guide (llm.md)

## Test plan
- [x] All 85 E2E tests pass across 4 frameworks
- [x] All unit tests pass for React, Vue, Svelte, and Astro
- [x] axe-core accessibility checks pass with no violations
- [x] Demo-only pages render correctly with proper landmark semantics
- [x] "Open demo only" links work from pattern pages
- [x] Both English and Japanese pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)