### PR TITLE
refactor(lint): improve ESLint config and fix remaining errors

### DIFF
--- a/src/patterns/feed/FeedDemo.tsx
+++ b/src/patterns/feed/FeedDemo.tsx
@@ -123,7 +123,7 @@ export function FeedDemo() {
           </div>
         )}
         {!hasMore && (
-          <div className="apg-feed-end-message">You've reached the end of the feed.</div>
+          <div className="apg-feed-end-message">You&apos;ve reached the end of the feed.</div>
         )}
       </div>
       <button

--- a/src/patterns/menu-button/MenuButtonDemo.tsx
+++ b/src/patterns/menu-button/MenuButtonDemo.tsx
@@ -36,7 +36,7 @@ export function DisabledItemsMenuButtonDemo() {
       <MenuButton items={fileItems} label="File" onItemSelect={setLastAction} />
       <p className="text-muted-foreground text-sm">Last action: {lastAction ?? 'None'}</p>
       <p className="text-muted-foreground text-xs">
-        Note: "Export" is disabled and will be skipped during keyboard navigation
+        Note: &quot;Export&quot; is disabled and will be skipped during keyboard navigation
       </p>
     </div>
   );

--- a/src/patterns/table/Table.test.tsx
+++ b/src/patterns/table/Table.test.tsx
@@ -408,7 +408,15 @@ describe('Table', () => {
       const rowsWithNodes: TableRow[] = [
         {
           id: '1',
-          cells: [<a href="/alice">Alice</a>, '30', <span className="highlight">Tokyo</span>],
+          cells: [
+            <a key="name" href="/alice">
+              Alice
+            </a>,
+            '30',
+            <span key="city" className="highlight">
+              Tokyo
+            </span>,
+          ],
         },
       ];
       render(<Table columns={basicColumns} rows={rowsWithNodes} aria-label="Users" />);


### PR DESCRIPTION
## Summary
- ESLint設定をリファクタリングし、マルチフレームワーク対応を改善
- TypeScriptルールを`.ts/.tsx`ファイルのみに限定して競合を防止
- 品質向上ルール（`eqeqeq`, `no-debugger`, `@typescript-eslint/no-shadow`）を追加
- React/Vue/Svelte/Astroの各フレームワーク固有の設定を整理
- 残存していたESLintエラー（309件→0件）を修正

## Test plan
- [ ] `npm run lint` でエラーが0件であることを確認
- [ ] `npm run test:unit` でユニットテストがパスすることを確認
- [ ] `npm run test:e2e` でE2Eテストがパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)