### PR TITLE
refactor(header): unify focus styles and heights across header components

### DIFF
--- a/src/components/ui/LanguageSwitcher.astro
+++ b/src/components/ui/LanguageSwitcher.astro
@@ -30,6 +30,7 @@ const alternateLanguageName = languages[alternateLocale];
   class:list={[
     'inline-flex items-center gap-1.5 rounded-md px-2 py-1.5 text-sm transition-colors',
     'text-muted-foreground hover:text-foreground hover:bg-muted',
+    'focus-visible:ring-foreground focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
     Astro.props.class,
   ]}
   aria-label={`Switch to ${alternateLanguageName}`}

--- a/src/components/ui/button/button.astro
+++ b/src/components/ui/button/button.astro
@@ -14,7 +14,7 @@ type Props = VariantProps<typeof variants> &
   };
 
 const variants = cva(
-  "focus-visible:border-ring text-foreground focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "focus-visible:border-ring text-foreground focus-visible:ring-foreground aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-colors outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/src/components/ui/logo/logo.astro
+++ b/src/components/ui/logo/logo.astro
@@ -16,7 +16,7 @@ const slot = await Astro.slots.render('default');
   slot?.trim().length > 0 && (
     <Comp
       class={cn(
-        'flex h-11 items-center justify-start gap-2.5 text-base font-semibold whitespace-nowrap',
+        'focus-visible:ring-foreground -mx-2 flex h-8 items-center justify-start gap-2.5 rounded-md px-2 text-base font-semibold whitespace-nowrap focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
         className
       )}
       href={href}

--- a/src/components/ui/navigation-menu/navigation-menu-link.astro
+++ b/src/components/ui/navigation-menu/navigation-menu-link.astro
@@ -5,13 +5,13 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const variants = cva(
-  'underline leading-none focus-visible:ring-ring/50 inline-flex items-start justify-start rounded-md transition-all outline-none focus-visible:ring-[3px] focus-visible:outline-none',
+  'underline leading-none focus-visible:ring-foreground inline-flex items-center justify-start rounded-md transition-colors outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
   {
     variants: {
       variant: {
-        default: 'text-muted-foreground gap-1 px-2 py-4',
+        default: 'text-muted-foreground gap-1 px-3 py-1 h-8',
         trigger:
-          'bg-background hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground h-8 w-max px-3 py-0 text-sm font-medium disabled:pointer-events-none disabled:opacity-50',
+          'bg-background hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground h-8 w-max px-3 py-1 text-sm font-medium disabled:pointer-events-none disabled:opacity-50',
       },
     },
     defaultVariants: {

--- a/src/components/ui/navigation-menu/navigation-menu-trigger.astro
+++ b/src/components/ui/navigation-menu/navigation-menu-trigger.astro
@@ -18,7 +18,7 @@ const Comp = href ? 'a' : 'button';
     <Comp
       data-slot="navigation-menu-trigger"
       class={cn(
-        'bg-background hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-ring/50 inline-flex h-9 w-max items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors focus-visible:ring-[3px] focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50',
+        'bg-background hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-foreground inline-flex h-8 w-max items-center justify-center rounded-md px-4 py-1 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50',
         'navigation-menu-trigger cursor-pointer [&:where(button)]:border-none [&:where(button)]:bg-transparent',
         className
       )}

--- a/src/components/ui/pattern-search/PatternSearch.tsx
+++ b/src/components/ui/pattern-search/PatternSearch.tsx
@@ -329,7 +329,7 @@ export function PatternSearch({
           type="text"
           role="combobox"
           className={cn(
-            'bg-background border-input placeholder:text-muted-foreground focus-visible:ring-ring',
+            'bg-background border-input placeholder:text-muted-foreground focus-visible:ring-foreground',
             'flex h-9 w-full rounded-md border py-2 pr-3 pl-9 text-sm',
             'focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
             'disabled:cursor-not-allowed disabled:opacity-50'

--- a/src/components/ui/theme-toggle/theme-toggle.astro
+++ b/src/components/ui/theme-toggle/theme-toggle.astro
@@ -10,7 +10,7 @@ const { class: className } = Astro.props;
 
 const containerStyles = cn(
   // Layout
-  'inline-flex h-8 items-center',
+  'inline-flex h-9 items-center',
   // Border
   'rounded-md border border-input',
   // Background
@@ -35,8 +35,8 @@ const buttonStyles = cn(
   'aria-checked:shadow-sm',
   // Focus state
   'focus-visible:outline-none',
-  'focus-visible:ring-inset',
   'focus-visible:ring-2',
+  'focus-visible:ring-offset-2',
   'focus-visible:ring-foreground',
   // Forced colors: checked state
   'forced-colors:aria-checked:outline-2',


### PR DESCRIPTION
## Summary
- Standardize focus ring styles to `ring-foreground` with `ring-2` and `ring-offset-2` across all header components (both light and dark themes)
- Remove focus ring animation by using `transition-colors` instead of `transition-all`
- Unify logo and navigation menu heights to 32px (`h-8`)
- Set theme toggle height to 36px (`h-9`) to match PatternSearch
- Add missing focus styles to LanguageSwitcher

## Test plan
- [ ] Verify focus ring appearance is consistent across all header components
- [ ] Confirm focus rings do not animate when focusing elements
- [ ] Check that logo and navigation items are aligned at 32px height
- [ ] Verify theme toggle height matches PatternSearch input height
- [ ] Test keyboard navigation through header components

🤖 Generated with [Claude Code](https://claude.com/claude-code)