### PR TITLE
test(listbox): add comprehensive E2E tests for Listbox pattern

### DIFF
--- a/e2e/listbox.spec.ts
+++ b/e2e/listbox.spec.ts
@@ -1,0 +1,733 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+/**
+ * E2E Tests for Listbox Pattern
+ *
+ * A widget that allows the user to select one or more items from a list of choices.
+ * Supports single-select (selection follows focus) and multi-select modes.
+ *
+ * APG Reference: https://www.w3.org/WAI/ARIA/apg/patterns/listbox/
+ */
+
+const frameworks = ['react', 'vue', 'svelte', 'astro'] as const;
+
+// Helper to get all listboxes
+const getListboxes = (page: import('@playwright/test').Page) => {
+  return page.locator('[role="listbox"]');
+};
+
+// Helper to get listbox by index (0=single-select, 1=multi-select, 2=horizontal)
+const getListboxByIndex = (page: import('@playwright/test').Page, index: number) => {
+  return page.locator('[role="listbox"]').nth(index);
+};
+
+// Helper to get available (non-disabled) options in a listbox
+const getAvailableOptions = (listbox: import('@playwright/test').Locator) => {
+  return listbox.locator('[role="option"]:not([aria-disabled="true"])');
+};
+
+// Helper to get selected options in a listbox
+const getSelectedOptions = (listbox: import('@playwright/test').Locator) => {
+  return listbox.locator('[role="option"][aria-selected="true"]');
+};
+
+// Helper to focus the first available option
+const focusFirstOption = async (listbox: import('@playwright/test').Locator) => {
+  const firstOption = listbox.locator('[role="option"][tabindex="0"]');
+  await firstOption.focus();
+};
+
+for (const framework of frameworks) {
+  test.describe(`Listbox (${framework})`, () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(`patterns/listbox/${framework}/demo/`);
+      await page.waitForLoadState('networkidle');
+    });
+
+    // =========================================================================
+    // High Priority: ARIA Structure
+    // =========================================================================
+    test.describe('APG: ARIA Structure', () => {
+      test('has role="listbox" on container', async ({ page }) => {
+        const listboxes = getListboxes(page);
+        const count = await listboxes.count();
+        expect(count).toBe(3); // single-select, multi-select, horizontal
+
+        for (let i = 0; i < count; i++) {
+          await expect(listboxes.nth(i)).toHaveAttribute('role', 'listbox');
+        }
+      });
+
+      test('options have role="option"', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 0);
+        const options = listbox.locator('[role="option"]');
+        const count = await options.count();
+        expect(count).toBeGreaterThan(0);
+
+        for (let i = 0; i < count; i++) {
+          await expect(options.nth(i)).toHaveAttribute('role', 'option');
+        }
+      });
+
+      test('has accessible name via aria-labelledby', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 0);
+        const ariaLabelledby = await listbox.getAttribute('aria-labelledby');
+        expect(ariaLabelledby).toBeTruthy();
+
+        const label = page.locator(`#${ariaLabelledby}`);
+        const labelText = await label.textContent();
+        expect(labelText?.trim().length).toBeGreaterThan(0);
+      });
+
+      test('single-select listbox does not have aria-multiselectable', async ({ page }) => {
+        const singleSelectListbox = getListboxByIndex(page, 0);
+        const ariaMultiselectable = await singleSelectListbox.getAttribute('aria-multiselectable');
+        expect(ariaMultiselectable).toBeFalsy();
+      });
+
+      test('multi-select listbox has aria-multiselectable="true"', async ({ page }) => {
+        const multiSelectListbox = getListboxByIndex(page, 1);
+        await expect(multiSelectListbox).toHaveAttribute('aria-multiselectable', 'true');
+      });
+
+      test('horizontal listbox has aria-orientation="horizontal"', async ({ page }) => {
+        const horizontalListbox = getListboxByIndex(page, 2);
+        await expect(horizontalListbox).toHaveAttribute('aria-orientation', 'horizontal');
+      });
+
+      test('selected options have aria-selected="true"', async ({ page }) => {
+        const singleSelectListbox = getListboxByIndex(page, 0);
+        const selectedOptions = getSelectedOptions(singleSelectListbox);
+        const count = await selectedOptions.count();
+        expect(count).toBeGreaterThan(0);
+
+        for (let i = 0; i < count; i++) {
+          await expect(selectedOptions.nth(i)).toHaveAttribute('aria-selected', 'true');
+        }
+      });
+
+      test('disabled options have aria-disabled="true"', async ({ page }) => {
+        const multiSelectListbox = getListboxByIndex(page, 1);
+        const disabledOptions = multiSelectListbox.locator('[role="option"][aria-disabled="true"]');
+        const count = await disabledOptions.count();
+        expect(count).toBeGreaterThan(0);
+      });
+    });
+
+    // =========================================================================
+    // High Priority: Single-Select Keyboard Navigation
+    // =========================================================================
+    test.describe('APG: Single-Select Keyboard Navigation', () => {
+      test('ArrowDown moves focus and selection to next option', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 0);
+        const options = getAvailableOptions(listbox);
+        const firstOption = options.first();
+        const secondOption = options.nth(1);
+
+        await firstOption.focus();
+        await expect(firstOption).toHaveAttribute('aria-selected', 'true');
+
+        await page.keyboard.press('ArrowDown');
+        await expect(secondOption).toHaveAttribute('tabindex', '0');
+        await expect(secondOption).toHaveAttribute('aria-selected', 'true');
+        await expect(firstOption).toHaveAttribute('aria-selected', 'false');
+      });
+
+      test('ArrowUp moves focus and selection to previous option', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 0);
+        const options = getAvailableOptions(listbox);
+        const firstOption = options.first();
+        const secondOption = options.nth(1);
+
+        // Click to set initial state, then navigate down to second option
+        await firstOption.click();
+        await page.keyboard.press('ArrowDown');
+        await expect(secondOption).toHaveAttribute('tabindex', '0');
+        await expect(secondOption).toHaveAttribute('aria-selected', 'true');
+
+        // Now navigate up
+        await page.keyboard.press('ArrowUp');
+        await expect(firstOption).toHaveAttribute('tabindex', '0');
+        await expect(firstOption).toHaveAttribute('aria-selected', 'true');
+      });
+
+      test('Home moves focus and selection to first option', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 0);
+        const options = getAvailableOptions(listbox);
+        const firstOption = options.first();
+        const thirdOption = options.nth(2);
+
+        await firstOption.focus();
+        await page.keyboard.press('ArrowDown');
+        await page.keyboard.press('ArrowDown');
+
+        await page.keyboard.press('Home');
+        await expect(firstOption).toHaveAttribute('tabindex', '0');
+        await expect(firstOption).toHaveAttribute('aria-selected', 'true');
+      });
+
+      test('End moves focus and selection to last option', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 0);
+        const options = getAvailableOptions(listbox);
+        const firstOption = options.first();
+        const lastOption = options.last();
+
+        await firstOption.focus();
+        await page.keyboard.press('End');
+        await expect(lastOption).toHaveAttribute('tabindex', '0');
+        await expect(lastOption).toHaveAttribute('aria-selected', 'true');
+      });
+
+      test('focus does not wrap at boundaries', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 0);
+        const options = getAvailableOptions(listbox);
+        const lastOption = options.last();
+
+        await lastOption.focus();
+        await page.keyboard.press('End'); // Ensure we're at the end
+
+        const lastOptionId = await lastOption.getAttribute('id');
+        await page.keyboard.press('ArrowDown');
+
+        // Should still be on last option
+        await expect(lastOption).toHaveAttribute('tabindex', '0');
+      });
+
+      // Note: disabled option skip test is in Multi-Select section since the multi-select
+      // listbox has disabled options (Green) while single-select doesn't
+    });
+
+    // =========================================================================
+    // High Priority: Multi-Select Keyboard Navigation
+    // =========================================================================
+    test.describe('APG: Multi-Select Keyboard Navigation', () => {
+      test('ArrowDown moves focus only (no selection change)', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 1);
+        const options = getAvailableOptions(listbox);
+        const firstOption = options.first();
+        const secondOption = options.nth(1);
+
+        await firstOption.focus();
+        // Initially no selection in multi-select
+        const initialSelected = await getSelectedOptions(listbox).count();
+
+        await page.keyboard.press('ArrowDown');
+        await expect(secondOption).toHaveAttribute('tabindex', '0');
+
+        // Selection should not have changed
+        const afterSelected = await getSelectedOptions(listbox).count();
+        expect(afterSelected).toBe(initialSelected);
+      });
+
+      test('ArrowUp moves focus only (no selection change)', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 1);
+        const options = getAvailableOptions(listbox);
+        const firstOption = options.first();
+        const secondOption = options.nth(1);
+
+        // Click to set initial state, then navigate down to second option
+        await firstOption.click();
+        await page.keyboard.press('ArrowDown');
+        await expect(secondOption).toHaveAttribute('tabindex', '0');
+
+        // Navigate up should move focus but not change selection
+        await page.keyboard.press('ArrowUp');
+        await expect(firstOption).toHaveAttribute('tabindex', '0');
+      });
+
+      test('Space toggles selection of focused option (select)', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 1);
+        const firstOption = getAvailableOptions(listbox).first();
+
+        await firstOption.focus();
+        await expect(firstOption).not.toHaveAttribute('aria-selected', 'true');
+
+        await page.keyboard.press('Space');
+        await expect(firstOption).toHaveAttribute('aria-selected', 'true');
+      });
+
+      test('Space toggles selection of focused option (deselect)', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 1);
+        const firstOption = getAvailableOptions(listbox).first();
+
+        await firstOption.focus();
+        await page.keyboard.press('Space'); // Select
+        await expect(firstOption).toHaveAttribute('aria-selected', 'true');
+
+        await page.keyboard.press('Space'); // Deselect
+        await expect(firstOption).toHaveAttribute('aria-selected', 'false');
+      });
+
+      test('Shift+ArrowDown extends selection range', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 1);
+        const options = getAvailableOptions(listbox);
+        const firstOption = options.first();
+        const secondOption = options.nth(1);
+
+        await firstOption.focus();
+        await page.keyboard.press('Space'); // Select first as anchor
+        await expect(firstOption).toHaveAttribute('aria-selected', 'true');
+
+        await page.keyboard.press('Shift+ArrowDown');
+        await expect(secondOption).toHaveAttribute('aria-selected', 'true');
+        await expect(firstOption).toHaveAttribute('aria-selected', 'true');
+      });
+
+      test('Shift+ArrowUp extends selection range', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 1);
+        const options = getAvailableOptions(listbox);
+        const firstOption = options.first();
+        const secondOption = options.nth(1);
+
+        // Click second option to set it as anchor (click toggles selection and sets anchor)
+        await secondOption.click();
+        await expect(secondOption).toHaveAttribute('aria-selected', 'true');
+
+        await page.keyboard.press('Shift+ArrowUp');
+        await expect(firstOption).toHaveAttribute('aria-selected', 'true');
+        await expect(secondOption).toHaveAttribute('aria-selected', 'true');
+      });
+
+      test('Shift+Home selects from anchor to first option', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 1);
+        const options = getAvailableOptions(listbox);
+        const firstOption = options.first();
+        const thirdOption = options.nth(2);
+
+        await thirdOption.focus();
+        await page.keyboard.press('ArrowDown');
+        await page.keyboard.press('ArrowDown');
+        await page.keyboard.press('Space'); // Select third as anchor
+
+        await page.keyboard.press('Shift+Home');
+
+        // All options from first to anchor should be selected
+        await expect(firstOption).toHaveAttribute('aria-selected', 'true');
+      });
+
+      test('Shift+End selects from anchor to last option', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 1);
+        const options = getAvailableOptions(listbox);
+        const firstOption = options.first();
+        const lastOption = options.last();
+
+        await firstOption.focus();
+        await page.keyboard.press('Space'); // Select first as anchor
+
+        await page.keyboard.press('Shift+End');
+
+        // All options from anchor to last should be selected
+        await expect(lastOption).toHaveAttribute('aria-selected', 'true');
+        await expect(firstOption).toHaveAttribute('aria-selected', 'true');
+      });
+
+      test('Ctrl+A selects all available options', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 1);
+        const availableOptions = getAvailableOptions(listbox);
+        const firstOption = availableOptions.first();
+
+        await firstOption.focus();
+        await page.keyboard.press('Control+a');
+
+        const count = await availableOptions.count();
+        for (let i = 0; i < count; i++) {
+          await expect(availableOptions.nth(i)).toHaveAttribute('aria-selected', 'true');
+        }
+      });
+
+      test('disabled options are skipped during navigation', async ({ page }) => {
+        // Multi-select listbox has disabled options (Green at index 3)
+        const listbox = getListboxByIndex(page, 1);
+        const availableOptions = getAvailableOptions(listbox);
+
+        // Get Yellow (index 2 in available options) and Blue (index 3 after skip)
+        const yellowOption = availableOptions.nth(2); // Red, Orange, Yellow
+        const blueOption = availableOptions.nth(3); // Blue (Green is skipped)
+
+        // Click to focus Yellow first (ensures proper component state)
+        await yellowOption.click();
+        await page.keyboard.press('ArrowDown');
+
+        // Should skip Green and land on Blue
+        await expect(blueOption).toHaveAttribute('tabindex', '0');
+      });
+    });
+
+    // =========================================================================
+    // High Priority: Horizontal Listbox
+    // =========================================================================
+    test.describe('APG: Horizontal Listbox', () => {
+      test('ArrowRight moves to next option', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 2);
+        const options = getAvailableOptions(listbox);
+        const firstOption = options.first();
+        const secondOption = options.nth(1);
+
+        await firstOption.focus();
+        await page.keyboard.press('ArrowRight');
+
+        await expect(secondOption).toHaveAttribute('tabindex', '0');
+        await expect(secondOption).toHaveAttribute('aria-selected', 'true');
+      });
+
+      test('ArrowLeft moves to previous option', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 2);
+        const options = getAvailableOptions(listbox);
+        const firstOption = options.first();
+        const secondOption = options.nth(1);
+
+        // Click to set initial state, then navigate right to second option
+        await firstOption.click();
+        await page.keyboard.press('ArrowRight');
+        await expect(secondOption).toHaveAttribute('tabindex', '0');
+
+        // Now navigate left
+        await page.keyboard.press('ArrowLeft');
+        await expect(firstOption).toHaveAttribute('tabindex', '0');
+      });
+
+      test('ArrowUp/ArrowDown are ignored in horizontal mode', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 2);
+        const options = getAvailableOptions(listbox);
+        const firstOption = options.first();
+
+        await firstOption.focus();
+        const initialId = await firstOption.getAttribute('id');
+
+        await page.keyboard.press('ArrowDown');
+        // Should still be on first option
+        await expect(firstOption).toHaveAttribute('tabindex', '0');
+
+        await page.keyboard.press('ArrowUp');
+        await expect(firstOption).toHaveAttribute('tabindex', '0');
+      });
+
+      test('Home moves to first option', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 2);
+        const options = getAvailableOptions(listbox);
+        const firstOption = options.first();
+
+        await firstOption.focus();
+        await page.keyboard.press('ArrowRight');
+        await page.keyboard.press('ArrowRight');
+
+        await page.keyboard.press('Home');
+        await expect(firstOption).toHaveAttribute('tabindex', '0');
+      });
+
+      test('End moves to last option', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 2);
+        const options = getAvailableOptions(listbox);
+        const firstOption = options.first();
+        const lastOption = options.last();
+
+        await firstOption.focus();
+        await page.keyboard.press('End');
+
+        await expect(lastOption).toHaveAttribute('tabindex', '0');
+      });
+    });
+
+    // =========================================================================
+    // High Priority: Focus Management (Roving Tabindex)
+    // =========================================================================
+    test.describe('APG: Focus Management', () => {
+      test('focused option has tabindex="0"', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 0);
+        const focusedOption = listbox.locator('[role="option"][tabindex="0"]');
+        const count = await focusedOption.count();
+        expect(count).toBe(1);
+      });
+
+      test('other options have tabindex="-1"', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 0);
+        const allOptions = listbox.locator('[role="option"]');
+        const count = await allOptions.count();
+
+        let tabindexZeroCount = 0;
+        for (let i = 0; i < count; i++) {
+          const tabindex = await allOptions.nth(i).getAttribute('tabindex');
+          if (tabindex === '0') tabindexZeroCount++;
+        }
+        expect(tabindexZeroCount).toBe(1);
+      });
+
+      test('tabindex updates on navigation', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 0);
+        const options = getAvailableOptions(listbox);
+        const firstOption = options.first();
+        const secondOption = options.nth(1);
+
+        await firstOption.focus();
+        await expect(firstOption).toHaveAttribute('tabindex', '0');
+        await expect(secondOption).toHaveAttribute('tabindex', '-1');
+
+        await page.keyboard.press('ArrowDown');
+        await expect(firstOption).toHaveAttribute('tabindex', '-1');
+        await expect(secondOption).toHaveAttribute('tabindex', '0');
+      });
+
+      test('Tab exits listbox', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 0);
+        const firstOption = listbox.locator('[role="option"][tabindex="0"]');
+
+        await firstOption.focus();
+        await page.keyboard.press('Tab');
+
+        // Focus should have moved out of listbox
+        const focusedElement = page.locator(':focus');
+        const isInListbox = await focusedElement.evaluate(
+          (el, listboxEl) => listboxEl?.contains(el),
+          await listbox.elementHandle()
+        );
+        expect(isInListbox).toBeFalsy();
+      });
+
+      test('focus returns to last focused option on re-entry', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 0);
+        const options = getAvailableOptions(listbox);
+        const firstOption = options.first();
+        const thirdOption = options.nth(2);
+
+        await firstOption.focus();
+        await page.keyboard.press('ArrowDown');
+        await page.keyboard.press('ArrowDown');
+        await expect(thirdOption).toHaveAttribute('tabindex', '0');
+
+        // Tab out and back
+        await page.keyboard.press('Tab');
+        await page.keyboard.press('Shift+Tab');
+
+        // Should return to the third option
+        await expect(thirdOption).toHaveAttribute('tabindex', '0');
+      });
+    });
+
+    // =========================================================================
+    // High Priority: Type-ahead
+    // =========================================================================
+    test.describe('APG: Type-ahead', () => {
+      test('single character focuses matching option', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 0);
+        const grapeOption = listbox.locator('[role="option"]', { hasText: 'Grape' });
+        const firstOption = listbox.locator('[role="option"][tabindex="0"]');
+
+        await firstOption.focus();
+        await page.keyboard.press('g');
+
+        await expect(grapeOption).toHaveAttribute('tabindex', '0');
+      });
+
+      test('multiple characters match prefix', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 0);
+        const cherryOption = listbox.locator('[role="option"]', { hasText: 'Cherry' });
+        const firstOption = listbox.locator('[role="option"][tabindex="0"]');
+
+        await firstOption.focus();
+        await page.keyboard.type('ch', { delay: 50 });
+
+        await expect(cherryOption).toHaveAttribute('tabindex', '0');
+      });
+
+      test('repeated same character cycles through matches', async ({ page }) => {
+        // With fruit options: Apple, Apricot, Banana, Cherry, Date, Elderberry, Fig, Grape
+        // Apple and Apricot both start with 'a', so we can test cycling
+        const listbox = getListboxByIndex(page, 0);
+        const firstOption = listbox.locator('[role="option"][tabindex="0"]');
+        await firstOption.click();
+
+        // Use id attribute pattern (works across frameworks: id ends with -option-{id} or data-option-id)
+        const appleOption = listbox.locator(
+          '[role="option"][id$="-option-apple"], [role="option"][data-option-id="apple"]'
+        );
+        const apricotOption = listbox.locator(
+          '[role="option"][id$="-option-apricot"], [role="option"][data-option-id="apricot"]'
+        );
+
+        // Press 'a' - should stay on Apple (first match)
+        await page.keyboard.press('a');
+        await expect(appleOption).toHaveAttribute('tabindex', '0');
+
+        // Press 'a' again - should cycle to Apricot (next match)
+        await page.keyboard.press('a');
+        await expect(apricotOption).toHaveAttribute('tabindex', '0');
+
+        // Press 'a' again - should cycle back to Apple
+        await page.keyboard.press('a');
+        await expect(appleOption).toHaveAttribute('tabindex', '0');
+      });
+
+      test('type-ahead buffer clears after timeout', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 0);
+        const firstOption = listbox.locator('[role="option"][tabindex="0"]');
+        const cherryOption = listbox.locator('[role="option"]', { hasText: 'Cherry' });
+        const dateOption = listbox.locator('[role="option"]', { hasText: 'Date' });
+
+        await firstOption.focus();
+        await page.keyboard.press('c'); // Focus Cherry
+        await expect(cherryOption).toHaveAttribute('tabindex', '0');
+
+        // Wait for buffer to clear (default 500ms + margin)
+        await page.waitForTimeout(600);
+
+        await page.keyboard.press('d'); // Should focus Date, not search for "cd"
+        await expect(dateOption).toHaveAttribute('tabindex', '0');
+      });
+
+      test('type-ahead updates selection in single-select', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 0);
+        const grapeOption = listbox.locator('[role="option"]', { hasText: 'Grape' });
+        const firstOption = listbox.locator('[role="option"][tabindex="0"]');
+
+        await firstOption.focus();
+        await page.keyboard.press('g');
+
+        // In single-select, selection follows focus
+        await expect(grapeOption).toHaveAttribute('aria-selected', 'true');
+      });
+    });
+
+    // =========================================================================
+    // Medium Priority: Mouse Interaction
+    // =========================================================================
+    test.describe('Mouse Interaction', () => {
+      test('clicking option selects it (single-select)', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 0);
+        const secondOption = listbox.locator('[role="option"]').nth(1);
+
+        await secondOption.click();
+        await expect(secondOption).toHaveAttribute('aria-selected', 'true');
+        await expect(secondOption).toHaveAttribute('tabindex', '0');
+      });
+
+      test('clicking option toggles selection (multi-select)', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 1);
+        const firstOption = getAvailableOptions(listbox).first();
+
+        // First click - select
+        await firstOption.click();
+        await expect(firstOption).toHaveAttribute('aria-selected', 'true');
+
+        // Second click - deselect
+        await firstOption.click();
+        await expect(firstOption).toHaveAttribute('aria-selected', 'false');
+      });
+
+      test('clicking disabled option does nothing', async ({ page }) => {
+        const listbox = getListboxByIndex(page, 1);
+        const disabledOption = listbox.locator('[role="option"][aria-disabled="true"]').first();
+        const selectedCountBefore = await getSelectedOptions(listbox).count();
+
+        await disabledOption.click({ force: true });
+
+        const selectedCountAfter = await getSelectedOptions(listbox).count();
+        expect(selectedCountAfter).toBe(selectedCountBefore);
+      });
+    });
+
+    // =========================================================================
+    // Medium Priority: Accessibility
+    // =========================================================================
+    test.describe('Accessibility', () => {
+      test('has no axe-core violations', async ({ page }) => {
+        const results = await new AxeBuilder({ page }).include('[role="listbox"]').analyze();
+        expect(results.violations).toEqual([]);
+      });
+    });
+  });
+}
+
+// =============================================================================
+// Cross-framework Consistency Tests
+// =============================================================================
+test.describe('Listbox - Cross-framework Consistency', () => {
+  test('all frameworks have listbox elements', async ({ page }) => {
+    for (const framework of frameworks) {
+      await page.goto(`patterns/listbox/${framework}/demo/`);
+      await page.waitForLoadState('networkidle');
+
+      const listboxes = page.locator('[role="listbox"]');
+      const count = await listboxes.count();
+      expect(count).toBe(3); // single-select, multi-select, horizontal
+    }
+  });
+
+  test('all frameworks have consistent ARIA structure', async ({ page }) => {
+    const ariaStructures: Record<
+      string,
+      {
+        hasAriaLabelledby: boolean;
+        ariaMultiselectable: string | null;
+        ariaOrientation: string | null;
+        optionCount: number;
+      }[]
+    > = {};
+
+    for (const framework of frameworks) {
+      await page.goto(`patterns/listbox/${framework}/demo/`);
+      await page.waitForLoadState('networkidle');
+
+      ariaStructures[framework] = await page.evaluate(() => {
+        const listboxes = document.querySelectorAll('[role="listbox"]');
+        return Array.from(listboxes).map((listbox) => ({
+          hasAriaLabelledby: listbox.hasAttribute('aria-labelledby'),
+          ariaMultiselectable: listbox.getAttribute('aria-multiselectable'),
+          ariaOrientation: listbox.getAttribute('aria-orientation'),
+          optionCount: listbox.querySelectorAll('[role="option"]').length,
+        }));
+      });
+    }
+
+    // All frameworks should have the same structure
+    const reactStructure = ariaStructures['react'];
+    for (const framework of frameworks) {
+      expect(ariaStructures[framework].length).toBe(reactStructure.length);
+      for (let i = 0; i < reactStructure.length; i++) {
+        expect(ariaStructures[framework][i].hasAriaLabelledby).toBe(
+          reactStructure[i].hasAriaLabelledby
+        );
+        expect(ariaStructures[framework][i].ariaMultiselectable).toBe(
+          reactStructure[i].ariaMultiselectable
+        );
+        expect(ariaStructures[framework][i].ariaOrientation).toBe(
+          reactStructure[i].ariaOrientation
+        );
+        expect(ariaStructures[framework][i].optionCount).toBe(reactStructure[i].optionCount);
+      }
+    }
+  });
+
+  test('all frameworks select correctly on click', async ({ page }) => {
+    for (const framework of frameworks) {
+      await page.goto(`patterns/listbox/${framework}/demo/`);
+      await page.waitForLoadState('networkidle');
+
+      // Test single-select listbox
+      const singleSelectListbox = page.locator('[role="listbox"]').first();
+      const secondOption = singleSelectListbox.locator('[role="option"]').nth(1);
+
+      await secondOption.click();
+      await expect(secondOption).toHaveAttribute('aria-selected', 'true');
+    }
+  });
+
+  test('all frameworks handle keyboard navigation consistently', async ({ page }) => {
+    for (const framework of frameworks) {
+      await page.goto(`patterns/listbox/${framework}/demo/`);
+      await page.waitForLoadState('networkidle');
+
+      const listbox = page.locator('[role="listbox"]').first();
+      const options = listbox.locator('[role="option"]:not([aria-disabled="true"])');
+      const firstOption = options.first();
+      const secondOption = options.nth(1);
+
+      await firstOption.focus();
+      await page.keyboard.press('ArrowDown');
+
+      // Second option should now be focused and selected
+      await expect(secondOption).toHaveAttribute('tabindex', '0');
+      await expect(secondOption).toHaveAttribute('aria-selected', 'true');
+    }
+  });
+});

