### PR TITLE
feat(i18n): add Japanese demo pages and update README status

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -22,17 +22,17 @@
 | ------------------- | ----- | --- | ------ | ----- | ---------- |
 | Accordion           | ✅    | ✅  | ✅     | ✅    | 完了       |
 | Alert               | ✅    | ✅  | ✅     | ✅    | 完了       |
-| Alert Dialog        | -     | -   | -      | -     | 予定       |
+| Alert Dialog        | ✅    | ✅  | ✅     | ✅    | 完了       |
 | Breadcrumb          | ✅    | ✅  | ✅     | ✅    | 完了       |
 | Button              | -     | -   | -      | -     | 予定       |
-| Carousel            | -     | -   | -      | -     | 予定       |
+| Carousel            | ✅    | ✅  | ✅     | ✅    | 完了       |
 | Checkbox            | ✅    | ✅  | ✅     | ✅    | 完了       |
 | Combobox            | ✅    | ✅  | ✅     | ✅    | 完了       |
 | Dialog              | ✅    | ✅  | ✅     | ✅    | 完了       |
 | Disclosure          | ✅    | ✅  | ✅     | ✅    | 完了       |
-| Feed                | -     | -   | -      | -     | 予定       |
+| Feed                | ✅    | ✅  | ✅     | ✅    | 完了       |
 | Grid                | -     | -   | -      | -     | 予定       |
-| Landmarks           | -     | -   | -      | -     | 予定       |
+| Landmarks           | ✅    | ✅  | ✅     | ✅    | 完了       |
 | Link                | ✅    | ✅  | ✅     | ✅    | 完了       |
 | Listbox             | ✅    | ✅  | ✅     | ✅    | 完了       |
 | Menu and Menubar    | -     | -   | -      | -     | 予定       |
@@ -50,7 +50,7 @@
 | Tooltip             | ✅    | ✅  | ✅     | ✅    | 完了       |
 | Tree View           | ✅    | ✅  | ✅     | ✅    | 完了       |
 | Treegrid            | -     | -   | -      | -     | 予定       |
-| Window Splitter     | -     | -   | -      | -     | 予定       |
+| Window Splitter     | ✅    | ✅  | ✅     | ✅    | 完了       |
 
 ## スタイリング
 

--- a/README.md
+++ b/README.md
@@ -22,17 +22,17 @@ Additionally, we provide styling that supports dark mode, high contrast mode, an
 | -------------------- | ----- | --- | ------ | ----- | -------- |
 | Accordion            | ✅    | ✅  | ✅     | ✅    | Complete |
 | Alert                | ✅    | ✅  | ✅     | ✅    | Complete |
-| Alert Dialog         | -     | -   | -      | -     | Planned  |
+| Alert Dialog         | ✅    | ✅  | ✅     | ✅    | Complete |
 | Breadcrumb           | ✅    | ✅  | ✅     | ✅    | Complete |
 | Button               | -     | -   | -      | -     | Planned  |
-| Carousel             | -     | -   | -      | -     | Planned  |
+| Carousel             | ✅    | ✅  | ✅     | ✅    | Complete |
 | Checkbox             | ✅    | ✅  | ✅     | ✅    | Complete |
 | Combobox             | ✅    | ✅  | ✅     | ✅    | Complete |
 | Dialog               | ✅    | ✅  | ✅     | ✅    | Complete |
 | Disclosure           | ✅    | ✅  | ✅     | ✅    | Complete |
-| Feed                 | -     | -   | -      | -     | Planned  |
+| Feed                 | ✅    | ✅  | ✅     | ✅    | Complete |
 | Grid                 | -     | -   | -      | -     | Planned  |
-| Landmarks            | -     | -   | -      | -     | Planned  |
+| Landmarks            | ✅    | ✅  | ✅     | ✅    | Complete |
 | Link                 | ✅    | ✅  | ✅     | ✅    | Complete |
 | Listbox              | ✅    | ✅  | ✅     | ✅    | Complete |
 | Menu and Menubar     | -     | -   | -      | -     | Planned  |
@@ -50,7 +50,7 @@ Additionally, we provide styling that supports dark mode, high contrast mode, an
 | Tooltip              | ✅    | ✅  | ✅     | ✅    | Complete |
 | Tree View            | ✅    | ✅  | ✅     | ✅    | Complete |
 | Treegrid             | -     | -   | -      | -     | Planned  |
