### PR TITLE
fix: sync llm.md with implementations and add aria-current to Link

### DIFF
--- a/src/patterns/accordion/llm.md
+++ b/src/patterns/accordion/llm.md
@@ -18,11 +18,12 @@ An accordion is a vertically stacked set of interactive headings that each revea
 
 ### Properties
 
-| Attribute         | Element | Values       | Required        | Notes                       |
-| ----------------- | ------- | ------------ | --------------- | --------------------------- |
-| `aria-level`      | heading | `2` - `6`    | Yes             | Set via `headingLevel` prop |
-| `aria-controls`   | button  | ID of panel  | Yes             | Auto-generated              |
-| `aria-labelledby` | region  | ID of button | Yes (if region) | Auto-generated              |
+| Attribute         | Element | Values       | Required        | Notes                                              |
+| ----------------- | ------- | ------------ | --------------- | -------------------------------------------------- |
+| `aria-controls`   | button  | ID of panel  | Yes             | Auto-generated                                     |
+| `aria-labelledby` | region  | ID of button | Yes (if region) | Auto-generated                                     |
+
+> Note: `aria-level` is implicit when using native heading elements (h2-h6). The `headingLevel` prop controls which heading tag is rendered, providing the level semantically without an explicit `aria-level` attribute.
 
 ### States
 

--- a/src/patterns/button/llm.md
+++ b/src/patterns/button/llm.md
@@ -16,9 +16,11 @@ A toggle button is a two-state button that can be either pressed or not pressed.
 
 ### States
 
-| Attribute      | Element | Values                         | Required | Change Trigger      |
-| -------------- | ------- | ------------------------------ | -------- | ------------------- |
-| `aria-pressed` | button  | `true` \| `false` \| `"mixed"` | Yes      | Click, Enter, Space |
+| Attribute      | Element | Values            | Required | Change Trigger      |
+| -------------- | ------- | ----------------- | -------- | ------------------- |
+| `aria-pressed` | button  | `true` \| `false` | Yes      | Click, Enter, Space |
+
+> Note: `aria-pressed="mixed"` is valid per WAI-ARIA spec for tri-state toggles (e.g., "Select All" when some items selected), but this implementation uses binary true/false only.
 
 ## Keyboard Support
 

