### PR TITLE
fix: llm.md リンクを AiGuideBadge/AiGuideResourceItem に統一

### DIFF
--- a/src/components/ui/AiGuideBadge.astro
+++ b/src/components/ui/AiGuideBadge.astro
@@ -3,13 +3,13 @@ import { withBase } from '@/lib/utils';
 
 interface Props {
   pattern: string;
-  locale?: string;
+  locale?: string; // Kept for backward compatibility, but not used (llm.md is language-agnostic)
   class?: string;
 }
 
-const { pattern, locale, class: className } = Astro.props;
-const basePath = locale ? `/${locale}` : '';
-const href = withBase(`${basePath}/patterns/${pattern}/llm.md`);
+const { pattern, class: className } = Astro.props;
+// llm.md is always at the root patterns path (not language-specific)
+const href = withBase(`/patterns/${pattern}/llm.md`);
 ---
 
 <a

--- a/src/components/ui/AiGuideResourceItem.astro
+++ b/src/components/ui/AiGuideResourceItem.astro
@@ -4,12 +4,12 @@ import { withBase } from '@/lib/utils';
 
 interface Props {
   pattern: string;
-  locale?: string;
+  locale?: string; // Kept for backward compatibility, but not used (llm.md is language-agnostic)
 }
 
-const { pattern, locale } = Astro.props;
-const basePath = locale ? `/${locale}` : '';
-const href = withBase(`${basePath}/patterns/${pattern}/llm.md`);
+const { pattern } = Astro.props;
+// llm.md is always at the root patterns path (not language-specific)
+const href = withBase(`/patterns/${pattern}/llm.md`);
 ---
 
 <li>

--- a/src/pages/ja/patterns/accordion/astro/index.astro
+++ b/src/pages/ja/patterns/accordion/astro/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import Accordion from '@patterns/accordion/Accordion.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/accordion/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/accordion/TestingDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -100,15 +101,7 @@ const disabledItems = [
     <p class="text-muted-foreground text-lg">
       複数のセクションを縦に並べ、各セクションのヘッダーをクリックすることで内容を表示/非表示できるコンポーネント。
     </p>