-| Window Splitter      | -     | -   | -      | -     | Planned  |
+| Window Splitter      | ✅    | ✅  | ✅     | ✅    | Complete |
 
 ## Styling
 

--- a/src/pages/ja/patterns/breadcrumb/astro/demo/index.astro
+++ b/src/pages/ja/patterns/breadcrumb/astro/demo/index.astro
@@ -1,0 +1,52 @@
+---
+/**
+ * Demo-only Page: Breadcrumb (Astro)
+ *
+ * This page renders the Breadcrumb component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ *
+ * Used for:
+ * - E2E testing with correct selector isolation
+ * - Standalone demo viewing
+ */
+import '@/styles/global.css';
+import Breadcrumb from '@patterns/breadcrumb/Breadcrumb.astro';
+
+const basicItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Patterns', href: '/patterns/' },
+  { label: 'Breadcrumb' },
+];
+
+const longPathItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Products', href: '/products/' },
+  { label: 'Electronics', href: '/products/electronics/' },
+  { label: 'Computers', href: '/products/electronics/computers/' },
+  { label: 'Laptops', href: '/products/electronics/computers/laptops/' },
+  { label: 'MacBook Pro' },
+];
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Breadcrumb (Astro)</title>
+  </head>
+  <body class="p-8">
+    <h1 class="mb-6 text-2xl font-bold">Breadcrumb Demo</h1>
+
+    <div class="mb-8">
+      <h2 class="mb-3 text-lg font-medium">Basic Breadcrumb</h2>
+      <Breadcrumb items={basicItems} ariaLabel="Basic Breadcrumb" />
+    </div>
+
+    <div>
+      <h2 class="mb-3 text-lg font-medium">Long Path</h2>
+      <Breadcrumb items={longPathItems} ariaLabel="Long Path Breadcrumb" />
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/breadcrumb/react/demo/index.astro
+++ b/src/pages/ja/patterns/breadcrumb/react/demo/index.astro
@@ -1,0 +1,52 @@
+---
+/**
+ * Demo-only Page: Breadcrumb (React)
+ *
+ * This page renders the Breadcrumb component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ *
+ * Used for:
+ * - E2E testing with correct selector isolation
+ * - Standalone demo viewing
+ */
+import '@/styles/global.css';
+import Breadcrumb from '@patterns/breadcrumb/Breadcrumb';
+
+const basicItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Patterns', href: '/patterns/' },
+  { label: 'Breadcrumb' },
+];
+
+const longPathItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Products', href: '/products/' },
+  { label: 'Electronics', href: '/products/electronics/' },
+  { label: 'Computers', href: '/products/electronics/computers/' },
+  { label: 'Laptops', href: '/products/electronics/computers/laptops/' },
+  { label: 'MacBook Pro' },
+];
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Breadcrumb (React)</title>
+  </head>
+  <body class="p-8">
+    <h1 class="mb-6 text-2xl font-bold">Breadcrumb Demo</h1>
+
+    <div class="mb-8">
+      <h2 class="mb-3 text-lg font-medium">Basic Breadcrumb</h2>
+      <Breadcrumb items={basicItems} ariaLabel="Basic Breadcrumb" />
+    </div>
+
+    <div>
+      <h2 class="mb-3 text-lg font-medium">Long Path</h2>
+      <Breadcrumb items={longPathItems} ariaLabel="Long Path Breadcrumb" />
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/breadcrumb/svelte/demo/index.astro
+++ b/src/pages/ja/patterns/breadcrumb/svelte/demo/index.astro
@@ -1,0 +1,52 @@
+---
+/**
+ * Demo-only Page: Breadcrumb (Svelte)
+ *
+ * This page renders the Breadcrumb component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ *
+ * Used for:
+ * - E2E testing with correct selector isolation
+ * - Standalone demo viewing
+ */
+import '@/styles/global.css';
+import Breadcrumb from '@patterns/breadcrumb/Breadcrumb.svelte';
+
+const basicItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Patterns', href: '/patterns/' },
+  { label: 'Breadcrumb' },
+];
+
+const longPathItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Products', href: '/products/' },
+  { label: 'Electronics', href: '/products/electronics/' },
+  { label: 'Computers', href: '/products/electronics/computers/' },
+  { label: 'Laptops', href: '/products/electronics/computers/laptops/' },
+  { label: 'MacBook Pro' },
+];
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Breadcrumb (Svelte)</title>
+  </head>
+  <body class="p-8">
+    <h1 class="mb-6 text-2xl font-bold">Breadcrumb Demo</h1>
+
+    <div class="mb-8">
+      <h2 class="mb-3 text-lg font-medium">Basic Breadcrumb</h2>
+      <Breadcrumb items={basicItems} ariaLabel="Basic Breadcrumb" />
+    </div>
+
+    <div>
+      <h2 class="mb-3 text-lg font-medium">Long Path</h2>
+      <Breadcrumb items={longPathItems} ariaLabel="Long Path Breadcrumb" />
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/breadcrumb/vue/demo/index.astro
+++ b/src/pages/ja/patterns/breadcrumb/vue/demo/index.astro
@@ -1,0 +1,52 @@
+---
+/**
+ * Demo-only Page: Breadcrumb (Vue)
+ *
+ * This page renders the Breadcrumb component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ *
+ * Used for:
+ * - E2E testing with correct selector isolation
+ * - Standalone demo viewing
+ */
+import '@/styles/global.css';
+import Breadcrumb from '@patterns/breadcrumb/Breadcrumb.vue';
+
+const basicItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Patterns', href: '/patterns/' },
+  { label: 'Breadcrumb' },
+];
+
+const longPathItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Products', href: '/products/' },
+  { label: 'Electronics', href: '/products/electronics/' },
+  { label: 'Computers', href: '/products/electronics/computers/' },
+  { label: 'Laptops', href: '/products/electronics/computers/laptops/' },
+  { label: 'MacBook Pro' },
+];
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Breadcrumb (Vue)</title>
+  </head>
+  <body class="p-8">
+    <h1 class="mb-6 text-2xl font-bold">Breadcrumb Demo</h1>
+
+    <div class="mb-8">
+      <h2 class="mb-3 text-lg font-medium">Basic Breadcrumb</h2>
+      <Breadcrumb items={basicItems} ariaLabel="Basic Breadcrumb" />
+    </div>
+
+    <div>
+      <h2 class="mb-3 text-lg font-medium">Long Path</h2>
+      <Breadcrumb items={longPathItems} ariaLabel="Long Path Breadcrumb" />
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/button/astro/demo/index.astro
+++ b/src/pages/ja/patterns/button/astro/demo/index.astro
@@ -1,0 +1,44 @@
+---
+/**
+ * Demo-only Page: ToggleButton (Astro)
+ *
+ * This page renders the ToggleButton component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ *
+ * Used for:
+ * - E2E testing with correct focus management
+ * - Standalone demo viewing
+ */
+import '@/styles/global.css';
+import ToggleButton from '@patterns/button/ToggleButton.astro';
+import Icon from '@/components/ui/icon/icon.astro';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Toggle Button (Astro)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-wrap gap-4">
+      <ToggleButton>
+        <Icon name="volume-off" slot="pressed-indicator" />
+        <Icon name="volume-2" slot="unpressed-indicator" />
+        Mute
+      </ToggleButton>
+      <ToggleButton initialPressed={true}>
+        <Icon name="moon" slot="pressed-indicator" />
+        <Icon name="sun" slot="unpressed-indicator" />
+        Dark Mode
+      </ToggleButton>
+      <ToggleButton disabled>
+        <Icon name="bell-off" slot="pressed-indicator" />
+        <Icon name="bell" slot="unpressed-indicator" />
+        Notifications
+      </ToggleButton>
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/button/react/demo/index.astro
+++ b/src/pages/ja/patterns/button/react/demo/index.astro
@@ -1,0 +1,31 @@
+---
+/**
+ * Demo-only Page: ToggleButtonDemo (React)
+ *
+ * This page renders the ToggleButtonDemo components in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ *
+ * Used for:
+ * - E2E testing with correct focus management
+ * - Standalone demo viewing
+ */
+import '@/styles/global.css';
+import { MuteDemo, DarkModeDemo, NotificationsDemo } from '@patterns/button/ToggleButtonDemo';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Toggle Button (React)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-wrap gap-4">
+      <MuteDemo client:load />
+      <DarkModeDemo client:load />
+      <NotificationsDemo client:load />
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/button/svelte/demo/index.astro
+++ b/src/pages/ja/patterns/button/svelte/demo/index.astro
@@ -1,0 +1,27 @@
+---
+/**
+ * Demo-only Page: ToggleButtonDemo (Svelte)
+ *
+ * This page renders the ToggleButtonDemo component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ *
+ * Used for:
+ * - E2E testing with correct focus management
+ * - Standalone demo viewing
+ */
+import '@/styles/global.css';
+import ToggleButtonDemo from '@patterns/button/ToggleButtonDemo.svelte';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Toggle Button (Svelte)</title>
+  </head>
+  <body class="p-8">
+    <ToggleButtonDemo client:load />
+  </body>
+</html>

