### PR TITLE
docs: update project status to reflect completed E2E tests

### DIFF
--- a/.internal/site-specification.md
+++ b/.internal/site-specification.md
@@ -1,7 +1,7 @@
 # サイト仕様書
 
 > APG Patterns Examples - Astro リビルド
-> 最終更新: 2025-12-26
+> 最終更新: 2026-01-16
 
 ## 概要
 
@@ -502,7 +502,7 @@ function getFramework(): Framework {
 - [x] React / Vue / Svelte / Astro 統合設定
 - [x] Tailwind + shadcn/ui 設定
 - [x] 基本レイアウト作成
-- [ ] i18n 設定
+- [x] i18n 設定
 - [x] ダークモード実装
 
 ### Phase 2: コア機能 ✅ 完了
@@ -514,17 +514,22 @@ function getFramework(): Framework {
 
 ### Phase 3: コンテンツ移行 ✅ 完了
 
-- [x] ToggleButton パターン移行（React / Vue / Svelte / Astro）
-- [x] Tabs パターン移行（React / Vue / Svelte / Astro）
+全 29 パターン実装完了（React / Vue / Svelte / Astro）:
 
-### Phase 4: サイト完成
+- Toggle Button, Tabs, Accordion, Dialog, Menu Button, Disclosure, Alert
+- Checkbox, Radio Group, Switch, Listbox, Combobox, Tooltip, Breadcrumb, Link
+- Toolbar, Menubar, Grid, Slider, Spinbutton, Meter, Alert Dialog
+- Carousel, Table, Tree View, Treegrid, Feed, Window Splitter, Landmarks
+
+### Phase 4: サイト完成 ✅ 完了
 
 - [x] トップページ
-- [ ] ガイドページ
-- [ ] About ページ
-- [ ] テスト整備
-- [ ] GitHub Actions 設定
-- [ ] 動作確認・デプロイ
+- [x] ガイドページ
+- [x] About ページ
+- [x] テスト整備（Vitest + Playwright）
+- [x] GitHub Actions 設定
+- [x] 動作確認・デプロイ
+- [ ] Pagefind 検索設定
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,13 +1,13 @@
 # TODO - APG Patterns Examples
 
-> 最終更新: 2026-01-13
+> 最終更新: 2026-01-16
 
 ## 現状
 
-**Astro 移行完了・全パターン実装完了**
+**Astro 移行完了・全パターン実装完了・全 E2E テスト完了**
 
 Docusaurus + 3 Storybook 構成から Astro Islands アーキテクチャへの移行が完了。
-28 パターン全て実装済み。
+29 パターン全て実装済み、E2E テスト完了。
 
 仕様詳細: [.internal/site-specification.md](.internal/site-specification.md)
 
@@ -27,18 +27,18 @@ Docusaurus + 3 Storybook 構成から Astro Islands アーキテクチャへの�
 
 ### E2E テスト
 
-25/28 パターン完了（89%）
+29/29 パターン完了（100%）
 
 - [x] Accordion
-- [ ] Dialog
-- [ ] Menu Button
+- [x] Dialog
+- [x] Menu Button
 - [x] Radio Group
 - [x] Slider
-- [ ] Spinbutton
+- [x] Spinbutton
 - [x] Tabs
 - [x] Toolbar
 - [x] Tooltip
-- [ ] Tree View
+- [x] Tree View
 
 ---
 
@@ -51,8 +51,8 @@ Docusaurus + 3 Storybook 構成から Astro Islands アーキテクチャへの�
 | Toggle Button  | ✅ 完了 | ✅  | 低     |
 | Tabs           | ✅ 完了 | ✅  | 中     |
 | Accordion      | ✅ 完了 | ✅  | 中     |
-| Dialog (Modal) | ✅ 完了 | -   | 高     |
-| Menu Button    | ✅ 完了 | -   | 中     |
+| Dialog (Modal) | ✅ 完了 | ✅  | 高     |
+| Menu Button    | ✅ 完了 | ✅  | 中     |
 | Disclosure     | ✅ 完了 | ✅  | 低     |
 | Alert          | ✅ 完了 | ✅  | 低     |
 
@@ -77,12 +77,12 @@ Docusaurus + 3 Storybook 構成から Astro Islands アーキテクチャへの�
 | Menubar         | ✅ 完了 | ✅  | 高     |
 | Grid            | ✅ 完了 | ✅  | 高     |
 | Slider          | ✅ 完了 | ✅  | 中     |
-| Spinbutton      | ✅ 完了 | -   | 中     |
+| Spinbutton      | ✅ 完了 | ✅  | 中     |
 | Meter           | ✅ 完了 | ✅  | 低     |
 | Alert Dialog    | ✅ 完了 | ✅  | 中     |
 | Carousel        | ✅ 完了 | ✅  | 高     |
 | Table           | ✅ 完了 | ✅  | 中     |
-| Tree View       | ✅ 完了 | -   | 高     |
+| Tree View       | ✅ 完了 | ✅  | 高     |
 | Treegrid        | ✅ 完了 | ✅  | 高     |
 | Feed            | ✅ 完了 | ✅  | 中     |
 | Window Splitter | ✅ 完了 | ✅  | 中     |


### PR DESCRIPTION
## Summary
- TODO.md と site-specification.md を現在の実装状況に合わせて更新
- 全 29 パターンの E2E テストが完了（100%）
- i18n 設定、ガイドページ、About ページ、テスト整備、GitHub Actions、デプロイが完了
- 残タスクは Pagefind 検索設定のみ

## Test plan
- [ ] ドキュメントの内容が正確であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)