-    <a
-      href={withBase('/patterns/accordion/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="accordion" />
   </header>
 
   <!-- Framework Selector -->
@@ -340,17 +333,7 @@ const items = [
           WAI-ARIA APG: Accordion パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/accordion/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA 仕様、キーボード操作、テストチェックリスト</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="accordion" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/accordion/react/index.astro
+++ b/src/pages/ja/patterns/accordion/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import Accordion from '@patterns/accordion/Accordion';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/accordion/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/accordion/TestingDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -100,15 +101,7 @@ const disabledItems = [
     <p class="text-muted-foreground text-lg">
       垂直に積み重ねられたインタラクティブな見出しのセット。各見出しをクリックするとコンテンツセクションが展開されます。
     </p>
-    <a
-      href={withBase('/patterns/accordion/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="accordion" />
   </header>
 
   <!-- Framework Selector -->
@@ -342,17 +335,7 @@ function App() {
           WAI-ARIA APG: Accordion パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/accordion/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="accordion" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/accordion/svelte/index.astro
+++ b/src/pages/ja/patterns/accordion/svelte/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import Accordion from '@patterns/accordion/Accordion.svelte';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/accordion/AccessibilityDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
@@ -100,15 +101,7 @@ const disabledItems = [
     <p class="text-muted-foreground text-lg">
       垂直に積み重ねられたインタラクティブな見出しのセットで、それぞれがコンテンツのセクションを表示します。
     </p>
-    <a
-      href={withBase('/patterns/accordion/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="accordion" />
   </header>
 
   <!-- Framework Selector -->
@@ -313,17 +306,7 @@ const disabledItems = [
           WAI-ARIA APG: Accordion パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/accordion/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA 仕様、キーボード操作、テストチェックリスト</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="accordion" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/accordion/vue/index.astro
+++ b/src/pages/ja/patterns/accordion/vue/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import Accordion from '@patterns/accordion/Accordion.vue';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/accordion/AccessibilityDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
@@ -100,15 +101,7 @@ const disabledItems = [
     <p class="text-muted-foreground text-lg">
       縦に積み重ねられたインタラクティブな見出しのセットで、それぞれがコンテンツのセクションを表示します。
     </p>
-    <a
-      href={withBase('/patterns/accordion/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="accordion" />
   </header>
 
   <!-- Framework Selector -->
@@ -320,17 +313,7 @@ const items = [
           WAI-ARIA APG: Accordion パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/accordion/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA 仕様、キーボード操作、テストチェックリスト</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="accordion" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/alert-dialog/react/index.astro
+++ b/src/pages/ja/patterns/alert-dialog/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import AlertDialogDemo from '@patterns/alert-dialog/AlertDialogDemo';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/alert-dialog/AccessibilityDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
@@ -39,15 +40,7 @@ const tocItems = [
     <p class="text-muted-foreground text-lg">
       ユーザーのワークフローを中断し、重要なメッセージを伝えて応答を求めるモーダルダイアログ。
     </p>
-    <a
-      href={withBase('/patterns/alert-dialog/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="alert-dialog" />
   </header>
 
   <!-- Framework Selector -->
@@ -260,17 +253,7 @@ function App() {
           WAI-ARIA APG: Alert Dialog パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/alert-dialog/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="alert-dialog" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/alert/react/index.astro
+++ b/src/pages/ja/patterns/alert/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import { AlertDemo } from '@patterns/alert/AlertDemo';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/alert/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/alert/TestingDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -39,15 +40,7 @@ const tocItems = [
     <p class="text-muted-foreground text-lg">
       ユーザーのタスクを中断せずに、重要なメッセージを目立つ形で表示する要素。
     </p>
-    <a
-      href={withBase('/patterns/alert/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="alert" />
   </header>
 
   <!-- Framework Selector -->
@@ -208,17 +201,7 @@ function App() {
           WAI-ARIA APG: Alert Dialog Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/alert/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="alert" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/breadcrumb/react/index.astro
+++ b/src/pages/ja/patterns/breadcrumb/react/index.astro
@@ -1,10 +1,11 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import { useTranslation } from '@/i18n';
 import Breadcrumb from '@patterns/breadcrumb/Breadcrumb';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/breadcrumb/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/breadcrumb/TestingDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -53,15 +54,7 @@ const longPathItems = [
     <p class="text-muted-foreground text-lg">
       現在のページから親ページへの階層的なリンクのリスト。
     </p>
-    <a
-      href={withBase('/patterns/breadcrumb/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="breadcrumb" />
   </header>
 
   <!-- Framework Selector -->
@@ -230,17 +223,7 @@ function App() {
           MDN: Breadcrumb Navigation
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/breadcrumb/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="breadcrumb" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/button/react/index.astro
+++ b/src/pages/ja/patterns/button/react/index.astro
@@ -1,10 +1,11 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import Heading from '@/components/ui/Heading.astro';
 import { MuteDemo, DarkModeDemo, NotificationsDemo } from '@patterns/button/ToggleButtonDemo';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/button/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/button/TestingDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -39,15 +40,7 @@ const tocItems = [
     <p class="text-muted-foreground text-lg">
       「押されている」または「押されていない」の2つの状態を持つボタン。
     </p>
-    <a
-      href={withBase('/patterns/button/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="button" />
   </header>
 
   <!-- Framework Selector -->
@@ -199,17 +192,7 @@ function App() {
           WAI-ARIA APG: Button パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/button/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA 仕様、キーボード操作、テストチェックリスト</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="button" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/button/vue/index.astro
+++ b/src/pages/ja/patterns/button/vue/index.astro
@@ -1,10 +1,11 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import Heading from '@/components/ui/Heading.astro';
 import ToggleButtonDemo from '@patterns/button/ToggleButtonDemo.vue';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/button/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/button/TestingDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -39,15 +40,7 @@ const tocItems = [
     <p class="text-muted-foreground text-lg">
       「押された」または「押されていない」の2つの状態を持つボタンです。
     </p>
-    <a
-      href={withBase('/patterns/button/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="button" />
   </header>
 
   <!-- Framework Selector -->
@@ -244,17 +237,7 @@ const handleToggle = (pressed) => {
           WAI-ARIA APG: Button パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/button/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA 仕様、キーボードサポート、テストチェックリスト</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="button" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/carousel/astro/index.astro
+++ b/src/pages/ja/patterns/carousel/astro/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import CarouselDemo from '@patterns/carousel/CarouselDemo.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/carousel/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/carousel/TestingDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -39,15 +40,7 @@ const tocItems = [
     <p class="text-muted-foreground text-lg">
       回転するコンテンツアイテム（スライド）のセットで、一度に1つずつ表示し、ナビゲーションコントロールで切り替えます。
     </p>
-    <a
-      href={withBase('/patterns/carousel/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="carousel" />
   </header>
 
   <!-- Framework Selector -->
@@ -229,17 +222,7 @@ const slides = [
           WAI-ARIA APG: Carousel パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/carousel/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA 仕様、キーボードサポート、テストチェックリスト</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="carousel" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/carousel/react/index.astro
+++ b/src/pages/ja/patterns/carousel/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import { CarouselDemo } from '@patterns/carousel/CarouselDemo';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/carousel/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/carousel/TestingDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -40,15 +41,7 @@ const tocItems = [
     <p class="text-muted-foreground text-lg">
       回転するコンテンツアイテム（スライド）のセットで、一度に1つずつ表示し、ナビゲーションコントロールで切り替えます。
     </p>
-    <a
-      href={withBase('/patterns/carousel/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="carousel" />
   </header>
 
   <!-- Framework Selector -->
@@ -227,17 +220,7 @@ function App() {
           WAI-ARIA APG: Carousel パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/carousel/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA 仕様、キーボードサポート、テストチェックリスト</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="carousel" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/carousel/svelte/index.astro
+++ b/src/pages/ja/patterns/carousel/svelte/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import CarouselDemo from '@patterns/carousel/CarouselDemo.svelte';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/carousel/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/carousel/TestingDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -40,15 +41,7 @@ const tocItems = [
     <p class="text-muted-foreground text-lg">
       回転するコンテンツアイテム（スライド）のセットで、一度に1つずつ表示し、ナビゲーションコントロールで切り替えます。
     </p>
-    <a
-      href={withBase('/patterns/carousel/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="carousel" />
   </header>
 
   <!-- Framework Selector -->
@@ -235,17 +228,7 @@ const tocItems = [
           WAI-ARIA APG: Carousel パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/carousel/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA 仕様、キーボードサポート、テストチェックリスト</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="carousel" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/carousel/vue/index.astro
+++ b/src/pages/ja/patterns/carousel/vue/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import CarouselDemo from '@patterns/carousel/CarouselDemo.vue';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/carousel/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/carousel/TestingDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -40,15 +41,7 @@ const tocItems = [
     <p class="text-muted-foreground text-lg">
       回転するコンテンツアイテム（スライド）のセットで、一度に1つずつ表示し、ナビゲーションコントロールで切り替えます。
     </p>
-    <a
-      href={withBase('/patterns/carousel/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="carousel" />
   </header>
 
   <!-- Framework Selector -->
@@ -225,17 +218,7 @@ function handleSlideChange(index: number) {
           WAI-ARIA APG: Carousel パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/carousel/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA 仕様、キーボードサポート、テストチェックリスト</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="carousel" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/dialog/react/index.astro
+++ b/src/pages/ja/patterns/dialog/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import DialogDemo from '@patterns/dialog/DialogDemo';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/dialog/AccessibilityDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
@@ -39,15 +40,7 @@ const tocItems = [
     <p class="text-muted-foreground text-lg">
       プライマリウィンドウの上に重なるウィンドウで、背後のコンテンツを不活性にします。
     </p>
-    <a
-      href={withBase('/patterns/dialog/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="dialog" />
   </header>
 
   <!-- Framework Selector -->
@@ -257,17 +250,7 @@ function App() {
           WAI-ARIA APG: Dialog (Modal) パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/dialog/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="dialog" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/disclosure/react/index.astro
+++ b/src/pages/ja/patterns/disclosure/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import Disclosure from '@patterns/disclosure/Disclosure';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/disclosure/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/disclosure/TestingDocs.ja.astro';
 import NativeHtmlNotice from '@patterns/disclosure/NativeHtmlNotice.ja.astro';
@@ -38,15 +39,7 @@ const tocItems = [
   <header class="mb-8">
     <h1 class="mb-4 text-3xl font-bold">Disclosure</h1>
     <p class="text-muted-foreground text-lg">コンテンツセクションの表示/非表示を制御するボタン。</p>
-    <a
-      href={withBase('/patterns/disclosure/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="disclosure" />
   </header>
 
   <!-- Framework Selector -->
@@ -236,17 +229,7 @@ function App() {
           MDN: &lt;details&gt; element
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/disclosure/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="disclosure" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/feed/astro/index.astro
+++ b/src/pages/ja/patterns/feed/astro/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import FeedDemoJa from '@patterns/feed/FeedDemoJa.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/feed/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/feed/TestingDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -40,15 +41,7 @@ const tocItems = [
       スクロールに応じて新しいコンテンツが追加される記事リストで、Page Up/Down
       キーで記事間をナビゲートできます。
     </p>
-    <a
-      href={withBase('/patterns/feed/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="feed" />
   </header>
 
   <!-- Framework Selector -->
@@ -246,14 +239,7 @@ const articles = [
           WAI-ARIA APG: Feed パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink href={withBase('/patterns/feed/llm.md')} class="text-primary hover:underline">
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA 仕様、キーボードサポート、テストチェックリスト</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="feed" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/feed/react/index.astro
+++ b/src/pages/ja/patterns/feed/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import { FeedDemoJa } from '@patterns/feed/FeedDemoJa';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/feed/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/feed/TestingDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -40,15 +41,7 @@ const tocItems = [
       スクロールに応じて新しいコンテンツが追加される記事リストで、Page Up/Down
       キーで記事間をナビゲートできます。
     </p>
-    <a
-      href={withBase('/patterns/feed/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="feed" />
   </header>
 
   <!-- Framework Selector -->
@@ -232,14 +225,7 @@ function App() {
           WAI-ARIA APG: Feed パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink href={withBase('/patterns/feed/llm.md')} class="text-primary hover:underline">
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA 仕様、キーボードサポート、テストチェックリスト</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="feed" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/feed/svelte/index.astro
+++ b/src/pages/ja/patterns/feed/svelte/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import FeedDemoJa from '@patterns/feed/FeedDemoJa.svelte';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/feed/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/feed/TestingDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -40,15 +41,7 @@ const tocItems = [
       スクロールに応じて新しいコンテンツが追加される記事リストで、Page Up/Down
       キーで記事間をナビゲートできます。
     </p>
-    <a
-      href={withBase('/patterns/feed/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="feed" />
   </header>
 
   <!-- Framework Selector -->
@@ -244,14 +237,7 @@ const tocItems = [
           WAI-ARIA APG: Feed パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink href={withBase('/patterns/feed/llm.md')} class="text-primary hover:underline">
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA 仕様、キーボードサポート、テストチェックリスト</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="feed" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/feed/vue/index.astro
+++ b/src/pages/ja/patterns/feed/vue/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import FeedDemoJa from '@patterns/feed/FeedDemoJa.vue';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/feed/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/feed/TestingDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -40,15 +41,7 @@ const tocItems = [
       スクロールに応じて新しいコンテンツが追加される記事リストで、Page Up/Down
       キーで記事間をナビゲートできます。
     </p>
-    <a
-      href={withBase('/patterns/feed/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="feed" />
   </header>
 
   <!-- Framework Selector -->
@@ -257,14 +250,7 @@ function handleFocusChange(id: string, index: number) {
           WAI-ARIA APG: Feed パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink href={withBase('/patterns/feed/llm.md')} class="text-primary hover:underline">
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA 仕様、キーボードサポート、テストチェックリスト</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="feed" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/listbox/react/index.astro
+++ b/src/pages/ja/patterns/listbox/react/index.astro
@@ -1,5 +1,4 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import {
   SingleSelectListboxDemo,
@@ -10,6 +9,8 @@ import AccessibilityDocs from '@patterns/listbox/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/listbox/TestingDocs.ja.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
@@ -42,15 +43,7 @@ const tocItems = [
     <p class="text-muted-foreground text-lg">
       ユーザーが選択肢のリストから1つまたは複数のアイテムを選択できるウィジェット。
     </p>
-    <a
-      href={withBase('/patterns/listbox/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="listbox" />
   </header>
 
   <!-- Framework Selector -->
@@ -242,17 +235,7 @@ const options = [
           WAI-ARIA APG: Listbox パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/listbox/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="listbox" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/menu-button/astro/index.astro
+++ b/src/pages/ja/patterns/menu-button/astro/index.astro
@@ -1,5 +1,4 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import { useTranslation } from '@/i18n';
 import MenuButton from '@patterns/menu-button/MenuButton.astro';
@@ -7,6 +6,8 @@ import AccessibilityDocs from '@patterns/menu-button/AccessibilityDocs.ja.astro'
 import TestingDocs from '@patterns/menu-button/TestingDocs.ja.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
@@ -52,15 +53,7 @@ const fileItems = [
   <header class="mb-8">
     <h1 class="mb-4 text-3xl font-bold">Menu Button</h1>
     <p class="text-muted-foreground text-lg">アクションまたはオプションのメニューを開くボタン。</p>
-    <a
-      href={withBase('/patterns/menu-button/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="menu-button" />
   </header>
 
   <!-- Framework Selector -->
@@ -270,17 +263,7 @@ const items = [
           WAI-ARIA APG: Menu Button パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/menu-button/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="menu-button" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/menu-button/react/index.astro
+++ b/src/pages/ja/patterns/menu-button/react/index.astro
@@ -1,5 +1,4 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import { useTranslation } from '@/i18n';
 import {
@@ -10,6 +9,8 @@ import AccessibilityDocs from '@patterns/menu-button/AccessibilityDocs.ja.astro'
 import TestingDocs from '@patterns/menu-button/TestingDocs.ja.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
@@ -39,15 +40,7 @@ const tocItems = [
   <header class="mb-8">
     <h1 class="mb-4 text-3xl font-bold">Menu Button</h1>
     <p class="text-muted-foreground text-lg">アクションやオプションのメニューを開くボタン。</p>
-    <a
-      href={withBase('/patterns/menu-button/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="menu-button" />
   </header>
 
   <!-- Framework Selector -->
@@ -214,17 +207,7 @@ const items = [
           WAI-ARIA APG: Menu Button パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/menu-button/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="menu-button" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/menu-button/svelte/index.astro
+++ b/src/pages/ja/patterns/menu-button/svelte/index.astro
@@ -1,11 +1,12 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import MenuButtonDemo from '@patterns/menu-button/MenuButtonDemo.svelte';
 import AccessibilityDocs from '@patterns/menu-button/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/menu-button/TestingDocs.ja.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
@@ -36,15 +37,7 @@ const tocItems = [
   <header class="mb-8">
     <h1 class="mb-4 text-3xl font-bold">Menu Button</h1>
     <p class="text-muted-foreground text-lg">アクションまたはオプションのメニューを開くボタン。</p>
-    <a
-      href={withBase('/patterns/menu-button/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="menu-button" />
   </header>
 
   <!-- Framework Selector -->
@@ -214,17 +207,7 @@ const tocItems = [
           WAI-ARIA APG: Menu Button パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/menu-button/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA 仕様、キーボード操作、テストチェックリスト</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="menu-button" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/menu-button/vue/index.astro
+++ b/src/pages/ja/patterns/menu-button/vue/index.astro
@@ -1,11 +1,12 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import MenuButtonDemo from '@patterns/menu-button/MenuButtonDemo.vue';
 import AccessibilityDocs from '@patterns/menu-button/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/menu-button/TestingDocs.ja.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
@@ -36,15 +37,7 @@ const tocItems = [
   <header class="mb-8">
     <h1 class="mb-4 text-3xl font-bold">Menu Button</h1>
     <p class="text-muted-foreground text-lg">アクションやオプションのメニューを開くボタン。</p>
-    <a
-      href={withBase('/patterns/menu-button/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="menu-button" />
   </header>
 
   <!-- Framework Selector -->
@@ -233,17 +226,7 @@ const handleItemSelect = (itemId: string) => {
           WAI-ARIA APG: Menu Button パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/menu-button/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA 仕様、キーボード操作、テストチェックリスト</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="menu-button" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/menubar/astro/index.astro
+++ b/src/pages/ja/patterns/menubar/astro/index.astro
@@ -1,5 +1,4 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import { useTranslation } from '@/i18n';
 import Menubar, { type MenubarItem } from '@patterns/menubar/Menubar.astro';
@@ -7,6 +6,8 @@ import AccessibilityDocs from '@patterns/menubar/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/menubar/TestingDocs.ja.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
@@ -107,15 +108,7 @@ const menubarItems: MenubarItem[] = [
     <p class="text-muted-foreground text-lg">
       ドロップダウンメニュー、サブメニュー、チェックボックス、ラジオグループをサポートする、アプリケーションスタイルの水平メニューバー。
     </p>
-    <a
-      href={withBase('/patterns/menubar/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="menubar" />
   </header>
 
   <FrameworkTabs pattern="menubar" currentFramework="astro" locale={locale} />
@@ -237,14 +230,7 @@ const menuItems: MenubarItem[] = [
           WAI-ARIA APG: Menubar パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/menubar/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-      </li>
+      <AiGuideResourceItem pattern="menubar" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/menubar/react/index.astro
+++ b/src/pages/ja/patterns/menubar/react/index.astro
@@ -1,5 +1,4 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import { useTranslation } from '@/i18n';
 import { BasicMenubarDemo } from '@patterns/menubar/MenubarDemo';
@@ -7,6 +6,8 @@ import AccessibilityDocs from '@patterns/menubar/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/menubar/TestingDocs.ja.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
@@ -38,15 +39,7 @@ const tocItems = [
     <p class="text-muted-foreground text-lg">
       ドロップダウンメニュー、サブメニュー、チェックボックス、ラジオグループをサポートする、アプリケーションスタイルの水平メニューバー。
     </p>
-    <a
-      href={withBase('/patterns/menubar/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="menubar" />
   </header>
 
   <!-- Framework Selector -->
@@ -201,17 +194,7 @@ const menuItems: MenubarItem[] = [
           WAI-ARIA APG: Menubar パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/menubar/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA仕様、キーボードサポート、テストチェックリスト
-        </span>
-      </li>
+      <AiGuideResourceItem pattern="menubar" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/menubar/svelte/index.astro
+++ b/src/pages/ja/patterns/menubar/svelte/index.astro
@@ -1,5 +1,4 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import { useTranslation } from '@/i18n';
 import MenubarDemo from '@patterns/menubar/MenubarDemo.svelte';
@@ -7,6 +6,8 @@ import AccessibilityDocs from '@patterns/menubar/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/menubar/TestingDocs.ja.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
@@ -38,15 +39,7 @@ const tocItems = [
     <p class="text-muted-foreground text-lg">
       ドロップダウンメニュー、サブメニュー、チェックボックス、ラジオグループをサポートする、アプリケーションスタイルの水平メニューバー。
     </p>
-    <a
-      href={withBase('/patterns/menubar/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="menubar" />
   </header>
 
   <FrameworkTabs pattern="menubar" currentFramework="svelte" locale={locale} />
@@ -171,14 +164,7 @@ const tocItems = [
           WAI-ARIA APG: Menubar パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/menubar/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-      </li>
+      <AiGuideResourceItem pattern="menubar" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/menubar/vue/index.astro
+++ b/src/pages/ja/patterns/menubar/vue/index.astro
@@ -1,5 +1,4 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import { useTranslation } from '@/i18n';
 import MenubarDemo from '@patterns/menubar/MenubarDemo.vue';
@@ -7,6 +6,8 @@ import AccessibilityDocs from '@patterns/menubar/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/menubar/TestingDocs.ja.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
@@ -38,15 +39,7 @@ const tocItems = [
     <p class="text-muted-foreground text-lg">
       ドロップダウンメニュー、サブメニュー、チェックボックス、ラジオグループをサポートする、アプリケーションスタイルの水平メニューバー。
     </p>
-    <a
-      href={withBase('/patterns/menubar/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="menubar" />
   </header>
 
   <FrameworkTabs pattern="menubar" currentFramework="vue" locale={locale} />
@@ -181,14 +174,7 @@ function handleItemSelect(id: string) {
           WAI-ARIA APG: Menubar パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/menubar/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-      </li>
+      <AiGuideResourceItem pattern="menubar" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/radio-group/react/index.astro
+++ b/src/pages/ja/patterns/radio-group/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import { RadioGroup } from '@patterns/radio-group/RadioGroup';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/radio-group/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/radio-group/TestingDocs.ja.astro';
 import NativeHtmlNotice from '@patterns/radio-group/NativeHtmlNotice.ja.astro';
@@ -67,15 +68,7 @@ const ratingOptions = [
     <p class="text-muted-foreground text-lg">
       ラジオボタンと呼ばれるチェック可能なボタンのセットで、一度に1つだけチェックできます。
     </p>
-    <a
-      href={withBase('/patterns/radio-group/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="radio-group" />
   </header>
 
   <!-- Framework Selector -->
@@ -318,17 +311,7 @@ function App() {
           MDN: &lt;input type="radio"&gt;
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/radio-group/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA 仕様、キーボード操作、テストチェックリスト</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="radio-group" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/slider/react/index.astro
+++ b/src/pages/ja/patterns/slider/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import { Slider } from '@patterns/slider/Slider';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/slider/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/slider/TestingDocs.ja.astro';
 import NativeHtmlNotice from '@patterns/slider/NativeHtmlNotice.ja.astro';
@@ -39,15 +40,7 @@ const tocItems = [
   <header class="mb-8">
     <h1 class="mb-4 text-3xl font-bold">Slider</h1>
     <p class="text-muted-foreground text-lg">指定された範囲内から値を選択する入力。</p>
-    <a
-      href={withBase('/patterns/slider/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="slider" />
   </header>
 
   <!-- Framework Selector -->
@@ -310,17 +303,7 @@ function App() {
           MDN: &lt;input type="range"&gt; element
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/slider/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA 仕様、キーボード操作、テストチェックリスト</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="slider" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/switch/react/index.astro
+++ b/src/pages/ja/patterns/switch/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import { Switch } from '@patterns/switch/Switch';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/switch/AccessibilityDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
@@ -38,15 +39,7 @@ const tocItems = [
     <p class="text-muted-foreground text-lg">
       チェック済み/未チェックではなく、オン/オフの値を表すチェックボックスの一種。
     </p>
-    <a
-      href={withBase('/patterns/switch/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="switch" />
   </header>
 
   <!-- Framework Selector -->
@@ -185,17 +178,7 @@ function App() {
           WAI-ARIA APG: Switch パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/switch/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA仕様、キーボードサポート、テストチェックリスト</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="switch" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/tabs/astro/index.astro
+++ b/src/pages/ja/patterns/tabs/astro/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import Tabs from '@patterns/tabs/Tabs.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/tabs/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/tabs/TestingDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -85,15 +86,7 @@ const verticalTabs = [
     <p class="text-muted-foreground text-lg">
       一度に1つのパネルを表示する、タブパネルと呼ばれる階層化されたコンテンツのセクション。
     </p>
-    <a
-      href={withBase('/patterns/tabs/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="tabs" />
   </header>
 
   <!-- Framework Selector -->
@@ -297,14 +290,7 @@ const tabs = [
           WAI-ARIA APG: Tabs パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink href={withBase('/patterns/tabs/llm.md')} class="text-primary hover:underline">
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA 仕様、キーボード操作、テストチェックリスト</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="tabs" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/tabs/react/index.astro
+++ b/src/pages/ja/patterns/tabs/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import Tabs from '@patterns/tabs/Tabs';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/tabs/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/tabs/TestingDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -70,15 +71,7 @@ const verticalTabs = [
     <p class="text-muted-foreground text-lg">
       タブパネルと呼ばれるコンテンツの層状セクションのセットで、一度に1つのパネルを表示します。
     </p>
-    <a
-      href={withBase('/patterns/tabs/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="tabs" />
   </header>
 
   <!-- Framework Selector -->
@@ -255,14 +248,7 @@ function App() {
           WAI-ARIA APG: Tabs パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink href={withBase('/patterns/tabs/llm.md')} class="text-primary hover:underline">
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="tabs" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/tabs/svelte/index.astro
+++ b/src/pages/ja/patterns/tabs/svelte/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import Tabs from '@patterns/tabs/Tabs.svelte';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/tabs/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/tabs/TestingDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -70,15 +71,7 @@ const verticalTabs = [
     <p class="text-muted-foreground text-lg">
       タブパネルと呼ばれるコンテンツの層状セクションのセットで、一度に1つのパネルを表示します。
     </p>
-    <a
-      href={withBase('/patterns/tabs/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="tabs" />
   </header>
 
   <!-- Framework Selector -->
@@ -288,14 +281,7 @@ const verticalTabs = [
           WAI-ARIA APG: Tabs パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink href={withBase('/patterns/tabs/llm.md')} class="text-primary hover:underline">
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA 仕様、キーボード操作、テストチェックリスト</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="tabs" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/tabs/vue/index.astro
+++ b/src/pages/ja/patterns/tabs/vue/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import Tabs from '@patterns/tabs/Tabs.vue';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/tabs/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/tabs/TestingDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -70,15 +71,7 @@ const verticalTabs = [
     <p class="text-muted-foreground text-lg">
       タブパネルと呼ばれる階層化されたコンテンツのセットで、一度に1つのパネルを表示します。
     </p>
-    <a
-      href={withBase('/patterns/tabs/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="tabs" />
   </header>
 
   <!-- Framework Selector -->
@@ -288,14 +281,7 @@ const tabs = [
           WAI-ARIA APG: Tabs パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink href={withBase('/patterns/tabs/llm.md')} class="text-primary hover:underline">
-          AI 実装ガイド (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA 仕様、キーボードサポート、テストチェックリスト</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="tabs" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/toolbar/react/index.astro
+++ b/src/pages/ja/patterns/toolbar/react/index.astro
@@ -1,5 +1,4 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import {
   ToolbarToggleDemo,
@@ -10,6 +9,8 @@ import {
 } from '@patterns/toolbar/ToolbarToggleDemo';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/toolbar/AccessibilityDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
@@ -45,15 +46,7 @@ const tocItems = [
     <p class="text-muted-foreground text-lg">
       ボタン、トグルボタン、チェックボックスなどのコントロールセットをグループ化するコンテナ。
     </p>
-    <a
-      href={withBase('/patterns/toolbar/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="toolbar" />
   </header>
 
   <!-- Framework Selector -->
@@ -326,17 +319,7 @@ const [isBold, setIsBold] = useState(false);
           WAI-ARIA: toolbar role
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/toolbar/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="toolbar" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/tooltip/react/index.astro
+++ b/src/pages/ja/patterns/tooltip/react/index.astro
@@ -1,10 +1,11 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import { useTranslation } from '@/i18n';
 import { Tooltip } from '@patterns/tooltip/Tooltip';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/tooltip/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/tooltip/TestingDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -39,15 +40,7 @@ const tocItems = [
     <p class="text-muted-foreground text-lg">
       要素がキーボードフォーカスを受けたとき、またはマウスがホバーしたときに、要素に関連する情報を表示するポップアップ。
     </p>
-    <a
-      href={withBase('/patterns/tooltip/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="tooltip" />
   </header>
 
   <!-- Framework Selector -->
@@ -238,17 +231,7 @@ function App() {
           WAI-ARIA APG: Tooltip パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/tooltip/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="tooltip" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/window-splitter/astro/index.astro
+++ b/src/pages/ja/patterns/window-splitter/astro/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import WindowSplitterDemo from '@patterns/window-splitter/WindowSplitterDemo.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/window-splitter/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/window-splitter/TestingDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -43,15 +44,7 @@ const tocItems = [
     <p class="text-muted-foreground mt-2 text-sm">
       Astro版はWeb Componentsを使用しており、フレームワークに依存しません。
     </p>
-    <a
-      href={withBase('/patterns/window-splitter/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="window-splitter" />
   </header>
 
   <!-- Framework Selector -->
@@ -243,17 +236,7 @@ import WindowSplitter from './WindowSplitter.astro';
           WAI-ARIA APG: Window Splitter パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/window-splitter/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="window-splitter" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/window-splitter/react/index.astro
+++ b/src/pages/ja/patterns/window-splitter/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import { WindowSplitterDemo } from '@patterns/window-splitter/WindowSplitterDemo';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/window-splitter/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/window-splitter/TestingDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -40,15 +41,7 @@ const tocItems = [
       2つのペイン間で移動可能なセパレーター。ユーザーが各ペインの相対的なサイズを変更できます。
       IDE、ファイルブラウザ、リサイズ可能なレイアウトで使用されます。
     </p>
-    <a
-      href={withBase('/patterns/window-splitter/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="window-splitter" />
   </header>
 
   <!-- Framework Selector -->
@@ -281,17 +274,7 @@ function App() {
           WAI-ARIA APG: Window Splitter パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/window-splitter/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="window-splitter" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/window-splitter/svelte/index.astro
+++ b/src/pages/ja/patterns/window-splitter/svelte/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import WindowSplitterDemo from '@patterns/window-splitter/WindowSplitterDemo.svelte';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/window-splitter/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/window-splitter/TestingDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -40,15 +41,7 @@ const tocItems = [
       2つのペイン間で移動可能なセパレーター。ユーザーが各ペインの相対的なサイズを変更できます。
       IDE、ファイルブラウザ、リサイズ可能なレイアウトで使用されます。
     </p>
-    <a
-      href={withBase('/patterns/window-splitter/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="window-splitter" />
   </header>
 
   <!-- Framework Selector -->
@@ -246,17 +239,7 @@ const tocItems = [
           WAI-ARIA APG: Window Splitter パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/window-splitter/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="window-splitter" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/ja/patterns/window-splitter/vue/index.astro
+++ b/src/pages/ja/patterns/window-splitter/vue/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../../layouts/PatternLayout.astro';
 import WindowSplitterDemo from '@patterns/window-splitter/WindowSplitterDemo.vue';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/window-splitter/AccessibilityDocs.ja.astro';
 import TestingDocs from '@patterns/window-splitter/TestingDocs.ja.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -40,15 +41,7 @@ const tocItems = [
       2つのペイン間で移動可能なセパレーター。ユーザーが各ペインの相対的なサイズを変更できます。
       IDE、ファイルブラウザ、リサイズ可能なレイアウトで使用されます。
     </p>
-    <a
-      href={withBase('/patterns/window-splitter/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI 実装ガイド
-    </a>
+    <AiGuideBadge pattern="window-splitter" />
   </header>
 
   <!-- Framework Selector -->
@@ -246,17 +239,7 @@ function handlePositionChange(position: number, sizeInPx: number) {
           WAI-ARIA APG: Window Splitter パターン
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/window-splitter/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="window-splitter" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/accordion/astro/index.astro
+++ b/src/pages/patterns/accordion/astro/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import Accordion from '@patterns/accordion/Accordion.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/accordion/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/accordion/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -90,15 +91,7 @@ const disabledItems = [
     <p class="text-muted-foreground text-lg">
       A vertically stacked set of interactive headings that each reveal a section of content.
     </p>
-    <a
-      href={withBase('/patterns/accordion/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="accordion" />
   </header>
 
   <!-- Framework Selector -->
@@ -321,17 +314,7 @@ const items = [
           WAI-ARIA APG: Accordion Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/accordion/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="accordion" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/accordion/react/index.astro
+++ b/src/pages/patterns/accordion/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import Accordion from '@patterns/accordion/Accordion';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/accordion/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/accordion/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -90,15 +91,7 @@ const disabledItems = [
     <p class="text-muted-foreground text-lg">
       A vertically stacked set of interactive headings that each reveal a section of content.
     </p>
-    <a
-      href={withBase('/patterns/accordion/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="accordion" />
   </header>
 
   <!-- Framework Selector -->
@@ -326,17 +319,7 @@ function App() {
           WAI-ARIA APG: Accordion Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/accordion/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="accordion" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/accordion/svelte/index.astro
+++ b/src/pages/patterns/accordion/svelte/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import Accordion from '@patterns/accordion/Accordion.svelte';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/accordion/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
@@ -95,15 +96,7 @@ const disabledItems = [
     <p class="text-muted-foreground text-lg">
       A vertically stacked set of interactive headings that each reveal a section of content.
     </p>
-    <a
-      href={withBase('/patterns/accordion/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="accordion" />
   </header>
 
   <!-- Framework Selector -->
@@ -302,17 +295,7 @@ const disabledItems = [
           WAI-ARIA APG: Accordion Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/accordion/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="accordion" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/accordion/vue/index.astro
+++ b/src/pages/patterns/accordion/vue/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import Accordion from '@patterns/accordion/Accordion.vue';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/accordion/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
@@ -90,15 +91,7 @@ const disabledItems = [
     <p class="text-muted-foreground text-lg">
       A vertically stacked set of interactive headings that each reveal a section of content.
     </p>
-    <a
-      href={withBase('/patterns/accordion/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="accordion" />
   </header>
 
   <!-- Framework Selector -->
@@ -303,17 +296,7 @@ const items = [
           WAI-ARIA APG: Accordion Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/accordion/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="accordion" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/alert-dialog/react/index.astro
+++ b/src/pages/patterns/alert-dialog/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import AlertDialogDemo from '@patterns/alert-dialog/AlertDialogDemo';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/alert-dialog/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
@@ -35,15 +36,7 @@ const tocItems = [
       A modal dialog that interrupts the user's workflow to communicate an important message and
       require a response.
     </p>
-    <a
-      href={withBase('/patterns/alert-dialog/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="alert-dialog" />
   </header>
 
   <!-- Framework Selector -->
@@ -248,17 +241,7 @@ function App() {
           WAI-ARIA APG: Alert Dialog Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/alert-dialog/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="alert-dialog" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/alert/react/index.astro
+++ b/src/pages/patterns/alert/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import { AlertDemo } from '@patterns/alert/AlertDemo';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/alert/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/alert/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -30,15 +31,7 @@ const tocItems = [
       An element that displays a brief, important message in a way that attracts the user's
       attention without interrupting the user's task.
     </p>
-    <a
-      href={withBase('/patterns/alert/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="alert" />
   </header>
 
   <!-- Framework Selector -->
@@ -192,17 +185,7 @@ function App() {
           WAI-ARIA APG: Alert Dialog Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/alert/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="alert" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/breadcrumb/react/index.astro
+++ b/src/pages/patterns/breadcrumb/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import Breadcrumb from '@patterns/breadcrumb/Breadcrumb';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/breadcrumb/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/breadcrumb/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -48,15 +49,7 @@ const longPathItems = [
     <p class="text-muted-foreground text-lg">
       A navigation pattern that shows the user's current location within a site hierarchy.
     </p>
-    <a
-      href={withBase('/patterns/breadcrumb/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="breadcrumb" />
   </header>
 
   <!-- Framework Selector -->
@@ -219,17 +212,7 @@ function App() {
           MDN: Breadcrumb Navigation
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/breadcrumb/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="breadcrumb" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/button/react/index.astro
+++ b/src/pages/patterns/button/react/index.astro
@@ -1,10 +1,11 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import Heading from '@/components/ui/Heading.astro';
 import { MuteDemo, DarkModeDemo, NotificationsDemo } from '@patterns/button/ToggleButtonDemo';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/button/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/button/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -29,15 +30,7 @@ const tocItems = [
     <p class="text-muted-foreground text-lg">
       A two-state button that can be either "pressed" or "not pressed".
     </p>
-    <a
-      href={withBase('/patterns/button/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="button" />
   </header>
 
   <!-- Framework Selector -->
@@ -181,17 +174,7 @@ function App() {
           WAI-ARIA APG: Button Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/button/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="button" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/button/vue/index.astro
+++ b/src/pages/patterns/button/vue/index.astro
@@ -1,10 +1,11 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import Heading from '@/components/ui/Heading.astro';
 import ToggleButtonDemo from '@patterns/button/ToggleButtonDemo.vue';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/button/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/button/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -29,15 +30,7 @@ const tocItems = [
     <p class="text-muted-foreground text-lg">
       A two-state button that can be either "pressed" or "not pressed".
     </p>
-    <a
-      href={withBase('/patterns/button/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="button" />
   </header>
 
   <!-- Framework Selector -->
@@ -228,17 +221,7 @@ const handleToggle = (pressed) => {
           WAI-ARIA APG: Button Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/button/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="button" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/carousel/astro/index.astro
+++ b/src/pages/patterns/carousel/astro/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import CarouselDemo from '@patterns/carousel/CarouselDemo.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/carousel/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/carousel/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -30,15 +31,7 @@ const tocItems = [
       A rotating set of content items (slides) displayed one at a time with controls to navigate
       between them.
     </p>
-    <a
-      href={withBase('/patterns/carousel/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="carousel" />
   </header>
 
   <!-- Framework Selector -->
@@ -232,17 +225,7 @@ const slides = [
           WAI-ARIA APG: Carousel Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/carousel/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="carousel" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/carousel/react/index.astro
+++ b/src/pages/patterns/carousel/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import { CarouselDemo } from '@patterns/carousel/CarouselDemo';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/carousel/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/carousel/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -32,15 +33,7 @@ const tocItems = [
       A rotating set of content items (slides) displayed one at a time with controls to navigate
       between them.
     </p>
-    <a
-      href={withBase('/patterns/carousel/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="carousel" />
   </header>
 
   <!-- Framework Selector -->
@@ -211,17 +204,7 @@ function App() {
           WAI-ARIA APG: Carousel Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/carousel/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="carousel" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/carousel/svelte/index.astro
+++ b/src/pages/patterns/carousel/svelte/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import CarouselDemo from '@patterns/carousel/CarouselDemo.svelte';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/carousel/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/carousel/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -32,15 +33,7 @@ const tocItems = [
       A rotating set of content items (slides) displayed one at a time with controls to navigate
       between them.
     </p>
-    <a
-      href={withBase('/patterns/carousel/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="carousel" />
   </header>
 
   <!-- Framework Selector -->
@@ -219,17 +212,7 @@ const tocItems = [
           WAI-ARIA APG: Carousel Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/carousel/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="carousel" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/carousel/vue/index.astro
+++ b/src/pages/patterns/carousel/vue/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import CarouselDemo from '@patterns/carousel/CarouselDemo.vue';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/carousel/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/carousel/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -32,15 +33,7 @@ const tocItems = [
       A rotating set of content items (slides) displayed one at a time with controls to navigate
       between them.
     </p>
-    <a
-      href={withBase('/patterns/carousel/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="carousel" />
   </header>
 
   <!-- Framework Selector -->
@@ -229,17 +222,7 @@ function handleSlideChange(index: number) {
           WAI-ARIA APG: Carousel Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/carousel/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="carousel" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/dialog/react/index.astro
+++ b/src/pages/patterns/dialog/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import DialogDemo from '@patterns/dialog/DialogDemo';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/dialog/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
@@ -29,15 +30,7 @@ const tocItems = [
     <p class="text-muted-foreground text-lg">
       A window overlaid on the primary window, rendering the content underneath inert.
     </p>
-    <a
-      href={withBase('/patterns/dialog/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="dialog" />
   </header>
 
   <!-- Framework Selector -->
@@ -237,17 +230,7 @@ function App() {
           WAI-ARIA APG: Dialog (Modal) Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/dialog/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="dialog" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/disclosure/react/index.astro
+++ b/src/pages/patterns/disclosure/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import Disclosure from '@patterns/disclosure/Disclosure';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/disclosure/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/disclosure/TestingDocs.astro';
 import NativeHtmlNotice from '@patterns/disclosure/NativeHtmlNotice.astro';
@@ -35,15 +36,7 @@ const tocItems = [
     <p class="text-muted-foreground text-lg">
       A button that controls the visibility of a section of content.
     </p>
-    <a
-      href={withBase('/patterns/disclosure/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="disclosure" />
   </header>
 
   <!-- Framework Selector -->
@@ -225,17 +218,7 @@ function App() {
           MDN: &lt;details&gt; element
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/disclosure/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="disclosure" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/feed/astro/index.astro
+++ b/src/pages/patterns/feed/astro/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import FeedDemo from '@patterns/feed/FeedDemo.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/feed/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/feed/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -30,15 +31,7 @@ const tocItems = [
       A scrollable list of articles where new content may be added as the user scrolls, enabling
       keyboard navigation between articles using Page Up/Down.
     </p>
-    <a
-      href={withBase('/patterns/feed/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="feed" />
   </header>
 
   <!-- Framework Selector -->
@@ -230,14 +223,7 @@ const articles = [
           WAI-ARIA APG: Feed Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink href={withBase('/patterns/feed/llm.md')} class="text-primary hover:underline">
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="feed" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/feed/react/index.astro
+++ b/src/pages/patterns/feed/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import { FeedDemo } from '@patterns/feed/FeedDemo';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/feed/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/feed/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -30,15 +31,7 @@ const tocItems = [
       A scrollable list of articles where new content may be added as the user scrolls, enabling
       keyboard navigation between articles using Page Up/Down.
     </p>
-    <a
-      href={withBase('/patterns/feed/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="feed" />
   </header>
 
   <!-- Framework Selector -->
@@ -216,14 +209,7 @@ function App() {
           WAI-ARIA APG: Feed Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink href={withBase('/patterns/feed/llm.md')} class="text-primary hover:underline">
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="feed" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/feed/svelte/index.astro
+++ b/src/pages/patterns/feed/svelte/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import FeedDemo from '@patterns/feed/FeedDemo.svelte';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/feed/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/feed/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -30,15 +31,7 @@ const tocItems = [
       A scrollable list of articles where new content may be added as the user scrolls, enabling
       keyboard navigation between articles using Page Up/Down.
     </p>
-    <a
-      href={withBase('/patterns/feed/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="feed" />
   </header>
 
   <!-- Framework Selector -->
@@ -228,14 +221,7 @@ const tocItems = [
           WAI-ARIA APG: Feed Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink href={withBase('/patterns/feed/llm.md')} class="text-primary hover:underline">
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="feed" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/feed/vue/index.astro
+++ b/src/pages/patterns/feed/vue/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import FeedDemo from '@patterns/feed/FeedDemo.vue';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/feed/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/feed/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -30,15 +31,7 @@ const tocItems = [
       A scrollable list of articles where new content may be added as the user scrolls, enabling
       keyboard navigation between articles using Page Up/Down.
     </p>
-    <a
-      href={withBase('/patterns/feed/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="feed" />
   </header>
 
   <!-- Framework Selector -->
@@ -241,14 +234,7 @@ function handleFocusChange(id: string, index: number) {
           WAI-ARIA APG: Feed Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink href={withBase('/patterns/feed/llm.md')} class="text-primary hover:underline">
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="feed" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/listbox/react/index.astro
+++ b/src/pages/patterns/listbox/react/index.astro
@@ -1,5 +1,4 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import {
   SingleSelectListboxDemo,
@@ -10,6 +9,8 @@ import AccessibilityDocs from '@patterns/listbox/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/listbox/TestingDocs.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
@@ -32,15 +33,7 @@ const tocItems = [
     <p class="text-muted-foreground text-lg">
       A widget that allows the user to select one or more items from a list of choices.
     </p>
-    <a
-      href={withBase('/patterns/listbox/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="listbox" />
   </header>
 
   <!-- Framework Selector -->
@@ -224,17 +217,7 @@ const options = [
           WAI-ARIA APG: Listbox Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/listbox/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="listbox" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/menu-button/astro/index.astro
+++ b/src/pages/patterns/menu-button/astro/index.astro
@@ -1,11 +1,12 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import MenuButton from '@patterns/menu-button/MenuButton.astro';
 import AccessibilityDocs from '@patterns/menu-button/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/menu-button/TestingDocs.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
@@ -47,15 +48,7 @@ const fileItems = [
   <header class="mb-8">
     <h1 class="mb-4 text-3xl font-bold">Menu Button</h1>
     <p class="text-muted-foreground text-lg">A button that opens a menu of actions or options.</p>
-    <a
-      href={withBase('/patterns/menu-button/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="menu-button" />
   </header>
 
   <!-- Framework Selector -->
@@ -257,17 +250,7 @@ const items = [
           WAI-ARIA APG: Menu Button Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/menu-button/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="menu-button" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/menu-button/react/index.astro
+++ b/src/pages/patterns/menu-button/react/index.astro
@@ -1,5 +1,4 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import {
   BasicMenuButtonDemo,
@@ -9,6 +8,8 @@ import AccessibilityDocs from '@patterns/menu-button/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/menu-button/TestingDocs.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
@@ -34,15 +35,7 @@ const tocItems = [
   <header class="mb-8">
     <h1 class="mb-4 text-3xl font-bold">Menu Button</h1>
     <p class="text-muted-foreground text-lg">A button that opens a menu of actions or options.</p>
-    <a
-      href={withBase('/patterns/menu-button/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="menu-button" />
   </header>
 
   <!-- Framework Selector -->
@@ -201,17 +194,7 @@ const items = [
           WAI-ARIA APG: Menu Button Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/menu-button/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="menu-button" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/menu-button/svelte/index.astro
+++ b/src/pages/patterns/menu-button/svelte/index.astro
@@ -1,11 +1,12 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import MenuButtonDemo from '@patterns/menu-button/MenuButtonDemo.svelte';
 import AccessibilityDocs from '@patterns/menu-button/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/menu-button/TestingDocs.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
@@ -31,15 +32,7 @@ const tocItems = [
   <header class="mb-8">
     <h1 class="mb-4 text-3xl font-bold">Menu Button</h1>
     <p class="text-muted-foreground text-lg">A button that opens a menu of actions or options.</p>
-    <a
-      href={withBase('/patterns/menu-button/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="menu-button" />
   </header>
 
   <!-- Framework Selector -->
@@ -201,17 +194,7 @@ const tocItems = [
           WAI-ARIA APG: Menu Button Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/menu-button/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="menu-button" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/menu-button/vue/index.astro
+++ b/src/pages/patterns/menu-button/vue/index.astro
@@ -1,11 +1,12 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import MenuButtonDemo from '@patterns/menu-button/MenuButtonDemo.vue';
 import AccessibilityDocs from '@patterns/menu-button/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/menu-button/TestingDocs.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
@@ -26,15 +27,7 @@ const tocItems = [
   <header class="mb-8">
     <h1 class="mb-4 text-3xl font-bold">Menu Button</h1>
     <p class="text-muted-foreground text-lg">A button that opens a menu of actions or options.</p>
-    <a
-      href={withBase('/patterns/menu-button/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="menu-button" />
   </header>
 
   <!-- Framework Selector -->
@@ -215,17 +208,7 @@ const handleItemSelect = (itemId: string) => {
           WAI-ARIA APG: Menu Button Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/menu-button/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="menu-button" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/menubar/astro/index.astro
+++ b/src/pages/patterns/menubar/astro/index.astro
@@ -1,11 +1,12 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import Menubar, { type MenubarItem } from '@patterns/menubar/Menubar.astro';
 import AccessibilityDocs from '@patterns/menubar/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/menubar/TestingDocs.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
@@ -98,15 +99,7 @@ const menubarItems: MenubarItem[] = [
       A horizontal menu bar that provides application-style navigation with dropdown menus,
       submenus, checkbox items, and radio groups.
     </p>
-    <a
-      href={withBase('/patterns/menubar/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="menubar" />
   </header>
 
   <!-- Framework Selector -->
@@ -257,17 +250,7 @@ const menuItems: MenubarItem[] = [
           WAI-ARIA APG: Menubar Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/menubar/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist
-        </span>
-      </li>
+      <AiGuideResourceItem pattern="menubar" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/menubar/react/index.astro
+++ b/src/pages/patterns/menubar/react/index.astro
@@ -1,11 +1,12 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import { BasicMenubarDemo } from '@patterns/menubar/MenubarDemo';
 import AccessibilityDocs from '@patterns/menubar/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/menubar/TestingDocs.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
@@ -29,15 +30,7 @@ const tocItems = [
       A horizontal menu bar that provides application-style navigation with dropdown menus,
       submenus, checkbox items, and radio groups.
     </p>
-    <a
-      href={withBase('/patterns/menubar/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="menubar" />
   </header>
 
   <!-- Framework Selector -->
@@ -223,17 +216,7 @@ type MenuItem =
           WAI-ARIA APG: Menubar Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/menubar/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist
-        </span>
-      </li>
+      <AiGuideResourceItem pattern="menubar" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/menubar/svelte/index.astro
+++ b/src/pages/patterns/menubar/svelte/index.astro
@@ -1,11 +1,12 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import MenubarDemo from '@patterns/menubar/MenubarDemo.svelte';
 import AccessibilityDocs from '@patterns/menubar/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/menubar/TestingDocs.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
@@ -29,15 +30,7 @@ const tocItems = [
       A horizontal menu bar that provides application-style navigation with dropdown menus,
       submenus, checkbox items, and radio groups.
     </p>
-    <a
-      href={withBase('/patterns/menubar/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="menubar" />
   </header>
 
   <!-- Framework Selector -->
@@ -193,17 +186,7 @@ const tocItems = [
           WAI-ARIA APG: Menubar Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/menubar/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist
-        </span>
-      </li>
+      <AiGuideResourceItem pattern="menubar" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/menubar/vue/index.astro
+++ b/src/pages/patterns/menubar/vue/index.astro
@@ -1,11 +1,12 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import MenubarDemo from '@patterns/menubar/MenubarDemo.vue';
 import AccessibilityDocs from '@patterns/menubar/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/menubar/TestingDocs.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
 import Heading from '@/components/ui/Heading.astro';
@@ -29,15 +30,7 @@ const tocItems = [
       A horizontal menu bar that provides application-style navigation with dropdown menus,
       submenus, checkbox items, and radio groups.
     </p>
-    <a
-      href={withBase('/patterns/menubar/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="menubar" />
   </header>
 
   <!-- Framework Selector -->
@@ -203,17 +196,7 @@ function handleItemSelect(id: string) {
           WAI-ARIA APG: Menubar Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/menubar/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist
-        </span>
-      </li>
+      <AiGuideResourceItem pattern="menubar" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/switch/react/index.astro
+++ b/src/pages/patterns/switch/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import { Switch } from '@patterns/switch/Switch';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/switch/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
@@ -28,15 +29,7 @@ const tocItems = [
     <p class="text-muted-foreground text-lg">
       A control that allows users to toggle between two states: on and off.
     </p>
-    <a
-      href={withBase('/patterns/switch/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="switch" />
   </header>
 
   <!-- Framework Selector -->
@@ -168,17 +161,7 @@ function App() {
           WAI-ARIA APG: Switch Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/switch/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="switch" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/tabs/astro/index.astro
+++ b/src/pages/patterns/tabs/astro/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import Tabs from '@patterns/tabs/Tabs.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/tabs/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/tabs/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -76,15 +77,7 @@ const verticalTabs = [
       A set of layered sections of content, known as tab panels, that display one panel of content
       at a time.
     </p>
-    <a
-      href={withBase('/patterns/tabs/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="tabs" />
   </header>
 
   <!-- Framework Selector -->
@@ -280,14 +273,7 @@ const tabs = [
           WAI-ARIA APG: Tabs Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink href={withBase('/patterns/tabs/llm.md')} class="text-primary hover:underline">
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="tabs" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/tabs/react/index.astro
+++ b/src/pages/patterns/tabs/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import Tabs from '@patterns/tabs/Tabs';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/tabs/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/tabs/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -61,15 +62,7 @@ const verticalTabs = [
       A set of layered sections of content, known as tab panels, that display one panel of content
       at a time.
     </p>
-    <a
-      href={withBase('/patterns/tabs/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="tabs" />
   </header>
 
   <!-- Framework Selector -->
@@ -240,14 +233,7 @@ function App() {
           WAI-ARIA APG: Tabs Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink href={withBase('/patterns/tabs/llm.md')} class="text-primary hover:underline">
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="tabs" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/tabs/svelte/index.astro
+++ b/src/pages/patterns/tabs/svelte/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import Tabs from '@patterns/tabs/Tabs.svelte';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/tabs/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/tabs/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -61,15 +62,7 @@ const verticalTabs = [
       A set of layered sections of content, known as tab panels, that display one panel of content
       at a time.
     </p>
-    <a
-      href={withBase('/patterns/tabs/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="tabs" />
   </header>
 
   <!-- Framework Selector -->
@@ -273,14 +266,7 @@ const verticalTabs = [
           WAI-ARIA APG: Tabs Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink href={withBase('/patterns/tabs/llm.md')} class="text-primary hover:underline">
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="tabs" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/tabs/vue/index.astro
+++ b/src/pages/patterns/tabs/vue/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import Tabs from '@patterns/tabs/Tabs.vue';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/tabs/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/tabs/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -61,15 +62,7 @@ const verticalTabs = [
       A set of layered sections of content, known as tab panels, that display one panel of content
       at a time.
     </p>
-    <a
-      href={withBase('/patterns/tabs/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="tabs" />
   </header>
 
   <!-- Framework Selector -->
@@ -271,14 +264,7 @@ const tabs = [
           WAI-ARIA APG: Tabs Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink href={withBase('/patterns/tabs/llm.md')} class="text-primary hover:underline">
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="tabs" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/toolbar/react/index.astro
+++ b/src/pages/patterns/toolbar/react/index.astro
@@ -1,5 +1,4 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import {
   ToolbarToggleDemo,
@@ -10,6 +9,8 @@ import {
 } from '@patterns/toolbar/ToolbarToggleDemo';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/toolbar/AccessibilityDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
 import { ResponsiveTable } from '@/components/ui/table';
@@ -36,15 +37,7 @@ const tocItems = [
       A container for grouping a set of controls, such as buttons, toggle buttons, or other input
       elements.
     </p>
-    <a
-      href={withBase('/patterns/toolbar/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="toolbar" />
   </header>
 
   <!-- Framework Selector -->
@@ -310,17 +303,7 @@ const [isBold, setIsBold] = useState(false);
           WAI-ARIA: toolbar role
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/toolbar/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="toolbar" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/tooltip/react/index.astro
+++ b/src/pages/patterns/tooltip/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import { Tooltip } from '@patterns/tooltip/Tooltip';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/tooltip/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/tooltip/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -30,15 +31,7 @@ const tocItems = [
       A popup that displays information related to an element when the element receives keyboard
       focus or the mouse hovers over it.
     </p>
-    <a
-      href={withBase('/patterns/tooltip/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="tooltip" />
   </header>
 
   <!-- Framework Selector -->
@@ -221,17 +214,7 @@ function App() {
           WAI-ARIA APG: Tooltip Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/tooltip/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="tooltip" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/window-splitter/astro/index.astro
+++ b/src/pages/patterns/window-splitter/astro/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import WindowSplitterDemo from '@patterns/window-splitter/WindowSplitterDemo.astro';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/window-splitter/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/window-splitter/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -35,15 +36,7 @@ const tocItems = [
       A movable separator between two panes that allows users to resize the relative size of each
       pane. Uses Web Components for client-side interactivity.
     </p>
-    <a
-      href={withBase('/patterns/window-splitter/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="window-splitter" />
   </header>
 
   <!-- Framework Selector -->
@@ -248,14 +241,7 @@ import WindowSplitter from './WindowSplitter.astro';
           WAI-ARIA APG: Window Splitter Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/window-splitter/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-      </li>
+      <AiGuideResourceItem pattern="window-splitter" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/window-splitter/react/index.astro
+++ b/src/pages/patterns/window-splitter/react/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import { WindowSplitterDemo } from '@patterns/window-splitter/WindowSplitterDemo';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/window-splitter/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/window-splitter/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -35,15 +36,7 @@ const tocItems = [
       A movable separator between two panes that allows users to resize the relative size of each
       pane. Used in IDEs, file browsers, and resizable layouts.
     </p>
-    <a
-      href={withBase('/patterns/window-splitter/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="window-splitter" />
   </header>
 
   <!-- Framework Selector -->
@@ -268,17 +261,7 @@ function App() {
           WAI-ARIA APG: Window Splitter Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/window-splitter/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-        <span class="text-muted-foreground text-sm">
-          - ARIA specs, keyboard support, test checklist</span
-        >
-      </li>
+      <AiGuideResourceItem pattern="window-splitter" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/window-splitter/svelte/index.astro
+++ b/src/pages/patterns/window-splitter/svelte/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import WindowSplitterDemo from '@patterns/window-splitter/WindowSplitterDemo.svelte';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/window-splitter/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/window-splitter/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -35,15 +36,7 @@ const tocItems = [
       A movable separator between two panes that allows users to resize the relative size of each
       pane. Used in IDEs, file browsers, and resizable layouts.
     </p>
-    <a
-      href={withBase('/patterns/window-splitter/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="window-splitter" />
   </header>
 
   <!-- Framework Selector -->
@@ -233,14 +226,7 @@ const tocItems = [
           WAI-ARIA APG: Window Splitter Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/window-splitter/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-      </li>
+      <AiGuideResourceItem pattern="window-splitter" />
     </ul>
   </section>
 </PatternLayout>

--- a/src/pages/patterns/window-splitter/vue/index.astro
+++ b/src/pages/patterns/window-splitter/vue/index.astro
@@ -1,9 +1,10 @@
 ---
-import { withBase } from '@/lib/utils';
 import PatternLayout from '../../../../layouts/PatternLayout.astro';
 import WindowSplitterDemo from '@patterns/window-splitter/WindowSplitterDemo.vue';
 import CodeBlock from '@/components/ui/CodeBlock.astro';
 import ExternalLink from '@/components/ui/ExternalLink.astro';
+import AiGuideBadge from '@/components/ui/AiGuideBadge.astro';
+import AiGuideResourceItem from '@/components/ui/AiGuideResourceItem.astro';
 import AccessibilityDocs from '@patterns/window-splitter/AccessibilityDocs.astro';
 import TestingDocs from '@patterns/window-splitter/TestingDocs.astro';
 import FrameworkTabs from '@/components/ui/FrameworkTabs.astro';
@@ -35,15 +36,7 @@ const tocItems = [
       A movable separator between two panes that allows users to resize the relative size of each
       pane. Used in IDEs, file browsers, and resizable layouts.
     </p>
-    <a
-      href={withBase('/patterns/window-splitter/llm.md')}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="mt-4 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
-    >
-      <span class="text-base">🤖</span>
-      AI Implementation Guide
-    </a>
+    <AiGuideBadge pattern="window-splitter" />
   </header>
 
   <!-- Framework Selector -->
@@ -233,14 +226,7 @@ function handlePositionChange(position: number, sizeInPx: number) {
           WAI-ARIA APG: Window Splitter Pattern
         </ExternalLink>
       </li>
-      <li>
-        <ExternalLink
-          href={withBase('/patterns/window-splitter/llm.md')}
-          class="text-primary hover:underline"
-        >
-          AI Implementation Guide (llm.md)
-        </ExternalLink>
-      </li>
+      <AiGuideResourceItem pattern="window-splitter" />
     </ul>
   </section>
 </PatternLayout>


### PR DESCRIPTION
## Summary

- 日本語ページから llm.md へのリンクが 404 になる問題を修正
- 全ページで `AiGuideBadge` と `AiGuideResourceItem` コンポーネントを使用するように統一

## Changes

### コンポーネントの修正
- `AiGuideBadge.astro`: `locale` パラメータを無視し、常に `/patterns/{pattern}/llm.md` を参照
- `AiGuideResourceItem.astro`: 同様に修正

### ページの修正
- 82ファイル（日本語41 + 英語39 + コンポーネント2）
- 手動の llm.md リンクを `AiGuideBadge` / `AiGuideResourceItem` に置き換え
- 不要になった `withBase` import を削除

## Test plan
- [x] `npm run build` が成功することを確認
- [ ] 日本語ページから llm.md へのリンクが正しく動作することを確認
- [ ] 英語ページから llm.md へのリンクが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)