--- a/src/pages/ja/patterns/button/vue/demo/index.astro
+++ b/src/pages/ja/patterns/button/vue/demo/index.astro
@@ -1,0 +1,27 @@
+---
+/**
+ * Demo-only Page: ToggleButtonDemo (Vue)
+ *
+ * This page renders the ToggleButtonDemo component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ *
+ * Used for:
+ * - E2E testing with correct focus management
+ * - Standalone demo viewing
+ */
+import '@/styles/global.css';
+import ToggleButtonDemo from '@patterns/button/ToggleButtonDemo.vue';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Toggle Button (Vue)</title>
+  </head>
+  <body class="p-8">
+    <ToggleButtonDemo client:load />
+  </body>
+</html>

--- a/src/pages/ja/patterns/disclosure/astro/demo/index.astro
+++ b/src/pages/ja/patterns/disclosure/astro/demo/index.astro
@@ -1,0 +1,33 @@
+---
+/**
+ * Demo-only Page: Disclosure (Astro)
+ *
+ * This page renders the Disclosure component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import Disclosure from '@patterns/disclosure/Disclosure.astro';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Disclosure (Astro)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col gap-4">
+      <Disclosure trigger="What is a Disclosure?">
+        <p>A disclosure is a button that controls the visibility of a section of content.</p>
+      </Disclosure>
+      <Disclosure trigger="This section is open by default" defaultExpanded={true}>
+        <p>This content is visible when the page loads.</p>
+      </Disclosure>
+      <Disclosure trigger="This disclosure is disabled" disabled={true}>
+        <p>This content cannot be revealed because the disclosure is disabled.</p>
+      </Disclosure>
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/disclosure/react/demo/index.astro
+++ b/src/pages/ja/patterns/disclosure/react/demo/index.astro
@@ -1,0 +1,33 @@
+---
+/**
+ * Demo-only Page: Disclosure (React)
+ *
+ * This page renders the Disclosure component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import Disclosure from '@patterns/disclosure/Disclosure';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Disclosure (React)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col gap-4">
+      <Disclosure client:load trigger="What is a Disclosure?">
+        <p>A disclosure is a button that controls the visibility of a section of content.</p>
+      </Disclosure>
+      <Disclosure client:load trigger="This section is open by default" defaultExpanded={true}>
+        <p>This content is visible when the page loads.</p>
+      </Disclosure>
+      <Disclosure client:load trigger="This disclosure is disabled" disabled={true}>
+        <p>This content cannot be revealed because the disclosure is disabled.</p>
+      </Disclosure>
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/disclosure/svelte/demo/index.astro
+++ b/src/pages/ja/patterns/disclosure/svelte/demo/index.astro
@@ -1,0 +1,33 @@
+---
+/**
+ * Demo-only Page: Disclosure (Svelte)
+ *
+ * This page renders the Disclosure component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import Disclosure from '@patterns/disclosure/Disclosure.svelte';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Disclosure (Svelte)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col gap-4">
+      <Disclosure client:load trigger="What is a Disclosure?">
+        <p>A disclosure is a button that controls the visibility of a section of content.</p>
+      </Disclosure>
+      <Disclosure client:load trigger="This section is open by default" defaultExpanded={true}>
+        <p>This content is visible when the page loads.</p>
+      </Disclosure>
+      <Disclosure client:load trigger="This disclosure is disabled" disabled={true}>
+        <p>This content cannot be revealed because the disclosure is disabled.</p>
+      </Disclosure>
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/disclosure/vue/demo/index.astro
+++ b/src/pages/ja/patterns/disclosure/vue/demo/index.astro
@@ -1,0 +1,33 @@
+---
+/**
+ * Demo-only Page: Disclosure (Vue)
+ *
+ * This page renders the Disclosure component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import Disclosure from '@patterns/disclosure/Disclosure.vue';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Disclosure (Vue)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col gap-4">
+      <Disclosure client:load trigger="What is a Disclosure?">
+        <p>A disclosure is a button that controls the visibility of a section of content.</p>
+      </Disclosure>
+      <Disclosure client:load trigger="This section is open by default" default-expanded>
+        <p>This content is visible when the page loads.</p>
+      </Disclosure>
+      <Disclosure client:load trigger="This disclosure is disabled" disabled>
+        <p>This content cannot be revealed because the disclosure is disabled.</p>
+      </Disclosure>
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/feed/astro/demo/index.astro
+++ b/src/pages/ja/patterns/feed/astro/demo/index.astro
@@ -1,0 +1,27 @@
+---
+/**
+ * Demo-only Page: FeedDemo (Astro)
+ *
+ * This page renders the FeedDemo component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ *
+ * Used for:
+ * - E2E testing with correct feed structure
+ * - Standalone demo viewing
+ */
+import '@/styles/global.css';
+import FeedDemo from '@patterns/feed/FeedDemo.astro';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Feed (Astro)</title>
+  </head>
+  <body>
+    <FeedDemo />
+  </body>
+</html>