--- a/src/pages/ja/patterns/listbox/astro/demo/index.astro
+++ b/src/pages/ja/patterns/listbox/astro/demo/index.astro
@@ -1,0 +1,94 @@
+---
+/**
+ * Demo-only Page: Listbox (Astro) - Japanese
+ *
+ * This page renders the Listbox component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import Listbox from '@patterns/listbox/Listbox.astro';
+
+const fruitOptions = [
+  { id: 'apple', label: 'りんご' },
+  { id: 'apricot', label: 'アプリコット' },
+  { id: 'banana', label: 'バナナ' },
+  { id: 'cherry', label: 'さくらんぼ' },
+  { id: 'date', label: 'デーツ' },
+  { id: 'elderberry', label: 'エルダーベリー' },
+  { id: 'fig', label: 'いちじく' },
+  { id: 'grape', label: 'ぶどう' },
+];
+
+const colorOptions = [
+  { id: 'red', label: '赤' },
+  { id: 'orange', label: 'オレンジ' },
+  { id: 'yellow', label: '黄' },
+  { id: 'green', label: '緑', disabled: true },
+  { id: 'blue', label: '青' },
+  { id: 'indigo', label: '藍' },
+  { id: 'purple', label: '紫' },
+];
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: リストボックス (Astro)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-8">
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">単一選択リストボックス</h2>
+        <div class="space-y-4">
+          <div>
+            <label id="fruit-label-astro-ja" class="mb-2 block text-sm font-medium">
+              フルーツを選択:
+            </label>
+            <Listbox
+              options={fruitOptions}
+              aria-labelledby="fruit-label-astro-ja"
+              defaultSelectedIds={['apple']}
+            />
+          </div>
+        </div>
+      </section>
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">複数選択リストボックス</h2>
+        <div class="space-y-4">
+          <div>
+            <label id="color-label-astro-ja" class="mb-2 block text-sm font-medium">
+              色を選択（複数可）:
+            </label>
+            <Listbox
+              options={colorOptions}
+              aria-labelledby="color-label-astro-ja"
+              multiselectable
+            />
+          </div>
+          <p class="text-muted-foreground text-xs">
+            ヒント: Spaceで選択切替、Shift+矢印で範囲選択、Ctrl+Aで全選択
+          </p>
+        </div>
+      </section>
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">水平リストボックス</h2>
+        <div class="space-y-4">
+          <div>
+            <label id="horizontal-label-astro-ja" class="mb-2 block text-sm font-medium">
+              フルーツを選択（水平）:
+            </label>
+            <Listbox
+              options={fruitOptions.slice(0, 5)}
+              aria-labelledby="horizontal-label-astro-ja"
+              orientation="horizontal"
+              defaultSelectedIds={['apple']}
+            />
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/listbox/astro/index.astro
+++ b/src/pages/ja/patterns/listbox/astro/index.astro
@@ -118,6 +118,9 @@ const colorOptions = [
         />
       </div>
     </div>
+    <p class="text-muted-foreground mt-4 text-sm">
+      <a href="./demo/" class="text-primary hover:underline">デモのみを開く →</a>
+    </p>
   </section>
 
   <!-- Accessibility Section -->

--- a/src/pages/ja/patterns/listbox/react/demo/index.astro
+++ b/src/pages/ja/patterns/listbox/react/demo/index.astro
@@ -1,0 +1,98 @@
+---
+/**
+ * Demo-only Page: Listbox (React) - Japanese
+ *
+ * This page renders the Listbox component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import { Listbox } from '@patterns/listbox/Listbox';
+import { useState } from 'react';
+
+const fruitOptions = [
+  { id: 'apple', label: 'りんご' },
+  { id: 'apricot', label: 'アプリコット' },
+  { id: 'banana', label: 'バナナ' },
+  { id: 'cherry', label: 'さくらんぼ' },
+  { id: 'date', label: 'デーツ' },
+  { id: 'elderberry', label: 'エルダーベリー' },
+  { id: 'fig', label: 'いちじく' },
+  { id: 'grape', label: 'ぶどう' },
+];
+
+const colorOptions = [
+  { id: 'red', label: '赤' },
+  { id: 'orange', label: 'オレンジ' },
+  { id: 'yellow', label: '黄' },
+  { id: 'green', label: '緑', disabled: true },
+  { id: 'blue', label: '青' },
+  { id: 'indigo', label: '藍' },
+  { id: 'purple', label: '紫' },
+];
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: リストボックス (React)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-8">
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">単一選択リストボックス</h2>
+        <div class="space-y-4">
+          <div>
+            <label id="fruit-label-ja" class="mb-2 block text-sm font-medium">
+              フルーツを選択:
+            </label>
+            <Listbox
+              client:load
+              options={fruitOptions}
+              aria-labelledby="fruit-label-ja"
+              defaultSelectedIds={['apple']}
+            />
+          </div>
+        </div>
+      </section>
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">複数選択リストボックス</h2>
+        <div class="space-y-4">
+          <div>
+            <label id="color-label-ja" class="mb-2 block text-sm font-medium">
+              色を選択（複数可）:
+            </label>
+            <Listbox
+              client:load
+              options={colorOptions}
+              aria-labelledby="color-label-ja"
+              multiselectable
+            />
+          </div>
+          <p class="text-muted-foreground text-xs">
+            ヒント: Spaceで選択切替、Shift+矢印で範囲選択、Ctrl+Aで全選択
+          </p>
+        </div>
+      </section>
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">水平リストボックス</h2>
+        <div class="space-y-4">
+          <div>
+            <label id="horizontal-label-ja" class="mb-2 block text-sm font-medium">
+              フルーツを選択（水平）:
+            </label>
+            <Listbox
+              client:load
+              options={fruitOptions.slice(0, 5)}
+              aria-labelledby="horizontal-label-ja"
+              orientation="horizontal"
+              defaultSelectedIds={['apple']}
+            />
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/listbox/react/index.astro
+++ b/src/pages/ja/patterns/listbox/react/index.astro
@@ -89,6 +89,9 @@ const tocItems = [
         <HorizontalListboxDemo client:load />
       </div>
     </div>
+    <p class="text-muted-foreground mt-4 text-sm">
+      <a href="./demo/" class="text-primary hover:underline">デモのみを開く →</a>
+    </p>
   </section>
 
   <!-- Accessibility Section -->

--- a/src/pages/ja/patterns/listbox/svelte/demo/index.astro
+++ b/src/pages/ja/patterns/listbox/svelte/demo/index.astro
@@ -1,0 +1,73 @@
+---
+/**
+ * Demo-only Page: Listbox (Svelte) - Japanese
+ *
+ * This page renders the Listbox component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import ListboxDemo from '@patterns/listbox/ListboxDemo.svelte';
+
+const fruitOptions = [
+  { id: 'apple', label: 'りんご' },
+  { id: 'apricot', label: 'アプリコット' },
+  { id: 'banana', label: 'バナナ' },
+  { id: 'cherry', label: 'さくらんぼ' },
+  { id: 'date', label: 'デーツ' },
+  { id: 'elderberry', label: 'エルダーベリー' },
+  { id: 'fig', label: 'いちじく' },
+  { id: 'grape', label: 'ぶどう' },
+];
+
+const colorOptions = [
+  { id: 'red', label: '赤' },
+  { id: 'orange', label: 'オレンジ' },
+  { id: 'yellow', label: '黄' },
+  { id: 'green', label: '緑', disabled: true },
+  { id: 'blue', label: '青' },
+  { id: 'indigo', label: '藍' },
+  { id: 'purple', label: '紫' },
+];
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: リストボックス (Svelte)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-8">
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">単一選択リストボックス</h2>
+        <ListboxDemo
+          client:load
+          options={fruitOptions}
+          label="フルーツを選択:"
+          defaultSelectedIds={['apple']}
+        />
+      </section>
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">複数選択リストボックス</h2>
+        <ListboxDemo
+          client:load
+          options={colorOptions}
+          label="色を選択（複数可）:"
+          multiselectable
+        />
+      </section>
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">水平リストボックス</h2>
+        <ListboxDemo
+          client:load
+          options={fruitOptions.slice(0, 5)}
+          label="フルーツを選択（水平）:"
+          orientation="horizontal"
+          defaultSelectedIds={['apple']}
+        />
+      </section>
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/listbox/svelte/index.astro
+++ b/src/pages/ja/patterns/listbox/svelte/index.astro
@@ -115,6 +115,9 @@ const colorOptions = [
         />
       </div>
     </div>
+    <p class="text-muted-foreground mt-4 text-sm">
+      <a href="./demo/" class="text-primary hover:underline">デモのみを開く →</a>
+    </p>
   </section>
 
   <!-- Accessibility Section -->

--- a/src/pages/ja/patterns/listbox/vue/demo/index.astro
+++ b/src/pages/ja/patterns/listbox/vue/demo/index.astro
@@ -1,0 +1,73 @@
+---
+/**
+ * Demo-only Page: Listbox (Vue) - Japanese
+ *
+ * This page renders the Listbox component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import ListboxDemo from '@patterns/listbox/ListboxDemo.vue';
+
+const fruitOptions = [
+  { id: 'apple', label: 'りんご' },
+  { id: 'apricot', label: 'アプリコット' },
+  { id: 'banana', label: 'バナナ' },
+  { id: 'cherry', label: 'さくらんぼ' },
+  { id: 'date', label: 'デーツ' },
+  { id: 'elderberry', label: 'エルダーベリー' },
+  { id: 'fig', label: 'いちじく' },
+  { id: 'grape', label: 'ぶどう' },
+];
+
+const colorOptions = [
+  { id: 'red', label: '赤' },
+  { id: 'orange', label: 'オレンジ' },
+  { id: 'yellow', label: '黄' },
+  { id: 'green', label: '緑', disabled: true },
+  { id: 'blue', label: '青' },
+  { id: 'indigo', label: '藍' },
+  { id: 'purple', label: '紫' },
+];
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>デモ: リストボックス (Vue)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-8">
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">単一選択リストボックス</h2>
+        <ListboxDemo
+          client:load
+          options={fruitOptions}
+          label="フルーツを選択:"
+          defaultSelectedIds={['apple']}
+        />
+      </section>
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">複数選択リストボックス</h2>
+        <ListboxDemo
+          client:load
+          options={colorOptions}
+          label="色を選択（複数可）:"
+          multiselectable
+        />
+      </section>
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">水平リストボックス</h2>
+        <ListboxDemo
+          client:load
+          options={fruitOptions.slice(0, 5)}
+          label="フルーツを選択（水平）:"
+          orientation="horizontal"
+          defaultSelectedIds={['apple']}
+        />
+      </section>
+    </div>
+  </body>
+</html>

--- a/src/pages/ja/patterns/listbox/vue/index.astro
+++ b/src/pages/ja/patterns/listbox/vue/index.astro
@@ -117,6 +117,9 @@ const colorOptions = [
         />
       </div>
     </div>
+    <p class="text-muted-foreground mt-4 text-sm">
+      <a href="./demo/" class="text-primary hover:underline">デモのみを開く →</a>
+    </p>
   </section>
 
   <!-- Accessibility Section -->

--- a/src/pages/patterns/listbox/astro/demo/index.astro
+++ b/src/pages/patterns/listbox/astro/demo/index.astro
@@ -1,0 +1,90 @@
+---
+/**
+ * Demo-only Page: Listbox (Astro)
+ *
+ * This page renders the Listbox component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import Listbox from '@patterns/listbox/Listbox.astro';
+
+const fruitOptions = [
+  { id: 'apple', label: 'Apple' },
+  { id: 'apricot', label: 'Apricot' },
+  { id: 'banana', label: 'Banana' },
+  { id: 'cherry', label: 'Cherry' },
+  { id: 'date', label: 'Date' },
+  { id: 'elderberry', label: 'Elderberry' },
+  { id: 'fig', label: 'Fig' },
+  { id: 'grape', label: 'Grape' },
+];
+
+const colorOptions = [
+  { id: 'red', label: 'Red' },
+  { id: 'orange', label: 'Orange' },
+  { id: 'yellow', label: 'Yellow' },
+  { id: 'green', label: 'Green', disabled: true },
+  { id: 'blue', label: 'Blue' },
+  { id: 'indigo', label: 'Indigo' },
+  { id: 'purple', label: 'Purple' },
+];
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Demo: Listbox (Astro)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-8">
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">Single-Select Listbox</h2>
+        <div class="space-y-4">
+          <div>
+            <label id="fruit-label-astro" class="mb-2 block text-sm font-medium">
+              Choose a fruit:
+            </label>
+            <Listbox
+              options={fruitOptions}
+              aria-labelledby="fruit-label-astro"
+              defaultSelectedIds={['apple']}
+            />
+          </div>
+        </div>
+      </section>
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">Multi-Select Listbox</h2>
+        <div class="space-y-4">
+          <div>
+            <label id="color-label-astro" class="mb-2 block text-sm font-medium">
+              Choose colors (multiple):
+            </label>
+            <Listbox options={colorOptions} aria-labelledby="color-label-astro" multiselectable />
+          </div>
+          <p class="text-muted-foreground text-xs">
+            Tip: Use Space to toggle, Shift+Arrow to extend selection, Ctrl+A to select all
+          </p>
+        </div>
+      </section>
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">Horizontal Listbox</h2>
+        <div class="space-y-4">
+          <div>
+            <label id="horizontal-label-astro" class="mb-2 block text-sm font-medium">
+              Choose a fruit (horizontal):
+            </label>
+            <Listbox
+              options={fruitOptions.slice(0, 5)}
+              aria-labelledby="horizontal-label-astro"
+              orientation="horizontal"
+              defaultSelectedIds={['apple']}
+            />
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/src/pages/patterns/listbox/astro/index.astro
+++ b/src/pages/patterns/listbox/astro/index.astro
@@ -108,6 +108,9 @@ const colorOptions = [
         />
       </div>
     </div>
+    <p class="text-muted-foreground mt-4 text-sm">
+      <a href="./demo/" class="text-primary hover:underline">Open demo only →</a>
+    </p>
   </section>
 
   <!-- Accessibility Section -->

--- a/src/pages/patterns/listbox/react/demo/index.astro
+++ b/src/pages/patterns/listbox/react/demo/index.astro
@@ -1,0 +1,40 @@
+---
+/**
+ * Demo-only Page: Listbox (React)
+ *
+ * This page renders the Listbox component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import {
+  SingleSelectListboxDemo,
+  MultiSelectListboxDemo,
+  HorizontalListboxDemo,
+} from '@patterns/listbox/ListboxDemo';
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Demo: Listbox (React)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-8">
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">Single-Select Listbox</h2>
+        <SingleSelectListboxDemo client:load />
+      </section>
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">Multi-Select Listbox</h2>
+        <MultiSelectListboxDemo client:load />
+      </section>
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">Horizontal Listbox</h2>
+        <HorizontalListboxDemo client:load />
+      </section>
+    </div>
+  </body>
+</html>

--- a/src/pages/patterns/listbox/react/index.astro
+++ b/src/pages/patterns/listbox/react/index.astro
@@ -79,6 +79,9 @@ const tocItems = [
         <HorizontalListboxDemo client:load />
       </div>
     </div>
+    <p class="text-muted-foreground mt-4 text-sm">
+      <a href="./demo/" class="text-primary hover:underline">Open demo only →</a>
+    </p>
   </section>
 
   <!-- Accessibility Section -->

--- a/src/pages/patterns/listbox/svelte/demo/index.astro
+++ b/src/pages/patterns/listbox/svelte/demo/index.astro
@@ -1,0 +1,73 @@
+---
+/**
+ * Demo-only Page: Listbox (Svelte)
+ *
+ * This page renders the Listbox component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import ListboxDemo from '@patterns/listbox/ListboxDemo.svelte';
+
+const fruitOptions = [
+  { id: 'apple', label: 'Apple' },
+  { id: 'apricot', label: 'Apricot' },
+  { id: 'banana', label: 'Banana' },
+  { id: 'cherry', label: 'Cherry' },
+  { id: 'date', label: 'Date' },
+  { id: 'elderberry', label: 'Elderberry' },
+  { id: 'fig', label: 'Fig' },
+  { id: 'grape', label: 'Grape' },
+];
+
+const colorOptions = [
+  { id: 'red', label: 'Red' },
+  { id: 'orange', label: 'Orange' },
+  { id: 'yellow', label: 'Yellow' },
+  { id: 'green', label: 'Green', disabled: true },
+  { id: 'blue', label: 'Blue' },
+  { id: 'indigo', label: 'Indigo' },
+  { id: 'purple', label: 'Purple' },
+];
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Demo: Listbox (Svelte)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-8">
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">Single-Select Listbox</h2>
+        <ListboxDemo
+          client:load
+          options={fruitOptions}
+          label="Choose a fruit:"
+          defaultSelectedIds={['apple']}
+        />
+      </section>
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">Multi-Select Listbox</h2>
+        <ListboxDemo
+          client:load
+          options={colorOptions}
+          label="Choose colors (multiple):"
+          multiselectable
+        />
+      </section>
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">Horizontal Listbox</h2>
+        <ListboxDemo
+          client:load
+          options={fruitOptions.slice(0, 5)}
+          label="Choose a fruit (horizontal):"
+          orientation="horizontal"
+          defaultSelectedIds={['apple']}
+        />
+      </section>
+    </div>
+  </body>
+</html>

--- a/src/pages/patterns/listbox/svelte/index.astro
+++ b/src/pages/patterns/listbox/svelte/index.astro
@@ -105,6 +105,9 @@ const colorOptions = [
         />
       </div>
     </div>
+    <p class="text-muted-foreground mt-4 text-sm">
+      <a href="./demo/" class="text-primary hover:underline">Open demo only →</a>
+    </p>
   </section>
 
   <!-- Accessibility Section -->

--- a/src/pages/patterns/listbox/vue/demo/index.astro
+++ b/src/pages/patterns/listbox/vue/demo/index.astro
@@ -1,0 +1,73 @@
+---
+/**
+ * Demo-only Page: Listbox (Vue)
+ *
+ * This page renders the Listbox component in isolation without
+ * the site layout. This ensures clean E2E testing environment.
+ */
+import '@/styles/global.css';
+import ListboxDemo from '@patterns/listbox/ListboxDemo.vue';
+
+const fruitOptions = [
+  { id: 'apple', label: 'Apple' },
+  { id: 'apricot', label: 'Apricot' },
+  { id: 'banana', label: 'Banana' },
+  { id: 'cherry', label: 'Cherry' },
+  { id: 'date', label: 'Date' },
+  { id: 'elderberry', label: 'Elderberry' },
+  { id: 'fig', label: 'Fig' },
+  { id: 'grape', label: 'Grape' },
+];
+
+const colorOptions = [
+  { id: 'red', label: 'Red' },
+  { id: 'orange', label: 'Orange' },
+  { id: 'yellow', label: 'Yellow' },
+  { id: 'green', label: 'Green', disabled: true },
+  { id: 'blue', label: 'Blue' },
+  { id: 'indigo', label: 'Indigo' },
+  { id: 'purple', label: 'Purple' },
+];
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Demo: Listbox (Vue)</title>
+  </head>
+  <body class="p-8">
+    <div class="flex flex-col items-start gap-8">
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">Single-Select Listbox</h2>
+        <ListboxDemo
+          client:load
+          options={fruitOptions}
+          label="Choose a fruit:"
+          defaultSelectedIds={['apple']}
+        />
+      </section>
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">Multi-Select Listbox</h2>
+        <ListboxDemo
+          client:load
+          options={colorOptions}
+          label="Choose colors (multiple):"
+          multiselectable
+        />
+      </section>
+      <section>
+        <h2 class="mb-4 text-lg font-semibold">Horizontal Listbox</h2>
+        <ListboxDemo
+          client:load
+          options={fruitOptions.slice(0, 5)}
+          label="Choose a fruit (horizontal):"
+          orientation="horizontal"
+          defaultSelectedIds={['apple']}
+        />
+      </section>
+    </div>
+  </body>
+</html>

