### PR TITLE
Add e2e tests for Combobox component

### DIFF
--- a/e2e/combobox.spec.ts
+++ b/e2e/combobox.spec.ts
@@ -1,0 +1,491 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+/**
+ * E2E Tests for Combobox Pattern
+ *
+ * An editable combobox with list autocomplete. Users can type to filter
+ * options or select from a popup listbox using keyboard or mouse.
+ *
+ * APG Reference: https://www.w3.org/WAI/ARIA/apg/patterns/combobox/
+ */
+
+const frameworks = ['react', 'vue', 'svelte', 'astro'] as const;
+
+// Helper to get combobox elements
+const getComboboxes = (page: import('@playwright/test').Page) => {
+  return page.locator('[role="combobox"]');
+};
+
+// Helper to get the first non-disabled combobox
+const getFirstCombobox = (page: import('@playwright/test').Page) => {
+  return page.locator('[role="combobox"]:not([disabled])').first();
+};
+
+for (const framework of frameworks) {
+  test.describe(`Combobox (${framework})`, () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(`patterns/combobox/${framework}/demo/`);
+      await page.waitForLoadState('networkidle');
+    });
+
+    // High Priority: ARIA Structure
+    test.describe('APG: ARIA Structure', () => {
+      test('has role="combobox" on input', async ({ page }) => {
+        const comboboxes = getComboboxes(page);
+        const count = await comboboxes.count();
+        expect(count).toBeGreaterThan(0);
+
+        for (let i = 0; i < count; i++) {
+          await expect(comboboxes.nth(i)).toHaveAttribute('role', 'combobox');
+        }
+      });
+
+      test('has aria-controls pointing to listbox', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        const ariaControls = await combobox.getAttribute('aria-controls');
+        expect(ariaControls).toBeTruthy();
+
+        const listbox = page.locator(`#${ariaControls}`);
+        await expect(listbox).toHaveAttribute('role', 'listbox');
+      });
+
+      test('has aria-expanded attribute', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        const ariaExpanded = await combobox.getAttribute('aria-expanded');
+        expect(['true', 'false']).toContain(ariaExpanded);
+      });
+
+      test('has aria-autocomplete attribute', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        const ariaAutocomplete = await combobox.getAttribute('aria-autocomplete');
+        expect(['none', 'list', 'both', 'inline']).toContain(ariaAutocomplete);
+      });
+
+      test('has accessible name via aria-labelledby', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        const ariaLabelledby = await combobox.getAttribute('aria-labelledby');
+        expect(ariaLabelledby).toBeTruthy();
+
+        const label = page.locator(`#${ariaLabelledby}`);
+        const labelText = await label.textContent();
+        expect(labelText?.trim().length).toBeGreaterThan(0);
+      });
+
+      test('listbox has role="listbox"', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        const ariaControls = await combobox.getAttribute('aria-controls');
+        const listbox = page.locator(`#${ariaControls}`);
+        await expect(listbox).toHaveAttribute('role', 'listbox');
+      });
+
+      test('options have role="option"', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        await combobox.focus();
+
+        const ariaControls = await combobox.getAttribute('aria-controls');
+        const options = page.locator(`#${ariaControls} [role="option"]`);
+        const count = await options.count();
+        expect(count).toBeGreaterThan(0);
+      });
+    });
+
+    // High Priority: Keyboard Interaction (Popup Closed)
+    test.describe('APG: Keyboard Interaction (Popup Closed)', () => {
+      test('ArrowDown opens popup and focuses first option', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        await combobox.click();
+        // Close popup first if open
+        await page.keyboard.press('Escape');
+        await expect(combobox).toHaveAttribute('aria-expanded', 'false');
+
+        await page.keyboard.press('ArrowDown');
+        await expect(combobox).toHaveAttribute('aria-expanded', 'true');
+
+        const activeDescendant = await combobox.getAttribute('aria-activedescendant');
+        expect(activeDescendant).toBeTruthy();
+      });
+
+      test('ArrowUp opens popup and focuses last option', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        await combobox.click();
+        // Close popup first if open
+        await page.keyboard.press('Escape');
+        await expect(combobox).toHaveAttribute('aria-expanded', 'false');
+
+        await page.keyboard.press('ArrowUp');
+        await expect(combobox).toHaveAttribute('aria-expanded', 'true');
+
+        const activeDescendant = await combobox.getAttribute('aria-activedescendant');
+        expect(activeDescendant).toBeTruthy();
+      });
+
+      test('Alt+ArrowDown opens popup without focusing option', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        await combobox.click();
+        // Close popup first if open
+        await page.keyboard.press('Escape');
+        await expect(combobox).toHaveAttribute('aria-expanded', 'false');
+
+        await page.keyboard.press('Alt+ArrowDown');
+        await expect(combobox).toHaveAttribute('aria-expanded', 'true');
+
+        // Should not have active descendant
+        const activeDescendant = await combobox.getAttribute('aria-activedescendant');
+        expect(activeDescendant).toBeFalsy();
+      });
+
+      test('Typing opens popup and filters options', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        await combobox.click();
+        // Close popup first if open
+        await page.keyboard.press('Escape');
+        await expect(combobox).toHaveAttribute('aria-expanded', 'false');
+
+        await page.keyboard.type('App');
+        await expect(combobox).toHaveAttribute('aria-expanded', 'true');
+
+        // Should have filtered options
+        const ariaControls = await combobox.getAttribute('aria-controls');
+        const visibleOptions = page.locator(`#${ariaControls} [role="option"]:not([hidden])`);
+        const count = await visibleOptions.count();
+        expect(count).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    // High Priority: Keyboard Interaction (Popup Open)
+    test.describe('APG: Keyboard Interaction (Popup Open)', () => {
+      test('ArrowDown moves to next option (no wrap)', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        await combobox.focus();
+        await page.keyboard.press('ArrowDown'); // Open and focus first
+
+        const firstActiveDescendant = await combobox.getAttribute('aria-activedescendant');
+        await page.keyboard.press('ArrowDown');
+        const secondActiveDescendant = await combobox.getAttribute('aria-activedescendant');
+
+        expect(secondActiveDescendant).not.toBe(firstActiveDescendant);
+      });
+
+      test('ArrowUp moves to previous option (no wrap)', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        await combobox.focus();
+        await page.keyboard.press('ArrowDown'); // Open and focus first
+        await page.keyboard.press('ArrowDown'); // Move to second
+
+        const secondActiveDescendant = await combobox.getAttribute('aria-activedescendant');
+        await page.keyboard.press('ArrowUp');
+        const firstActiveDescendant = await combobox.getAttribute('aria-activedescendant');
+
+        expect(firstActiveDescendant).not.toBe(secondActiveDescendant);
+      });
+
+      test('Home moves to first option', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        await combobox.focus();
+        await page.keyboard.press('ArrowUp'); // Open and focus last
+
+        await page.keyboard.press('Home');
+        const activeDescendant = await combobox.getAttribute('aria-activedescendant');
+        expect(activeDescendant).toBeTruthy();
+
+        // Verify it's pointing to first option
+        const ariaControls = await combobox.getAttribute('aria-controls');
+        const firstOption = page.locator(`#${ariaControls} [role="option"]:not([hidden])`).first();
+        const firstOptionId = await firstOption.getAttribute('id');
+        expect(activeDescendant).toBe(firstOptionId);
+      });
+
+      test('End moves to last option', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        await combobox.focus();
+        await page.keyboard.press('ArrowDown'); // Open and focus first
+
+        await page.keyboard.press('End');
+        const activeDescendant = await combobox.getAttribute('aria-activedescendant');
+        expect(activeDescendant).toBeTruthy();
+
+        // Verify it's pointing to last option
+        const ariaControls = await combobox.getAttribute('aria-controls');
+        const lastOption = page.locator(`#${ariaControls} [role="option"]:not([hidden])`).last();
+        const lastOptionId = await lastOption.getAttribute('id');
+        expect(activeDescendant).toBe(lastOptionId);
+      });
+
+      test('Enter selects focused option and closes popup', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        await combobox.focus();
+        await page.keyboard.press('ArrowDown'); // Open and focus first
+
+        const activeDescendant = await combobox.getAttribute('aria-activedescendant');
+        const activeOption = page.locator(`#${activeDescendant}`);
+        const optionText = await activeOption.textContent();
+
+        await page.keyboard.press('Enter');
+
+        await expect(combobox).toHaveAttribute('aria-expanded', 'false');
+        await expect(combobox).toHaveValue(optionText?.trim() || '');
+      });
+
+      test('Escape closes popup and restores value', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        await combobox.focus();
+        const originalValue = await combobox.inputValue();
+
+        await page.keyboard.press('ArrowDown'); // Open popup
+        await expect(combobox).toHaveAttribute('aria-expanded', 'true');
+
+        await page.keyboard.type('xxx'); // Change value
+        await page.keyboard.press('Escape');
+
+        await expect(combobox).toHaveAttribute('aria-expanded', 'false');
+        await expect(combobox).toHaveValue(originalValue);
+      });
+
+      test('Alt+ArrowUp selects focused option and closes popup', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        await combobox.focus();
+        await page.keyboard.press('ArrowDown'); // Open and focus first
+        await page.keyboard.press('ArrowDown'); // Move to second
+
+        const activeDescendant = await combobox.getAttribute('aria-activedescendant');
+        const activeOption = page.locator(`#${activeDescendant}`);
+        const optionText = await activeOption.textContent();
+
+        await page.keyboard.press('Alt+ArrowUp');
+
+        await expect(combobox).toHaveAttribute('aria-expanded', 'false');
+        await expect(combobox).toHaveValue(optionText?.trim() || '');
+      });
+
+      test('Tab closes popup without selection change', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        await combobox.focus();
+        await page.keyboard.press('ArrowDown'); // Open popup
+        await expect(combobox).toHaveAttribute('aria-expanded', 'true');
+
+        await page.keyboard.press('Tab');
+        await expect(combobox).toHaveAttribute('aria-expanded', 'false');
+      });
+    });
+
+    // High Priority: Focus Management
+    test.describe('APG: Focus Management', () => {
+      test('DOM focus stays on input during navigation', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        await combobox.focus();
+        await page.keyboard.press('ArrowDown'); // Open and focus first
+        await page.keyboard.press('ArrowDown'); // Move to next
+
+        // DOM focus should still be on combobox
+        const focusedElement = page.locator(':focus');
+        await expect(focusedElement).toHaveAttribute('role', 'combobox');
+      });
+
+      test('aria-activedescendant updates on navigation', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        await combobox.focus();
+        await page.keyboard.press('ArrowDown'); // Open and focus first
+
+        const firstActiveDescendant = await combobox.getAttribute('aria-activedescendant');
+        expect(firstActiveDescendant).toBeTruthy();
+
+        await page.keyboard.press('ArrowDown');
+        const secondActiveDescendant = await combobox.getAttribute('aria-activedescendant');
+        expect(secondActiveDescendant).toBeTruthy();
+        expect(secondActiveDescendant).not.toBe(firstActiveDescendant);
+      });
+
+      test('aria-activedescendant cleared when popup closes', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        await combobox.focus();
+        await page.keyboard.press('ArrowDown'); // Open and focus first
+        await page.keyboard.press('Escape');
+
+        const activeDescendant = await combobox.getAttribute('aria-activedescendant');
+        expect(activeDescendant).toBeFalsy();
+      });
+
+      test('navigation skips disabled options', async ({ page }) => {
+        // Use the combobox with disabled options (third one)
+        const comboboxes = page.locator('[role="combobox"]:not([disabled])');
+        const combobox = comboboxes.nth(2); // Country combobox with disabled options
+        await combobox.focus();
+        await page.keyboard.press('ArrowDown'); // Open and focus first
+
+        // Navigate through options and collect active descendant IDs
+        const activeIds: string[] = [];
+        for (let i = 0; i < 10; i++) {
+          const activeDescendant = await combobox.getAttribute('aria-activedescendant');
+          if (activeDescendant && !activeIds.includes(activeDescendant)) {
+            activeIds.push(activeDescendant);
+          }
+          await page.keyboard.press('ArrowDown');
+        }
+
+        // Check that none of the focused options are disabled
+        for (const id of activeIds) {
+          const option = page.locator(`#${id}`);
+          const ariaDisabled = await option.getAttribute('aria-disabled');
+          expect(ariaDisabled).not.toBe('true');
+        }
+      });
+    });
+
+    // Medium Priority: Mouse Interaction
+    test.describe('Mouse Interaction', () => {
+      test('clicking option selects it and closes popup', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        await combobox.focus();
+        await expect(combobox).toHaveAttribute('aria-expanded', 'true');
+
+        const ariaControls = await combobox.getAttribute('aria-controls');
+        const secondOption = page.locator(`#${ariaControls} [role="option"]:not([hidden])`).nth(1);
+        const optionText = await secondOption.textContent();
+
+        await secondOption.click();
+
+        await expect(combobox).toHaveAttribute('aria-expanded', 'false');
+        await expect(combobox).toHaveValue(optionText?.trim() || '');
+      });
+
+      test('hovering option updates aria-activedescendant', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        await combobox.focus();
+        await expect(combobox).toHaveAttribute('aria-expanded', 'true');
+
+        const ariaControls = await combobox.getAttribute('aria-controls');
+        const thirdOption = page.locator(`#${ariaControls} [role="option"]:not([hidden])`).nth(2);
+        const thirdOptionId = await thirdOption.getAttribute('id');
+
+        await thirdOption.hover();
+
+        const activeDescendant = await combobox.getAttribute('aria-activedescendant');
+        expect(activeDescendant).toBe(thirdOptionId);
+      });
+
+      test('clicking disabled option does not select', async ({ page }) => {
+        // Use the combobox with disabled options (third one)
+        const comboboxes = page.locator('[role="combobox"]:not([disabled])');
+        const combobox = comboboxes.nth(2); // Country combobox with disabled options
+        await combobox.focus();
+        await expect(combobox).toHaveAttribute('aria-expanded', 'true');
+
+        const originalValue = await combobox.inputValue();
+        const ariaControls = await combobox.getAttribute('aria-controls');
+        const disabledOption = page
+          .locator(`#${ariaControls} [role="option"][aria-disabled="true"]`)
+          .first();
+
+        if ((await disabledOption.count()) > 0) {
+          await disabledOption.click({ force: true });
+          await expect(combobox).toHaveAttribute('aria-expanded', 'true');
+          await expect(combobox).toHaveValue(originalValue);
+        }
+      });
+
+      test('clicking outside closes popup', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        await combobox.focus();
+        await expect(combobox).toHaveAttribute('aria-expanded', 'true');
+
+        await page.click('body', { position: { x: 10, y: 10 } });
+        await expect(combobox).toHaveAttribute('aria-expanded', 'false');
+      });
+    });
+
+    // Disabled State
+    test.describe('Disabled State', () => {
+      test('disabled combobox has disabled attribute', async ({ page }) => {
+        const disabledCombobox = page.locator('[role="combobox"][disabled]');
+
+        if ((await disabledCombobox.count()) > 0) {
+          await expect(disabledCombobox.first()).toBeDisabled();
+        }
+      });
+
+      test('disabled combobox does not open on focus', async ({ page }) => {
+        const disabledCombobox = page.locator('[role="combobox"][disabled]');
+
+        if ((await disabledCombobox.count()) > 0) {
+          await disabledCombobox
+            .first()
+            .focus({ timeout: 1000 })
+            .catch(() => {});
+          await expect(disabledCombobox.first()).toHaveAttribute('aria-expanded', 'false');
+        }
+      });
+    });
+
+    // Medium Priority: Accessibility
+    test.describe('Accessibility', () => {
+      test('has no axe-core violations', async ({ page }) => {
+        const combobox = getFirstCombobox(page);
+        await combobox.waitFor();
+
+        const accessibilityScanResults = await new AxeBuilder({ page })
+          .include('.apg-combobox')
+          .analyze();
+
+        expect(accessibilityScanResults.violations).toEqual([]);
+      });
+    });
+  });
+}
+
+// Cross-framework consistency tests
+test.describe('Combobox - Cross-framework Consistency', () => {
+  test('all frameworks have combobox elements', async ({ page }) => {
+    for (const framework of frameworks) {
+      await page.goto(`patterns/combobox/${framework}/demo/`);
+      await page.waitForLoadState('networkidle');
+
+      const comboboxes = page.locator('[role="combobox"]');
+      const count = await comboboxes.count();
+      expect(count).toBeGreaterThan(0);
+    }
+  });
+
+  test('all frameworks select correctly on click', async ({ page }) => {
+    for (const framework of frameworks) {
+      await page.goto(`patterns/combobox/${framework}/demo/`);
+      await page.waitForLoadState('networkidle');
+
+      const combobox = page.locator('[role="combobox"]:not([disabled])').first();
+      await combobox.focus();
+
+      const ariaControls = await combobox.getAttribute('aria-controls');
+      const secondOption = page.locator(`#${ariaControls} [role="option"]:not([hidden])`).nth(1);
+      const optionText = await secondOption.textContent();
+
+      await secondOption.click();
+
+      await expect(combobox).toHaveValue(optionText?.trim() || '');
+    }
+  });
+
+  test('all frameworks have consistent ARIA structure', async ({ page }) => {
+    const ariaStructures: Record<string, unknown[]> = {};
+
+    for (const framework of frameworks) {
+      await page.goto(`patterns/combobox/${framework}/demo/`);
+      await page.waitForLoadState('networkidle');
+
+      ariaStructures[framework] = await page.evaluate(() => {
+        const comboboxes = document.querySelectorAll('[role="combobox"]');
+        return Array.from(comboboxes).map((combobox) => ({
+          hasAriaControls: combobox.hasAttribute('aria-controls'),
+          hasAriaExpanded: combobox.hasAttribute('aria-expanded'),
+          hasAriaAutocomplete: combobox.hasAttribute('aria-autocomplete'),
+          hasAriaLabelledby: combobox.hasAttribute('aria-labelledby'),
+        }));
+      });
+    }
+
+    // All frameworks should have the same structure
+    const reactStructure = ariaStructures['react'];
+    for (const framework of frameworks) {
+      expect(ariaStructures[framework]).toEqual(reactStructure);
+    }
+  });
+});