--- a/src/pages/ja/patterns/feed/react/demo/index.astro
+++ b/src/pages/ja/patterns/feed/react/demo/index.astro
@@ -1,0 +1,27 @@
+---
+/**
+ * Demo-only Page: FeedDemo (React)
+ *
+ * This page renders the FeedDemo component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ *
+ * Used for:
+ * - E2E testing with correct feed structure
+ * - Standalone demo viewing
+ */
+import '@/styles/global.css';
+import FeedDemo from '@patterns/feed/FeedDemo.tsx';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Feed (React)</title>
+  </head>
+  <body>
+    <FeedDemo client:load />
+  </body>
+</html>

--- a/src/pages/ja/patterns/feed/svelte/demo/index.astro
+++ b/src/pages/ja/patterns/feed/svelte/demo/index.astro
@@ -1,0 +1,27 @@
+---
+/**
+ * Demo-only Page: FeedDemo (Svelte)
+ *
+ * This page renders the FeedDemo component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ *
+ * Used for:
+ * - E2E testing with correct feed structure
+ * - Standalone demo viewing
+ */
+import '@/styles/global.css';
+import FeedDemo from '@patterns/feed/FeedDemo.svelte';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Feed (Svelte)</title>
+  </head>
+  <body>
+    <FeedDemo client:load />
+  </body>
+</html>