--- a/src/patterns/carousel/llm.md
+++ b/src/patterns/carousel/llm.md
@@ -185,7 +185,7 @@ isPausedByInteraction:
 ```typescript
 // Use PointerEvents for cross-device support
 let startX: number;
-const threshold = 50; // px
+const threshold = containerWidth * 0.2; // 20% of container width (responsive)
 
 onPointerDown = (e) => { startX = e.clientX; pauseRotation(); };
 onPointerUp = (e) => {

--- a/src/patterns/dialog/llm.md
+++ b/src/patterns/dialog/llm.md
@@ -16,11 +16,13 @@ A dialog is a window overlaid on the primary content, requiring user interaction
 
 ### Properties
 
-| Attribute          | Element | Values                      | Required | Notes                            |
-| ------------------ | ------- | --------------------------- | -------- | -------------------------------- |
-| `aria-modal`       | dialog  | `true`                      | Yes      | Indicates this is a modal dialog |
-| `aria-labelledby`  | dialog  | ID reference to title       | Yes      | References the dialog title      |
-| `aria-describedby` | dialog  | ID reference to description | No       | References optional description  |
+| Attribute          | Element | Values                      | Required | Notes                                                     |
+| ------------------ | ------- | --------------------------- | -------- | --------------------------------------------------------- |
+| `aria-modal`       | dialog  | `true`                      | Yes*     | Native `<dialog>` + `showModal()` provides this implicitly |
+| `aria-labelledby`  | dialog  | ID reference to title       | Yes      | References the dialog title                               |
+| `aria-describedby` | dialog  | ID reference to description | No       | References optional description                           |
+
+> *When using native `<dialog>` element with `showModal()`, the modal behavior is implicit and `aria-modal` may be omitted.
 
 ## Keyboard Support
 

--- a/src/patterns/disclosure/llm.md
+++ b/src/patterns/disclosure/llm.md
@@ -16,10 +16,11 @@ A disclosure is a button that controls visibility of a section of content. It's 
 
 ### Properties
 
-| Attribute       | Element | Values            | Required | Notes                        |
-| --------------- | ------- | ----------------- | -------- | ---------------------------- |
-| `aria-controls` | button  | ID of panel       | Yes      | Associates button with panel |
-| `aria-hidden`   | panel   | `true` \| `false` | No       | Hides from AT when collapsed |
+| Attribute       | Element | Values            | Required | Notes                                          |
+| --------------- | ------- | ----------------- | -------- | ---------------------------------------------- |
+| `aria-controls` | button  | ID of panel       | Yes      | Associates button with panel                   |
+| `aria-hidden`   | panel   | `true` \| `false` | Yes      | Hides from AT when collapsed                   |
+| `inert`         | panel   | boolean           | Yes      | Prevents focus/interaction when collapsed      |
 
 ### States
 
@@ -55,6 +56,14 @@ A disclosure is a button that controls visibility of a section of content. It's 
 ### Medium Priority: Accessibility
 
 - [ ] No axe-core violations (WCAG 2.1 AA)
+
+## Component Props
+
+| Prop               | Type                         | Default | Description                           |
+| ------------------ | ---------------------------- | ------- | ------------------------------------- |
+| `defaultExpanded`  | `boolean`                    | `false` | Initial expanded state                |
+| `disabled`         | `boolean`                    | `false` | Disables the trigger button           |
+| `onExpandedChange` | `(expanded: boolean) => void`| -       | Callback when expanded state changes  |
 
 ## Disclosure vs Accordion
 

--- a/src/patterns/link/Link.astro
+++ b/src/patterns/link/Link.astro
@@ -18,11 +18,19 @@ export interface Props {
   target?: '_self' | '_blank';
   /** Whether the link is disabled */
   disabled?: boolean;
+  /** Indicates current item in a set (e.g., current page in navigation) */
+  'aria-current'?: 'page' | 'step' | 'location' | 'date' | 'time' | 'true' | boolean;
   /** Additional CSS class */
   class?: string;
 }
 
-const { href, target, disabled = false, class: className = '' } = Astro.props;
+const {
+  href,
+  target,
+  disabled = false,
+  'aria-current': ariaCurrent,
+  class: className = '',
+} = Astro.props;
 ---
 
 <apg-link data-href={href} data-target={target}>
@@ -30,6 +38,7 @@ const { href, target, disabled = false, class: className = '' } = Astro.props;
     role="link"
     tabindex={disabled ? -1 : 0}
     aria-disabled={disabled ? 'true' : undefined}
+    aria-current={ariaCurrent || undefined}
     class={`apg-link ${className}`.trim()}
   >
     <slot />

--- a/src/patterns/link/Link.svelte
+++ b/src/patterns/link/Link.svelte
@@ -8,6 +8,8 @@
     target?: '_self' | '_blank';
     /** Whether the link is disabled */
     disabled?: boolean;
+    /** Indicates current item in a set (e.g., current page in navigation) */
+    'aria-current'?: 'page' | 'step' | 'location' | 'date' | 'time' | 'true' | boolean;
     /** Click handler */
     onClick?: (event: MouseEvent | KeyboardEvent) => void;
     /** Children content (string for tests, Snippet for slots) */

--- a/src/patterns/link/Link.tsx
+++ b/src/patterns/link/Link.tsx
@@ -10,6 +10,8 @@ export interface LinkProps extends Omit<React.HTMLAttributes<HTMLSpanElement>, '
   onClick?: (event: React.MouseEvent | React.KeyboardEvent) => void;
   /** Disabled state */
   disabled?: boolean;
+  /** Indicates current item in a set (e.g., current page in navigation) */
+  'aria-current'?: 'page' | 'step' | 'location' | 'date' | 'time' | 'true' | boolean;
   /** Link content */
   children: React.ReactNode;
 }

--- a/src/patterns/link/Link.vue
+++ b/src/patterns/link/Link.vue
@@ -3,6 +3,7 @@
     role="link"
     :tabindex="props.disabled ? -1 : 0"
     :aria-disabled="props.disabled ? 'true' : undefined"
+    :aria-current="props.ariaCurrent || undefined"
     class="apg-link"
     v-bind="$attrs"
     @click="handleClick"
@@ -24,6 +25,8 @@ export interface LinkProps {
   target?: '_self' | '_blank';
   /** Whether the link is disabled */
   disabled?: boolean;
+  /** Indicates current item in a set (e.g., current page in navigation) */
+  ariaCurrent?: 'page' | 'step' | 'location' | 'date' | 'time' | 'true' | boolean;
   /** Callback fired when link is activated */
   onClick?: (event: MouseEvent | KeyboardEvent) => void;
 }
@@ -32,6 +35,7 @@ const props = withDefaults(defineProps<LinkProps>(), {
   href: undefined,
   target: undefined,
   disabled: false,
+  ariaCurrent: undefined,
   onClick: undefined,
 });
 

--- a/src/patterns/tabs/llm.md
+++ b/src/patterns/tabs/llm.md
@@ -18,11 +18,13 @@ Tabs are a set of layered sections of content, known as tab panels, that display
 
 ### Properties
 
-| Attribute          | Element  | Values                         | Required | Notes                  |
-| ------------------ | -------- | ------------------------------ | -------- | ---------------------- |
-| `aria-orientation` | tablist  | `"horizontal"` \| `"vertical"` | No       | Defaults to horizontal |
-| `aria-controls`    | tab      | ID of associated panel         | Yes      | Auto-generated         |
-| `aria-labelledby`  | tabpanel | ID of associated tab           | Yes      | Auto-generated         |
+| Attribute          | Element  | Values                         | Required | Notes                                    |
+| ------------------ | -------- | ------------------------------ | -------- | ---------------------------------------- |
+| `aria-orientation` | tablist  | `"horizontal"` \| `"vertical"` | No       | Defaults to horizontal                   |
+| `aria-controls`    | tab      | ID of associated panel         | Yes*     | Set only on the selected tab             |
+| `aria-labelledby`  | tabpanel | ID of associated tab           | Yes      | Auto-generated                           |
+
+> *`aria-controls` is set only on the currently selected tab. Non-selected tabs omit this attribute to avoid referencing hidden panels.
 
 ### States
 


### PR DESCRIPTION
## Summary

- llm.md ドキュメントを実装と同期
- Link コンポーネントに `aria-current` prop を追加

## 変更内容

### llm.md 更新

| パターン | 変更内容 |
|---------|---------|
| tabs | `aria-controls` は選択されたタブのみに設定される旨を追記 |
| dialog | native `<dialog>` + `showModal()` で `aria-modal` が暗黙的に提供される旨を追記 |
| button | `aria-pressed` は true/false のみ使用（mixedは未実装）を追記 |
| disclosure | `inert` 属性と Component Props セクションを追加 |
| carousel | swipe threshold を固定50pxからレスポンシブな20%に更新 |
| accordion | `aria-level` はnative heading要素で暗黙的に提供される旨を追記 |

### 実装修正

- **Link** (React/Vue/Svelte/Astro): ナビゲーションの現在ページ表示用に `aria-current` prop を追加

## Test plan

- [x] Unit tests pass (2410 tests)
- [x] Link tests specifically verified (81 tests)
- [x] TypeScript check pass (warnings only)
- [x] Format check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)