--- a/src/pages/ja/patterns/combobox/astro/demo/index.astro
+++ b/src/pages/ja/patterns/combobox/astro/demo/index.astro
@@ -1,0 +1,64 @@
+---
+/**
+ * Demo-only Page: Combobox (Astro) - Japanese
+ *
+ * This page renders the Combobox component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import Combobox from '@patterns/combobox/Combobox.astro';
+
+const fruitOptions = [
+  { id: 'apple', label: 'りんご' },
+  { id: 'banana', label: 'バナナ' },
+  { id: 'cherry', label: 'さくらんぼ' },
+  { id: 'date', label: 'デーツ' },
+  { id: 'elderberry', label: 'エルダーベリー' },
+  { id: 'fig', label: 'いちじく' },
+  { id: 'grape', label: 'ぶどう' },
+];
+
+const countryOptions = [
+  { id: 'jp', label: '日本' },
+  { id: 'us', label: 'アメリカ' },
+  { id: 'uk', label: 'イギリス' },
+  { id: 'de', label: 'ドイツ', disabled: true },
+  { id: 'fr', label: 'フランス' },
+  { id: 'it', label: 'イタリア' },
+  { id: 'es', label: 'スペイン', disabled: true },
+  { id: 'au', label: 'オーストラリア' },
+];
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: コンボボックス (Astro)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-6">
+      <Combobox options={fruitOptions} label="お気に入りのフルーツ" placeholder="検索..." />
+      <Combobox options={fruitOptions} label="デフォルト値あり" defaultSelectedOptionId="cherry" />
+      <Combobox
+        options={countryOptions}
+        label="国（無効なオプションあり）"
+        placeholder="国を選択..."
+      />
+      <Combobox
+        options={fruitOptions}
+        label="フィルタなし (autocomplete='none')"
+        autocomplete="none"
+        placeholder="すべてのオプションを表示..."
+      />
+      <Combobox
+        options={fruitOptions}
+        label="無効なコンボボックス"
+        disabled
+        placeholder="操作不可"
+      />
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/combobox/astro/index.astro
+++ b/src/pages/ja/patterns/combobox/astro/index.astro
@@ -108,6 +108,9 @@ const countryOptions = [
         </div>
       </div>
     </div>
+    <p class="text-muted-foreground mt-2 text-sm">
+      <a href="./demo/" class="text-primary hover:underline">デモのみを開く →</a>
+    </p>
   </section>
 
   <!-- Native HTML Section -->

--- a/src/pages/ja/patterns/combobox/react/demo/index.astro
+++ b/src/pages/ja/patterns/combobox/react/demo/index.astro
@@ -1,0 +1,77 @@
+---
+/**
+ * Demo-only Page: Combobox (React) - Japanese
+ *
+ * This page renders the Combobox component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import { Combobox } from '@patterns/combobox/Combobox';
+
+const fruitOptions = [
+  { id: 'apple', label: 'りんご' },
+  { id: 'banana', label: 'バナナ' },
+  { id: 'cherry', label: 'さくらんぼ' },
+  { id: 'date', label: 'デーツ' },
+  { id: 'elderberry', label: 'エルダーベリー' },
+  { id: 'fig', label: 'いちじく' },
+  { id: 'grape', label: 'ぶどう' },
+];
+
+const countryOptions = [
+  { id: 'jp', label: '日本' },
+  { id: 'us', label: 'アメリカ' },
+  { id: 'uk', label: 'イギリス' },
+  { id: 'de', label: 'ドイツ', disabled: true },
+  { id: 'fr', label: 'フランス' },
+  { id: 'it', label: 'イタリア' },
+  { id: 'es', label: 'スペイン', disabled: true },
+  { id: 'au', label: 'オーストラリア' },
+];
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: コンボボックス (React)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-6">
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="お気に入りのフルーツ"
+        placeholder="検索..."
+      />
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="デフォルト値あり"
+        defaultSelectedOptionId="cherry"
+      />
+      <Combobox
+        client:load
+        options={countryOptions}
+        label="国（無効なオプションあり）"
+        placeholder="国を選択..."
+      />
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="フィルタなし (autocomplete='none')"
+        autocomplete="none"
+        placeholder="すべてのオプションを表示..."
+      />
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="無効なコンボボックス"
+        disabled
+        placeholder="操作不可"
+      />
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/combobox/react/index.astro
+++ b/src/pages/ja/patterns/combobox/react/index.astro
@@ -118,6 +118,9 @@ const countryOptions = [
         </div>
       </div>
     </div>
+    <p class="text-muted-foreground mt-2 text-sm">
+      <a href="./demo/" class="text-primary hover:underline">デモのみを開く →</a>
+    </p>
   </section>
 
   <!-- Native HTML Section -->

--- a/src/pages/ja/patterns/combobox/svelte/demo/index.astro
+++ b/src/pages/ja/patterns/combobox/svelte/demo/index.astro
@@ -1,0 +1,77 @@
+---
+/**
+ * Demo-only Page: Combobox (Svelte) - Japanese
+ *
+ * This page renders the Combobox component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import Combobox from '@patterns/combobox/Combobox.svelte';
+
+const fruitOptions = [
+  { id: 'apple', label: 'りんご' },
+  { id: 'banana', label: 'バナナ' },
+  { id: 'cherry', label: 'さくらんぼ' },
+  { id: 'date', label: 'デーツ' },
+  { id: 'elderberry', label: 'エルダーベリー' },
+  { id: 'fig', label: 'いちじく' },
+  { id: 'grape', label: 'ぶどう' },
+];
+
+const countryOptions = [
+  { id: 'jp', label: '日本' },
+  { id: 'us', label: 'アメリカ' },
+  { id: 'uk', label: 'イギリス' },
+  { id: 'de', label: 'ドイツ', disabled: true },
+  { id: 'fr', label: 'フランス' },
+  { id: 'it', label: 'イタリア' },
+  { id: 'es', label: 'スペイン', disabled: true },
+  { id: 'au', label: 'オーストラリア' },
+];
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: コンボボックス (Svelte)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-6">
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="お気に入りのフルーツ"
+        placeholder="検索..."
+      />
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="デフォルト値あり"
+        defaultSelectedOptionId="cherry"
+      />
+      <Combobox
+        client:load
+        options={countryOptions}
+        label="国（無効なオプションあり）"
+        placeholder="国を選択..."
+      />
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="フィルタなし (autocomplete='none')"
+        autocomplete="none"
+        placeholder="すべてのオプションを表示..."
+      />
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="無効なコンボボックス"
+        disabled
+        placeholder="操作不可"
+      />
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/combobox/svelte/index.astro
+++ b/src/pages/ja/patterns/combobox/svelte/index.astro
@@ -118,6 +118,9 @@ const countryOptions = [
         </div>
       </div>
     </div>
+    <p class="text-muted-foreground mt-2 text-sm">
+      <a href="./demo/" class="text-primary hover:underline">デモのみを開く →</a>
+    </p>
   </section>
 
   <!-- Native HTML Section -->

--- a/src/pages/ja/patterns/combobox/vue/demo/index.astro
+++ b/src/pages/ja/patterns/combobox/vue/demo/index.astro
@@ -1,0 +1,77 @@
+---
+/**
+ * Demo-only Page: Combobox (Vue) - Japanese
+ *
+ * This page renders the Combobox component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import Combobox from '@patterns/combobox/Combobox.vue';
+
+const fruitOptions = [
+  { id: 'apple', label: 'りんご' },
+  { id: 'banana', label: 'バナナ' },
+  { id: 'cherry', label: 'さくらんぼ' },
+  { id: 'date', label: 'デーツ' },
+  { id: 'elderberry', label: 'エルダーベリー' },
+  { id: 'fig', label: 'いちじく' },
+  { id: 'grape', label: 'ぶどう' },
+];
+
+const countryOptions = [
+  { id: 'jp', label: '日本' },
+  { id: 'us', label: 'アメリカ' },
+  { id: 'uk', label: 'イギリス' },
+  { id: 'de', label: 'ドイツ', disabled: true },
+  { id: 'fr', label: 'フランス' },
+  { id: 'it', label: 'イタリア' },
+  { id: 'es', label: 'スペイン', disabled: true },
+  { id: 'au', label: 'オーストラリア' },
+];
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: コンボボックス (Vue)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-6">
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="お気に入りのフルーツ"
+        placeholder="検索..."
+      />
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="デフォルト値あり"
+        defaultSelectedOptionId="cherry"
+      />
+      <Combobox
+        client:load
+        options={countryOptions}
+        label="国（無効なオプションあり）"
+        placeholder="国を選択..."
+      />
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="フィルタなし (autocomplete='none')"
+        autocomplete="none"
+        placeholder="すべてのオプションを表示..."
+      />
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="無効なコンボボックス"
+        disabled
+        placeholder="操作不可"
+      />
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/combobox/vue/index.astro
+++ b/src/pages/ja/patterns/combobox/vue/index.astro
@@ -118,6 +118,9 @@ const countryOptions = [
         </div>
       </div>
     </div>
+    <p class="text-muted-foreground mt-2 text-sm">
+      <a href="./demo/" class="text-primary hover:underline">デモのみを開く →</a>
+    </p>
   </section>
 
   <!-- Native HTML Section -->

--- a/src/pages/patterns/combobox/astro/demo/index.astro
+++ b/src/pages/patterns/combobox/astro/demo/index.astro
@@ -1,0 +1,68 @@
+---
+/**
+ * Demo-only Page: Combobox (Astro)
+ *
+ * This page renders the Combobox component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import Combobox from '@patterns/combobox/Combobox.astro';
+
+const fruitOptions = [
+  { id: 'apple', label: 'Apple' },
+  { id: 'banana', label: 'Banana' },
+  { id: 'cherry', label: 'Cherry' },
+  { id: 'date', label: 'Date' },
+  { id: 'elderberry', label: 'Elderberry' },
+  { id: 'fig', label: 'Fig' },
+  { id: 'grape', label: 'Grape' },
+];
+
+const countryOptions = [
+  { id: 'jp', label: 'Japan' },
+  { id: 'us', label: 'United States' },
+  { id: 'uk', label: 'United Kingdom' },
+  { id: 'de', label: 'Germany', disabled: true },
+  { id: 'fr', label: 'France' },
+  { id: 'it', label: 'Italy' },
+  { id: 'es', label: 'Spain', disabled: true },
+  { id: 'au', label: 'Australia' },
+];
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Demo: Combobox (Astro)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-6">
+      <Combobox options={fruitOptions} label="Favorite Fruit" placeholder="Type to search..." />
+      <Combobox
+        options={fruitOptions}
+        label="With Default Value"
+        defaultSelectedOptionId="cherry"
+      />
+      <Combobox
+        options={countryOptions}
+        label="Country (with disabled options)"
+        placeholder="Select a country..."
+      />
+      <Combobox
+        options={fruitOptions}
+        label="No Filter (autocomplete='none')"
+        autocomplete="none"
+        placeholder="All options shown..."
+      />
+      <Combobox
+        options={fruitOptions}
+        label="Disabled Combobox"
+        disabled
+        placeholder="Cannot interact"
+      />
+    </div>
+  </body>
+</html>

--- a/src/pages/patterns/combobox/astro/index.astro
+++ b/src/pages/patterns/combobox/astro/index.astro
@@ -99,6 +99,9 @@ const countryOptions = [
         </div>
       </div>
     </div>
+    <p class="text-muted-foreground mt-2 text-sm">
+      <a href="./demo/" class="text-primary hover:underline">Open demo only →</a>
+    </p>
   </section>
 
   <!-- Native HTML Section -->

--- a/src/pages/patterns/combobox/react/demo/index.astro
+++ b/src/pages/patterns/combobox/react/demo/index.astro
@@ -1,0 +1,77 @@
+---
+/**
+ * Demo-only Page: Combobox (React)
+ *
+ * This page renders the Combobox component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import { Combobox } from '@patterns/combobox/Combobox';
+
+const fruitOptions = [
+  { id: 'apple', label: 'Apple' },
+  { id: 'banana', label: 'Banana' },
+  { id: 'cherry', label: 'Cherry' },
+  { id: 'date', label: 'Date' },
+  { id: 'elderberry', label: 'Elderberry' },
+  { id: 'fig', label: 'Fig' },
+  { id: 'grape', label: 'Grape' },
+];
+
+const countryOptions = [
+  { id: 'jp', label: 'Japan' },
+  { id: 'us', label: 'United States' },
+  { id: 'uk', label: 'United Kingdom' },
+  { id: 'de', label: 'Germany', disabled: true },
+  { id: 'fr', label: 'France' },
+  { id: 'it', label: 'Italy' },
+  { id: 'es', label: 'Spain', disabled: true },
+  { id: 'au', label: 'Australia' },
+];
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Demo: Combobox (React)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-6">
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="Favorite Fruit"
+        placeholder="Type to search..."
+      />
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="With Default Value"
+        defaultSelectedOptionId="cherry"
+      />
+      <Combobox
+        client:load
+        options={countryOptions}
+        label="Country (with disabled options)"
+        placeholder="Select a country..."
+      />
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="No Filter (autocomplete='none')"
+        autocomplete="none"
+        placeholder="All options shown..."
+      />
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="Disabled Combobox"
+        disabled
+        placeholder="Cannot interact"
+      />
+    </div>
+  </body>
+</html>

--- a/src/pages/patterns/combobox/react/index.astro
+++ b/src/pages/patterns/combobox/react/index.astro
@@ -109,6 +109,9 @@ const countryOptions = [
         </div>
       </div>
     </div>
+    <p class="text-muted-foreground mt-2 text-sm">
+      <a href="./demo/" class="text-primary hover:underline">Open demo only →</a>
+    </p>
   </section>
 
   <!-- Native HTML Section -->

--- a/src/pages/patterns/combobox/svelte/demo/index.astro
+++ b/src/pages/patterns/combobox/svelte/demo/index.astro
@@ -1,0 +1,77 @@
+---
+/**
+ * Demo-only Page: Combobox (Svelte)
+ *
+ * This page renders the Combobox component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import Combobox from '@patterns/combobox/Combobox.svelte';
+
+const fruitOptions = [
+  { id: 'apple', label: 'Apple' },
+  { id: 'banana', label: 'Banana' },
+  { id: 'cherry', label: 'Cherry' },
+  { id: 'date', label: 'Date' },
+  { id: 'elderberry', label: 'Elderberry' },
+  { id: 'fig', label: 'Fig' },
+  { id: 'grape', label: 'Grape' },
+];
+
+const countryOptions = [
+  { id: 'jp', label: 'Japan' },
+  { id: 'us', label: 'United States' },
+  { id: 'uk', label: 'United Kingdom' },
+  { id: 'de', label: 'Germany', disabled: true },
+  { id: 'fr', label: 'France' },
+  { id: 'it', label: 'Italy' },
+  { id: 'es', label: 'Spain', disabled: true },
+  { id: 'au', label: 'Australia' },
+];
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Demo: Combobox (Svelte)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-6">
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="Favorite Fruit"
+        placeholder="Type to search..."
+      />
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="With Default Value"
+        defaultSelectedOptionId="cherry"
+      />
+      <Combobox
+        client:load
+        options={countryOptions}
+        label="Country (with disabled options)"
+        placeholder="Select a country..."
+      />
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="No Filter (autocomplete='none')"
+        autocomplete="none"
+        placeholder="All options shown..."
+      />
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="Disabled Combobox"
+        disabled
+        placeholder="Cannot interact"
+      />
+    </div>
+  </body>
+</html>

--- a/src/pages/patterns/combobox/svelte/index.astro
+++ b/src/pages/patterns/combobox/svelte/index.astro
@@ -109,6 +109,9 @@ const countryOptions = [
         </div>
       </div>
     </div>
+    <p class="text-muted-foreground mt-2 text-sm">
+      <a href="./demo/" class="text-primary hover:underline">Open demo only →</a>
+    </p>
   </section>
 
   <!-- Native HTML Section -->

--- a/src/pages/patterns/combobox/vue/demo/index.astro
+++ b/src/pages/patterns/combobox/vue/demo/index.astro
@@ -1,0 +1,77 @@
+---
+/**
+ * Demo-only Page: Combobox (Vue)
+ *
+ * This page renders the Combobox component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import Combobox from '@patterns/combobox/Combobox.vue';
+
+const fruitOptions = [
+  { id: 'apple', label: 'Apple' },
+  { id: 'banana', label: 'Banana' },
+  { id: 'cherry', label: 'Cherry' },
+  { id: 'date', label: 'Date' },
+  { id: 'elderberry', label: 'Elderberry' },
+  { id: 'fig', label: 'Fig' },
+  { id: 'grape', label: 'Grape' },
+];
+
+const countryOptions = [
+  { id: 'jp', label: 'Japan' },
+  { id: 'us', label: 'United States' },
+  { id: 'uk', label: 'United Kingdom' },
+  { id: 'de', label: 'Germany', disabled: true },
+  { id: 'fr', label: 'France' },
+  { id: 'it', label: 'Italy' },
+  { id: 'es', label: 'Spain', disabled: true },
+  { id: 'au', label: 'Australia' },
+];
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Demo: Combobox (Vue)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-6">
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="Favorite Fruit"
+        placeholder="Type to search..."
+      />
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="With Default Value"
+        defaultSelectedOptionId="cherry"
+      />
+      <Combobox
+        client:load
+        options={countryOptions}
+        label="Country (with disabled options)"
+        placeholder="Select a country..."
+      />
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="No Filter (autocomplete='none')"
+        autocomplete="none"
+        placeholder="All options shown..."
+      />
+      <Combobox
+        client:load
+        options={fruitOptions}
+        label="Disabled Combobox"
+        disabled
+        placeholder="Cannot interact"
+      />
+    </div>
+  </body>
+</html>

--- a/src/pages/patterns/combobox/vue/index.astro
+++ b/src/pages/patterns/combobox/vue/index.astro
@@ -109,6 +109,9 @@ const countryOptions = [
         </div>
       </div>
     </div>
+    <p class="text-muted-foreground mt-2 text-sm">
+      <a href="./demo/" class="text-primary hover:underline">Open demo only →</a>
+    </p>
   </section>
 
   <!-- Native HTML Section -->

--- a/src/patterns/combobox/TestingDocs.astro
+++ b/src/patterns/combobox/TestingDocs.astro
@@ -6,14 +6,46 @@ import { ResponsiveTable } from '@/components/ui/table';
 <div class="prose dark:prose-invert max-w-none">
   <p class="text-muted-foreground mb-4">
     Tests verify APG compliance for ARIA attributes, keyboard interactions, filtering behavior, and
-    accessibility requirements.
+    accessibility requirements. The Combobox component uses a two-layer testing strategy.
   </p>
+
+  <h3 class="mb-3 text-lg font-medium">Testing Strategy</h3>
+
+  <div class="bg-muted/50 mb-6 rounded-lg p-4">
+    <h4 class="mb-2 font-medium">Unit Tests (Testing Library)</h4>
+    <p class="text-muted-foreground mb-2 text-sm">
+      Verify the component's rendered output using framework-specific testing libraries. These tests
+      ensure correct HTML structure and ARIA attributes.
+    </p>
+    <ul class="text-muted-foreground list-disc space-y-1 pl-6 text-sm">
+      <li>ARIA attributes (role, aria-controls, aria-expanded, etc.)</li>
+      <li>Keyboard interaction (Arrow keys, Enter, Escape, etc.)</li>
+      <li>Filtering behavior and option rendering</li>
+      <li>Accessibility via jest-axe</li>
+    </ul>
+  </div>
+
+  <div class="bg-muted/50 mb-6 rounded-lg p-4">
+    <h4 class="mb-2 font-medium">E2E Tests (Playwright)</h4>
+    <p class="text-muted-foreground mb-2 text-sm">
+      Verify component behavior in a real browser environment across all frameworks. These tests
+      cover interactions and cross-framework consistency.
+    </p>
+    <ul class="text-muted-foreground list-disc space-y-1 pl-6 text-sm">
+      <li>Keyboard navigation and selection</li>
+      <li>Mouse interactions (click, hover)</li>
+      <li>ARIA structure in live browser</li>
+      <li>Focus management with aria-activedescendant</li>
+      <li>axe-core accessibility scanning</li>
+      <li>Cross-framework consistency checks</li>
+    </ul>
+  </div>
 
   <h3 class="mb-3 text-lg font-medium">Test Categories</h3>
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
-    High Priority: ARIA Attributes
+    High Priority: ARIA Attributes (Unit + E2E)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -66,7 +98,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
-    High Priority: Accessible Name
+    High Priority: Accessible Name (Unit + E2E)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -91,7 +123,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
-    High Priority: Keyboard Interaction (Popup Closed)
+    High Priority: Keyboard Interaction - Popup Closed (Unit + E2E)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -124,7 +156,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
-    High Priority: Keyboard Interaction (Popup Open)
+    High Priority: Keyboard Interaction - Popup Open (Unit + E2E)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -173,7 +205,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
-    High Priority: Focus Management
+    High Priority: Focus Management (Unit + E2E)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -206,7 +238,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-yellow-500"></span>
-    Medium Priority: Filtering
+    Medium Priority: Filtering (Unit)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -239,7 +271,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-yellow-500"></span>
-    Medium Priority: Mouse Interaction
+    Medium Priority: Mouse Interaction (E2E)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -272,7 +304,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-yellow-500"></span>
-    Medium Priority: IME Composition
+    Medium Priority: IME Composition (Unit)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -297,7 +329,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-yellow-500"></span>
-    Medium Priority: Callbacks
+    Medium Priority: Callbacks (Unit)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -326,7 +358,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-green-500"></span>
-    Low Priority: HTML Attribute Inheritance
+    Low Priority: HTML Attribute Inheritance (Unit)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -353,46 +385,68 @@ import { ResponsiveTable } from '@/components/ui/table';
     </table>
   </ResponsiveTable>
 
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-green-500"></span>
+    Low Priority: Cross-framework Consistency (E2E)
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">Test</th>
+          <th class="py-2 text-left">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>All frameworks have combobox</code></td>
+          <td class="py-2">React, Vue, Svelte, Astro all render combobox elements</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Select on click</code></td>
+          <td class="py-2">All frameworks select correctly on click</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Consistent ARIA</code></td>
+          <td class="py-2">All frameworks have consistent ARIA structure</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
   <h3 class="mb-3 text-lg font-medium">Testing Tools</h3>
   <ul class="mb-6 list-disc space-y-2 pl-6">
     <li>
-      <strong>React:</strong>
-      <ExternalLink
-        href="https://testing-library.com/docs/react-testing-library/intro/"
-        class="text-primary hover:underline"
+      <ExternalLink href="https://vitest.dev/" class="text-primary hover:underline"
+        >Vitest</ExternalLink
       >
-        React Testing Library
-      </ExternalLink>
+      - Test runner for unit tests
     </li>
     <li>
-      <strong>Vue:</strong>
-      <ExternalLink
-        href="https://testing-library.com/docs/vue-testing-library/intro/"
-        class="text-primary hover:underline"
+      <ExternalLink href="https://testing-library.com/" class="text-primary hover:underline"
+        >Testing Library</ExternalLink
       >
-        Vue Testing Library
-      </ExternalLink>
+      - Framework-specific testing utilities (React, Vue, Svelte)
     </li>
     <li>
-      <strong>Svelte:</strong>
-      <ExternalLink
-        href="https://testing-library.com/docs/svelte-testing-library/intro/"
-        class="text-primary hover:underline"
+      <ExternalLink href="https://playwright.dev/" class="text-primary hover:underline"
+        >Playwright</ExternalLink
       >
-        Svelte Testing Library
-      </ExternalLink>
+      - Browser automation for E2E tests
     </li>
     <li>
-      <strong>Astro:</strong> Vitest with JSDOM for Web Component unit tests
-    </li>
-    <li>
-      <strong>Accessibility:</strong>
       <ExternalLink
-        href="https://github.com/dequelabs/axe-core"
-        class="text-primary hover:underline"
+        href="https://github.com/dequelabs/axe-core-npm/tree/develop/packages/playwright"
+        class="text-primary hover:underline">axe-core/playwright</ExternalLink
       >
-        axe-core
-      </ExternalLink>
+      - Automated accessibility testing in E2E
     </li>
   </ul>
+
+  <p class="text-muted-foreground text-sm">
+    See <ExternalLink
+      href="https://github.com/masuP9/apg-patterns-examples/blob/main/.internal/testing-strategy.md"
+      class="text-primary hover:underline">testing-strategy.md</ExternalLink
+    > for full documentation.
+  </p>
 </div>

--- a/src/patterns/combobox/TestingDocs.ja.astro
+++ b/src/patterns/combobox/TestingDocs.ja.astro
@@ -6,14 +6,46 @@ import { ResponsiveTable } from '@/components/ui/table';
 <div class="prose dark:prose-invert max-w-none">
   <p class="text-muted-foreground mb-4">
     テストは ARIA 属性、キーボード操作、フィルタリング動作、アクセシビリティ要件に対する APG
-    準拠を検証します。
+    準拠を検証します。Combobox コンポーネントは2層のテスト戦略を採用しています。
   </p>
+
+  <h3 class="mb-3 text-lg font-medium">テスト戦略</h3>
+
+  <div class="bg-muted/50 mb-6 rounded-lg p-4">
+    <h4 class="mb-2 font-medium">ユニットテスト (Testing Library)</h4>
+    <p class="text-muted-foreground mb-2 text-sm">
+      フレームワーク固有のテストライブラリを使用してコンポーネントの出力を検証します。正しい HTML
+      構造と ARIA 属性を確認します。
+    </p>
+    <ul class="text-muted-foreground list-disc space-y-1 pl-6 text-sm">
+      <li>ARIA 属性（role、aria-controls、aria-expanded など）</li>
+      <li>キーボード操作（矢印キー、Enter、Escape など）</li>
+      <li>フィルタリング動作とオプションのレンダリング</li>
+      <li>jest-axe によるアクセシビリティ検証</li>
+    </ul>
+  </div>
+
+  <div class="bg-muted/50 mb-6 rounded-lg p-4">
+    <h4 class="mb-2 font-medium">E2E テスト (Playwright)</h4>
+    <p class="text-muted-foreground mb-2 text-sm">
+      実際のブラウザ環境で全フレームワークのコンポーネント動作を検証します。インタラクションと
+      クロスフレームワークの一貫性をカバーします。
+    </p>
+    <ul class="text-muted-foreground list-disc space-y-1 pl-6 text-sm">
+      <li>キーボードナビゲーションと選択</li>
+      <li>マウス操作（クリック、ホバー）</li>
+      <li>ライブブラウザでの ARIA 構造</li>
+      <li>aria-activedescendant によるフォーカス管理</li>
+      <li>axe-core によるアクセシビリティスキャン</li>
+      <li>クロスフレームワーク一貫性チェック</li>
+    </ul>
+  </div>
 
   <h3 class="mb-3 text-lg font-medium">テストカテゴリ</h3>
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
-    高優先度: ARIA 属性
+    高優先度: ARIA 属性 (Unit + E2E)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -66,7 +98,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
-    高優先度: アクセシブル名
+    高優先度: アクセシブル名 (Unit + E2E)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -91,7 +123,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
-    高優先度: キーボード操作（ポップアップ閉時）
+    高優先度: キーボード操作 - ポップアップ閉時 (Unit + E2E)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -124,7 +156,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
-    高優先度: キーボード操作（ポップアップ開時）
+    高優先度: キーボード操作 - ポップアップ開時 (Unit + E2E)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -173,7 +205,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
-    高優先度: フォーカス管理
+    高優先度: フォーカス管理 (Unit + E2E)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -206,7 +238,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-yellow-500"></span>
-    中優先度: フィルタリング
+    中優先度: フィルタリング (Unit)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -239,7 +271,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-yellow-500"></span>
-    中優先度: マウス操作
+    中優先度: マウス操作 (E2E)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -272,7 +304,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-yellow-500"></span>
-    中優先度: IME 入力
+    中優先度: IME 入力 (Unit)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -297,7 +329,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-yellow-500"></span>
-    中優先度: コールバック
+    中優先度: コールバック (Unit)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -326,7 +358,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-green-500"></span>
-    低優先度: HTML 属性継承
+    低優先度: HTML 属性継承 (Unit)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -353,46 +385,68 @@ import { ResponsiveTable } from '@/components/ui/table';
     </table>
   </ResponsiveTable>
 
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-green-500"></span>
+    低優先度: クロスフレームワーク一貫性 (E2E)
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">テスト</th>
+          <th class="py-2 text-left">説明</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>全フレームワークにコンボボックス</code></td>
+          <td class="py-2">React、Vue、Svelte、Astro すべてがコンボボックス要素をレンダリング</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>クリックで選択</code></td>
+          <td class="py-2">すべてのフレームワークがクリックで正しく選択</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>一貫した ARIA</code></td>
+          <td class="py-2">すべてのフレームワークが一貫した ARIA 構造を持つ</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
   <h3 class="mb-3 text-lg font-medium">テストツール</h3>
   <ul class="mb-6 list-disc space-y-2 pl-6">
     <li>
-      <strong>React:</strong>
-      <ExternalLink
-        href="https://testing-library.com/docs/react-testing-library/intro/"
-        class="text-primary hover:underline"
+      <ExternalLink href="https://vitest.dev/" class="text-primary hover:underline"
+        >Vitest</ExternalLink
       >
-        React Testing Library
-      </ExternalLink>
+      - ユニットテスト用テストランナー
     </li>
     <li>
-      <strong>Vue:</strong>
-      <ExternalLink
-        href="https://testing-library.com/docs/vue-testing-library/intro/"
-        class="text-primary hover:underline"
+      <ExternalLink href="https://testing-library.com/" class="text-primary hover:underline"
+        >Testing Library</ExternalLink
       >
-        Vue Testing Library
-      </ExternalLink>
+      - フレームワーク固有のテストユーティリティ（React、Vue、Svelte）
     </li>
     <li>
-      <strong>Svelte:</strong>
-      <ExternalLink
-        href="https://testing-library.com/docs/svelte-testing-library/intro/"
-        class="text-primary hover:underline"
+      <ExternalLink href="https://playwright.dev/" class="text-primary hover:underline"
+        >Playwright</ExternalLink
       >
-        Svelte Testing Library
-      </ExternalLink>
+      - E2E テスト用ブラウザ自動化
     </li>
     <li>
-      <strong>Astro:</strong> Web Component ユニットテスト用の Vitest + JSDOM
-    </li>
-    <li>
-      <strong>アクセシビリティ:</strong>
       <ExternalLink
-        href="https://github.com/dequelabs/axe-core"
-        class="text-primary hover:underline"
+        href="https://github.com/dequelabs/axe-core-npm/tree/develop/packages/playwright"
+        class="text-primary hover:underline">axe-core/playwright</ExternalLink
       >
-        axe-core
-      </ExternalLink>
+      - E2E での自動アクセシビリティテスト
     </li>
   </ul>
+
+  <p class="text-muted-foreground text-sm">
+    詳細なドキュメントは <ExternalLink
+      href="https://github.com/masuP9/apg-patterns-examples/blob/main/.internal/testing-strategy.md"
+      class="text-primary hover:underline">testing-strategy.md</ExternalLink
+    > を参照してください。
+  </p>
 </div>


### PR DESCRIPTION
- Add comprehensive E2E tests covering ARIA structure, keyboard interactions, focus management, mouse interactions, and accessibility
- Create demo-only pages for all 4 frameworks (React, Vue, Svelte, Astro) in both English and Japanese locales
- Add demo links to pattern pages for direct E2E testing access
- Update TestingDocs with E2E testing documentation (EN/JA)