--- a/src/pages/ja/patterns/feed/vue/demo/index.astro
+++ b/src/pages/ja/patterns/feed/vue/demo/index.astro
@@ -1,0 +1,27 @@
+---
+/**
+ * Demo-only Page: FeedDemo (Vue)
+ *
+ * This page renders the FeedDemo component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ *
+ * Used for:
+ * - E2E testing with correct feed structure
+ * - Standalone demo viewing
+ */
+import '@/styles/global.css';
+import FeedDemo from '@patterns/feed/FeedDemo.vue';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Feed (Vue)</title>
+  </head>
+  <body>
+    <FeedDemo client:load />
+  </body>
+</html>

--- a/src/pages/ja/patterns/landmarks/astro/demo/index.astro
+++ b/src/pages/ja/patterns/landmarks/astro/demo/index.astro
@@ -1,0 +1,28 @@
+---
+/**
+ * Demo-only Page: LandmarkDemo (Astro)
+ *
+ * This page renders the LandmarkDemo component in isolation without
+ * the site layout. This ensures proper landmark semantics are preserved
+ * (e.g., <header> retains its implicit banner role).
+ *
+ * Used for:
+ * - E2E testing with correct landmark structure
+ * - Standalone demo viewing
+ */
+import '@/styles/global.css';
+import LandmarkDemo from '@patterns/landmarks/LandmarkDemo.astro';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Landmarks (Astro)</title>
+  </head>
+  <body>
+    <LandmarkDemo showLabels={true} />
+  </body>
+</html>