--- a/src/pages/patterns/listbox/vue/index.astro
+++ b/src/pages/patterns/listbox/vue/index.astro
@@ -105,6 +105,9 @@ const colorOptions = [
         />
       </div>
     </div>
+    <p class="text-muted-foreground mt-4 text-sm">
+      <a href="./demo/" class="text-primary hover:underline">Open demo only →</a>
+    </p>
   </section>
 
   <!-- Accessibility Section -->

--- a/src/patterns/listbox/Listbox.astro
+++ b/src/patterns/listbox/Listbox.astro
@@ -306,7 +306,7 @@ const listboxTabIndex = availableOptions.length === 0 ? 0 : undefined;
       for (let i = 0; i < options.length; i++) {
         const index = (startIndex + i) % options.length;
         const option = options[index];
-        const label = option.textContent?.toLowerCase() || '';
+        const label = option.textContent?.trim().toLowerCase() || '';
         const searchStr = isSameChar ? buffer[0] : this.typeAheadBuffer;
 
         if (label.startsWith(searchStr)) {

--- a/src/patterns/listbox/ListboxDemo.tsx
+++ b/src/patterns/listbox/ListboxDemo.tsx
@@ -3,6 +3,7 @@ import { Listbox, type ListboxOption } from './Listbox';
 
 const fruitOptions: ListboxOption[] = [
   { id: 'apple', label: 'Apple' },
+  { id: 'apricot', label: 'Apricot' },
   { id: 'banana', label: 'Banana' },
   { id: 'cherry', label: 'Cherry' },
   { id: 'date', label: 'Date' },

--- a/src/patterns/listbox/TestingDocs.astro
+++ b/src/patterns/listbox/TestingDocs.astro
@@ -1,19 +1,59 @@
 ---
 import ExternalLink from '@/components/ui/ExternalLink.astro';
 import { ResponsiveTable } from '@/components/ui/table';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Read actual test file at build time
+const e2eTestPath = path.join(process.cwd(), 'e2e/listbox.spec.ts');
+const e2eTestCode = fs.readFileSync(e2eTestPath, 'utf-8');
 ---
 
 <div class="prose dark:prose-invert max-w-none">
   <p class="text-muted-foreground mb-4">
-    Tests verify APG compliance across keyboard interaction, ARIA attributes, and accessibility
-    requirements.
+    Tests verify APG compliance for ARIA attributes, keyboard interactions, selection behavior, and
+    accessibility requirements. The Listbox component uses a two-layer testing strategy.
   </p>
+
+  <h3 class="mb-3 text-lg font-medium">Testing Strategy</h3>
+
+  <div class="bg-muted/50 mb-6 rounded-lg p-4">
+    <h4 class="mb-2 font-medium">Unit Tests (Testing Library)</h4>
+    <p class="text-muted-foreground mb-2 text-sm">
+      Verify the component's rendered output using framework-specific testing libraries. These tests
+      ensure correct HTML structure and ARIA attributes.
+    </p>
+    <ul class="text-muted-foreground list-disc space-y-1 pl-6 text-sm">
+      <li>ARIA attributes (role, aria-selected, aria-multiselectable, etc.)</li>
+      <li>Keyboard interaction (Arrow keys, Space, Home/End, etc.)</li>
+      <li>Selection behavior (single-select, multi-select)</li>
+      <li>Accessibility via jest-axe</li>
+    </ul>
+  </div>
+
+  <div class="bg-muted/50 mb-6 rounded-lg p-4">
+    <h4 class="mb-2 font-medium">E2E Tests (Playwright)</h4>
+    <p class="text-muted-foreground mb-2 text-sm">
+      Verify component behavior in a real browser environment across all frameworks. These tests
+      cover interactions and cross-framework consistency.
+    </p>
+    <ul class="text-muted-foreground list-disc space-y-1 pl-6 text-sm">
+      <li>Keyboard navigation (single-select, multi-select, horizontal)</li>
+      <li>Mouse interactions (click selection, toggle)</li>
+      <li>ARIA structure in live browser</li>
+      <li>Focus management with roving tabindex</li>
+      <li>Type-ahead character navigation</li>
+      <li>axe-core accessibility scanning</li>
+      <li>Cross-framework consistency checks</li>
+    </ul>
+  </div>
 
   <h3 class="mb-3 text-lg font-medium">Test Categories</h3>
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
-    High Priority: APG Keyboard Interaction
+    High Priority: APG Keyboard Interaction (Unit + E2E)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -74,7 +114,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
-    High Priority: APG ARIA Attributes
+    High Priority: APG ARIA Attributes (Unit + E2E)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -119,7 +159,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
-    High Priority: Focus Management (Roving Tabindex)
+    High Priority: Focus Management - Roving Tabindex (Unit + E2E)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -152,7 +192,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-yellow-500"></span>
-    Medium Priority: Accessibility
+    Medium Priority: Accessibility (Unit + E2E)
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -165,11 +205,85 @@ import { ResponsiveTable } from '@/components/ui/table';
       <tbody>
         <tr class="border-border border-b">
           <td class="py-2 pr-4"><code>axe violations</code></td>
-          <td class="py-2">No WCAG 2.1 AA violations (via jest-axe)</td>
+          <td class="py-2">No WCAG 2.1 AA violations (via jest-axe/axe-core)</td>
         </tr>
       </tbody>
     </table>
   </ResponsiveTable>
+
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-yellow-500"></span>
+    Medium Priority: Mouse Interaction (E2E)
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">Test</th>
+          <th class="py-2 text-left">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Click option</code></td>
+          <td class="py-2">Selects option on click (single-select)</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Click toggle</code></td>
+          <td class="py-2">Toggles selection on click (multi-select)</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Click disabled</code></td>
+          <td class="py-2">Disabled options cannot be selected</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-green-500"></span>
+    Low Priority: Cross-framework Consistency (E2E)
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">Test</th>
+          <th class="py-2 text-left">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>All frameworks have listbox</code></td>
+          <td class="py-2">React, Vue, Svelte, Astro all render listbox elements</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Consistent ARIA</code></td>
+          <td class="py-2">All frameworks have consistent ARIA structure</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Select on click</code></td>
+          <td class="py-2">All frameworks select correctly on click</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Keyboard navigation</code></td>
+          <td class="py-2">All frameworks respond to keyboard navigation consistently</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h3 class="mb-3 text-lg font-medium">Example Test Code</h3>
+  <p class="text-muted-foreground mb-4 text-sm">
+    The following is the actual E2E test file (<code>e2e/listbox.spec.ts</code>).
+  </p>
+  <CodeBlock
+    code={e2eTestCode}
+    lang="typescript"
+    title="e2e/listbox.spec.ts"
+    collapsible
+    collapsedLines={20}
+  />
 
   <h3 class="mb-3 text-lg font-medium">Testing Tools</h3>
   <ul class="mb-6 list-disc space-y-2 pl-6">
@@ -177,20 +291,26 @@ import { ResponsiveTable } from '@/components/ui/table';
       <ExternalLink href="https://vitest.dev/" class="text-primary hover:underline"
         >Vitest</ExternalLink
       >
-      - Test runner
+      - Test runner for unit tests
     </li>
     <li>
       <ExternalLink href="https://testing-library.com/" class="text-primary hover:underline"
         >Testing Library</ExternalLink
       >
-      - Framework-specific testing utilities
+      - Framework-specific testing utilities (React, Vue, Svelte)
+    </li>
+    <li>
+      <ExternalLink href="https://playwright.dev/" class="text-primary hover:underline"
+        >Playwright</ExternalLink
+      >
+      - Browser automation for E2E tests
     </li>
     <li>
       <ExternalLink
-        href="https://github.com/nickcolley/jest-axe"
-        class="text-primary hover:underline">jest-axe</ExternalLink
+        href="https://github.com/dequelabs/axe-core-npm/tree/develop/packages/playwright"
+        class="text-primary hover:underline">axe-core/playwright</ExternalLink
       >
-      - Automated accessibility testing
+      - Automated accessibility testing in E2E
     </li>
   </ul>
 

--- a/src/patterns/listbox/TestingDocs.ja.astro
+++ b/src/patterns/listbox/TestingDocs.ja.astro
@@ -1,18 +1,59 @@
 ---
 import ExternalLink from '@/components/ui/ExternalLink.astro';
 import { ResponsiveTable } from '@/components/ui/table';
+import CodeBlock from '@/components/ui/CodeBlock.astro';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Read actual test file at build time
+const e2eTestPath = path.join(process.cwd(), 'e2e/listbox.spec.ts');
+const e2eTestCode = fs.readFileSync(e2eTestPath, 'utf-8');
 ---
 
 <div class="prose dark:prose-invert max-w-none">
   <p class="text-muted-foreground mb-4">
-    テストは、キーボード操作、ARIA属性、アクセシビリティ要件全般にわたってAPG準拠を検証します。
+    テストは、ARIA属性、キーボード操作、選択動作、アクセシビリティ要件全般にわたってAPG準拠を検証します。
+    Listboxコンポーネントは2層のテスト戦略を採用しています。
   </p>
+
+  <h3 class="mb-3 text-lg font-medium">テスト戦略</h3>
+
+  <div class="bg-muted/50 mb-6 rounded-lg p-4">
+    <h4 class="mb-2 font-medium">ユニットテスト（Testing Library）</h4>
+    <p class="text-muted-foreground mb-2 text-sm">
+      フレームワーク固有のテストライブラリを使用して、コンポーネントのレンダリング出力を検証します。
+      正しいHTML構造とARIA属性を確認します。
+    </p>
+    <ul class="text-muted-foreground list-disc space-y-1 pl-6 text-sm">
+      <li>ARIA属性（role、aria-selected、aria-multiselectable など）</li>
+      <li>キーボード操作（矢印キー、Space、Home/End など）</li>
+      <li>選択動作（単一選択、複数選択）</li>
+      <li>jest-axeによるアクセシビリティ</li>
+    </ul>
+  </div>
+
+  <div class="bg-muted/50 mb-6 rounded-lg p-4">
+    <h4 class="mb-2 font-medium">E2Eテスト（Playwright）</h4>
+    <p class="text-muted-foreground mb-2 text-sm">
+      全フレームワークで実際のブラウザ環境でコンポーネントの動作を検証します。
+      インタラクションとクロスフレームワークの一貫性をカバーします。
+    </p>
+    <ul class="text-muted-foreground list-disc space-y-1 pl-6 text-sm">
+      <li>キーボードナビゲーション（単一選択、複数選択、水平方向）</li>
+      <li>マウス操作（クリック選択、トグル）</li>
+      <li>ライブブラウザでのARIA構造</li>
+      <li>ローヴィングタブインデックスによるフォーカス管理</li>
+      <li>タイプアヘッド文字ナビゲーション</li>
+      <li>axe-coreアクセシビリティスキャン</li>
+      <li>クロスフレームワーク一貫性チェック</li>
+    </ul>
+  </div>
 
   <h3 class="mb-3 text-lg font-medium">テストカテゴリ</h3>
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
-    高優先度: APG キーボード操作
+    高優先度: APG キーボード操作（Unit + E2E）
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -73,7 +114,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
-    高優先度: APG ARIA 属性
+    高優先度: APG ARIA 属性（Unit + E2E）
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -118,7 +159,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-red-500"></span>
-    高優先度: フォーカス管理（ローヴィングタブインデックス）
+    高優先度: フォーカス管理 - ローヴィングタブインデックス（Unit + E2E）
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -151,7 +192,7 @@ import { ResponsiveTable } from '@/components/ui/table';
 
   <h4 class="mb-2 flex items-center gap-2 font-medium">
     <span class="inline-block h-3 w-3 rounded-full bg-yellow-500"></span>
-    中優先度: アクセシビリティ
+    中優先度: アクセシビリティ（Unit + E2E）
   </h4>
   <ResponsiveTable class="mb-6">
     <table class="w-full border-collapse">
@@ -164,11 +205,85 @@ import { ResponsiveTable } from '@/components/ui/table';
       <tbody>
         <tr class="border-border border-b">
           <td class="py-2 pr-4"><code>axe violations</code></td>
-          <td class="py-2">WCAG 2.1 AA違反がないこと（jest-axe経由）</td>
+          <td class="py-2">WCAG 2.1 AA違反がないこと（jest-axe/axe-core経由）</td>
         </tr>
       </tbody>
     </table>
   </ResponsiveTable>
+
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-yellow-500"></span>
+    中優先度: マウス操作（E2E）
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">テスト</th>
+          <th class="py-2 text-left">説明</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Click option</code></td>
+          <td class="py-2">クリックでオプションを選択（単一選択）</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Click toggle</code></td>
+          <td class="py-2">クリックで選択をトグル（複数選択）</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Click disabled</code></td>
+          <td class="py-2">無効化されたオプションは選択できない</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h4 class="mb-2 flex items-center gap-2 font-medium">
+    <span class="inline-block h-3 w-3 rounded-full bg-green-500"></span>
+    低優先度: クロスフレームワーク一貫性（E2E）
+  </h4>
+  <ResponsiveTable class="mb-6">
+    <table class="w-full border-collapse">
+      <thead>
+        <tr class="border-border border-b">
+          <th class="py-2 pr-4 text-left">テスト</th>
+          <th class="py-2 text-left">説明</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>All frameworks have listbox</code></td>
+          <td class="py-2">React、Vue、Svelte、Astro全てがlistbox要素をレンダリング</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Consistent ARIA</code></td>
+          <td class="py-2">全フレームワークで一貫したARIA構造</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Select on click</code></td>
+          <td class="py-2">全フレームワークでクリック時に正しく選択</td>
+        </tr>
+        <tr class="border-border border-b">
+          <td class="py-2 pr-4"><code>Keyboard navigation</code></td>
+          <td class="py-2">全フレームワークでキーボードナビゲーションが一貫して動作</td>
+        </tr>
+      </tbody>
+    </table>
+  </ResponsiveTable>
+
+  <h3 class="mb-3 text-lg font-medium">テストコード例</h3>
+  <p class="text-muted-foreground mb-4 text-sm">
+    以下は実際のE2Eテストファイル（<code>e2e/listbox.spec.ts</code>）です。
+  </p>
+  <CodeBlock
+    code={e2eTestCode}
+    lang="typescript"
+    title="e2e/listbox.spec.ts"
+    collapsible
+    collapsedLines={20}
+  />
 
   <h3 class="mb-3 text-lg font-medium">テストツール</h3>
   <ul class="mb-6 list-disc space-y-2 pl-6">
@@ -176,20 +291,26 @@ import { ResponsiveTable } from '@/components/ui/table';
       <ExternalLink href="https://vitest.dev/" class="text-primary hover:underline"
         >Vitest</ExternalLink
       >
-      - テストランナー
+      - ユニットテスト用テストランナー
     </li>
     <li>
       <ExternalLink href="https://testing-library.com/" class="text-primary hover:underline"
         >Testing Library</ExternalLink
       >
-      - フレームワーク固有のテストユーティリティ
+      - フレームワーク固有のテストユーティリティ（React、Vue、Svelte）
+    </li>
+    <li>
+      <ExternalLink href="https://playwright.dev/" class="text-primary hover:underline"
+        >Playwright</ExternalLink
+      >
+      - E2Eテスト用ブラウザ自動化
     </li>
     <li>
       <ExternalLink
-        href="https://github.com/nickcolley/jest-axe"
-        class="text-primary hover:underline">jest-axe</ExternalLink
+        href="https://github.com/dequelabs/axe-core-npm/tree/develop/packages/playwright"
+        class="text-primary hover:underline">axe-core/playwright</ExternalLink
       >
-      - 自動アクセシビリティテスト
+      - E2Eでの自動アクセシビリティテスト
     </li>
   </ul>
 

--- a/src/patterns/listbox/llm.md
+++ b/src/patterns/listbox/llm.md
@@ -199,3 +199,19 @@ it('type-ahead focuses matching option', async () => {
   expect(screen.getByRole('option', { name: 'Green' })).toHaveFocus();
 });
 ```
+
+## E2E Test Execution
+
+```bash
+# Run all listbox E2E tests
+npx playwright test listbox
+
+# Run for specific framework
+npx playwright test listbox --grep "react"
+npx playwright test listbox --grep "vue"
+npx playwright test listbox --grep "svelte"
+npx playwright test listbox --grep "astro"
+
+# Run in UI mode for debugging
+npm run test:e2e:ui -- --grep listbox
+```


### PR DESCRIPTION
## Summary

- Listbox パターンの包括的な E2E テストを追加
- 全4フレームワーク（React, Vue, Svelte, Astro）で APG 準拠を検証
- TestingDocs に実際のテストコードを掲載するよう更新

## テストカバレッジ

### High Priority
- **ARIA Structure**: role="listbox/option", aria-selected, aria-multiselectable, aria-orientation, aria-disabled
- **Single-Select Keyboard**: ArrowDown/Up, Home/End, selection follows focus
- **Multi-Select Keyboard**: Space toggle, Shift+Arrow, Shift+Home/End, Ctrl+A
- **Horizontal Listbox**: ArrowRight/Left, ArrowUp/Down ignored
- **Focus Management**: roving tabindex, Tab exit, focus restoration
- **Type-ahead**: single char, prefix match, cycling, buffer timeout

### Medium Priority
- **Mouse Interaction**: click select/toggle, disabled handling
- **Accessibility**: axe-core scanning

### Low Priority
- **Cross-framework Consistency**: ARIA structure, click behavior, keyboard navigation

## 追加ファイル

| ファイル | 説明 |
|---------|------|
| `e2e/listbox.spec.ts` | E2E テスト本体（733行） |
| `src/pages/**/demo/index.astro` | E2E テスト用デモ単独ページ（8ファイル） |

## 更新ファイル

- `TestingDocs.astro` / `TestingDocs.ja.astro`: 実際のテストコードをビルド時に読み込んで表示
- `llm.md`: E2E テスト実行コマンドを追加
- パターンページ: デモ単独ページへのリンク追加

## Test plan

- [ ] `npm run test:e2e -- --grep listbox` で全テストがパス
- [ ] 各フレームワークのデモページ (`/patterns/listbox/{framework}/demo/`) が正常に表示
- [ ] TestingDocs セクションにテストコードが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)