### PR TITLE
fix: カルーセルの操作ボタンがモバイルで1行に収まるように改善

### DIFF
--- a/src/styles/patterns/carousel.css
+++ b/src/styles/patterns/carousel.css
@@ -430,22 +430,31 @@
   }
 
   .apg-carousel-controls {
-    flex-wrap: wrap;
-    gap: 0.75rem;
+    gap: 0.5rem;
     padding: 0.5rem;
   }
 
+  /* Reduce button sizes for mobile */
+  .apg-carousel-play-pause,
+  .apg-carousel-prev,
+  .apg-carousel-next {
+    width: 32px;
+    height: 32px;
+  }
+
+  /* Reduce tab size for mobile */
+  .apg-carousel-tab {
+    width: 28px;
+    height: 28px;
+  }
+
+  .apg-carousel-tab-indicator {
+    width: 8px;
+    height: 8px;
+  }
+
+  /* Tighter spacing for tablist */
   .apg-carousel-tablist {
-    order: 2;
-    width: 100%;
-    justify-content: center;
-  }
-
-  .apg-carousel-play-pause {
-    order: 1;
-  }
-
-  .apg-carousel-nav {
-    order: 3;
+    gap: 0.25rem;
   }
 }


### PR DESCRIPTION
モバイル表示時にカルーセルの操作ボタン（再生/停止、スライドインジケーター、前へ/次へ）が複数行に折り返されていた問題を修正。

変更内容:
- flex-wrap: wrapを削除し、ボタンを1行に配置
- ボタンとインジケーターのサイズを縮小（36px→32px、ドット10px→8px）
- 間隔を調整（gap: 0.75rem→0.5rem、tablist gap: 0.5rem→0.25rem）