--- a/src/pages/ja/patterns/landmarks/react/demo/index.astro
+++ b/src/pages/ja/patterns/landmarks/react/demo/index.astro
@@ -1,0 +1,28 @@
+---
+/**
+ * Demo-only Page: LandmarkDemo (React)
+ *
+ * This page renders the LandmarkDemo component in isolation without
+ * the site layout. This ensures proper landmark semantics are preserved
+ * (e.g., <header> retains its implicit banner role).
+ *
+ * Used for:
+ * - E2E testing with correct landmark structure
+ * - Standalone demo viewing
+ */
+import '@/styles/global.css';
+import LandmarkDemo from '@patterns/landmarks/LandmarkDemo.tsx';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Landmarks (React)</title>
+  </head>
+  <body>
+    <LandmarkDemo client:load showLabels={true} />
+  </body>
+</html>

--- a/src/pages/ja/patterns/landmarks/svelte/demo/index.astro
+++ b/src/pages/ja/patterns/landmarks/svelte/demo/index.astro
@@ -1,0 +1,29 @@
+---
+/**
+ * Demo-only Page: LandmarkDemo (Svelte)
+ *
+ * This page renders the LandmarkDemo component in isolation without
+ * the site layout. This ensures proper landmark semantics are preserved
+ * (e.g., <header> retains its implicit banner role).
+ *
+ * Used for:
+ * - E2E testing with correct landmark structure
+ * - Standalone demo viewing
+ */
+import '@/styles/global.css';
+import LandmarkDemo from '@patterns/landmarks/LandmarkDemo.svelte';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Landmarks (Svelte)</title>
+  </head>
+  <body>
+    <!-- No client:load needed - LandmarkDemo is a static component -->
+    <LandmarkDemo showLabels={true} />
+  </body>
+</html>

--- a/src/pages/ja/patterns/landmarks/vue/demo/index.astro
+++ b/src/pages/ja/patterns/landmarks/vue/demo/index.astro
@@ -1,0 +1,28 @@
+---
+/**
+ * Demo-only Page: LandmarkDemo (Vue)
+ *
+ * This page renders the LandmarkDemo component in isolation without
+ * the site layout. This ensures proper landmark semantics are preserved
+ * (e.g., <header> retains its implicit banner role).
+ *
+ * Used for:
+ * - E2E testing with correct landmark structure
+ * - Standalone demo viewing
+ */
+import '@/styles/global.css';
+import LandmarkDemo from '@patterns/landmarks/LandmarkDemo.vue';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Landmarks (Vue)</title>
+  </head>
+  <body>
+    <LandmarkDemo client:load showLabels={true} />
+  </body>
+</html>

--- a/src/pages/ja/patterns/link/astro/demo/index.astro
+++ b/src/pages/ja/patterns/link/astro/demo/index.astro
@@ -1,0 +1,28 @@
+---
+/**
+ * Demo-only Page: Link (Astro)
+ *
+ * This page renders the Link component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import Link from '@patterns/link/Link.astro';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Link (Astro)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-4">
+      <Link href="https://www.w3.org/WAI/ARIA/apg/"> WAI-ARIA APG Documentation </Link>
+      <Link href="https://example.com" target="_blank"> External Link (opens in new tab) </Link>
+      <Link href="#"> Link with hash href </Link>
+      <Link href="#" disabled> Disabled Link </Link>
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/link/react/demo/index.astro
+++ b/src/pages/ja/patterns/link/react/demo/index.astro
@@ -1,0 +1,30 @@
+---
+/**
+ * Demo-only Page: Link (React)
+ *
+ * This page renders the Link component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import { Link } from '@patterns/link/Link';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Link (React)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-4">
+      <Link client:load href="https://www.w3.org/WAI/ARIA/apg/"> WAI-ARIA APG Documentation </Link>
+      <Link client:load href="https://example.com" target="_blank">
+        External Link (opens in new tab)
+      </Link>
+      <Link client:load href="#"> Link with hash href </Link>
+      <Link client:load href="#" disabled> Disabled Link </Link>
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/link/svelte/demo/index.astro
+++ b/src/pages/ja/patterns/link/svelte/demo/index.astro
@@ -1,0 +1,30 @@
+---
+/**
+ * Demo-only Page: Link (Svelte)
+ *
+ * This page renders the Link component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import Link from '@patterns/link/Link.svelte';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Link (Svelte)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-4">
+      <Link client:load href="https://www.w3.org/WAI/ARIA/apg/"> WAI-ARIA APG Documentation </Link>
+      <Link client:load href="https://example.com" target="_blank">
+        External Link (opens in new tab)
+      </Link>
+      <Link client:load href="#"> Link with hash href </Link>
+      <Link client:load href="#" disabled> Disabled Link </Link>
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/link/vue/demo/index.astro
+++ b/src/pages/ja/patterns/link/vue/demo/index.astro
@@ -1,0 +1,30 @@
+---
+/**
+ * Demo-only Page: Link (Vue)
+ *
+ * This page renders the Link component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import Link from '@patterns/link/Link.vue';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Link (Vue)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-4">
+      <Link client:load href="https://www.w3.org/WAI/ARIA/apg/"> WAI-ARIA APG Documentation </Link>
+      <Link client:load href="https://example.com" target="_blank">
+        External Link (opens in new tab)
+      </Link>
+      <Link client:load href="#"> Link with hash href </Link>
+      <Link client:load href="#" disabled> Disabled Link </Link>
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/switch/astro/demo/index.astro
+++ b/src/pages/ja/patterns/switch/astro/demo/index.astro
@@ -1,0 +1,27 @@
+---
+/**
+ * Demo-only Page: Switch (Astro)
+ *
+ * This page renders the Switch component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import Switch from '@patterns/switch/Switch.astro';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Switch (Astro)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-4">
+      <Switch>Wi-Fi</Switch>
+      <Switch initialChecked={true}>Bluetooth</Switch>
+      <Switch disabled>Airplane Mode (disabled)</Switch>
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/switch/react/demo/index.astro
+++ b/src/pages/ja/patterns/switch/react/demo/index.astro
@@ -1,0 +1,27 @@
+---
+/**
+ * Demo-only Page: Switch (React)
+ *
+ * This page renders the Switch component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import { Switch } from '@patterns/switch/Switch';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Switch (React)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-4">
+      <Switch client:load>Wi-Fi</Switch>
+      <Switch client:load initialChecked={true}>Bluetooth</Switch>
+      <Switch client:load disabled>Airplane Mode (disabled)</Switch>
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/switch/svelte/demo/index.astro
+++ b/src/pages/ja/patterns/switch/svelte/demo/index.astro
@@ -1,0 +1,27 @@
+---
+/**
+ * Demo-only Page: Switch (Svelte)
+ *
+ * This page renders the Switch component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import Switch from '@patterns/switch/Switch.svelte';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Switch (Svelte)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-4">
+      <Switch client:load>Wi-Fi</Switch>
+      <Switch client:load initialChecked={true}>Bluetooth</Switch>
+      <Switch client:load disabled>Airplane Mode (disabled)</Switch>
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/switch/vue/demo/index.astro
+++ b/src/pages/ja/patterns/switch/vue/demo/index.astro
@@ -1,0 +1,27 @@
+---
+/**
+ * Demo-only Page: Switch (Vue)
+ *
+ * This page renders the Switch component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import Switch from '@patterns/switch/Switch.vue';
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: Switch (Vue)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-4">
+      <Switch client:load>Wi-Fi</Switch>
+      <Switch client:load initial-checked>Bluetooth</Switch>
+      <Switch client:load disabled>Airplane Mode (disabled)</Switch>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add Japanese demo pages for 7 patterns across all 4 frameworks (28 pages total)
  - button, switch, disclosure, link, breadcrumb, feed, landmarks
- Update README.md and README.ja.md component status to reflect current implementation

## Changes

### Japanese Demo Pages
Japanese pattern pages link to demo pages, so users viewing Japanese documentation can now access standalone demo pages with `lang="ja"` set correctly.

| Pattern | React | Vue | Svelte | Astro |
|---------|-------|-----|--------|-------|
| button | ✅ | ✅ | ✅ | ✅ |
| switch | ✅ | ✅ | ✅ | ✅ |
| disclosure | ✅ | ✅ | ✅ | ✅ |
| link | ✅ | ✅ | ✅ | ✅ |
| breadcrumb | ✅ | ✅ | ✅ | ✅ |
| feed | ✅ | ✅ | ✅ | ✅ |
| landmarks | ✅ | ✅ | ✅ | ✅ |

### README Updates
Updated component status for patterns that were marked as "Planned" but are now implemented:
- Alert Dialog: Planned → Complete
- Carousel: Planned → Complete
- Feed: Planned → Complete
- Landmarks: Planned → Complete
- Window Splitter: Planned → Complete

## Test plan
- [x] Build passes (`npm run build`)
- [ ] Verify Japanese demo pages are accessible at `/ja/patterns/{pattern}/{framework}/demo/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)