### PR TITLE
fix: remove hardcoded redirect causing 404 on radio-group pattern

### DIFF
--- a/src/pages/patterns/radio-group/index.astro
+++ b/src/pages/patterns/radio-group/index.astro
@@ -1,3 +1,0 @@
----
-return Astro.redirect('/patterns/radio-group/react/');
----


### PR DESCRIPTION
## Summary
- Removed `src/pages/patterns/radio-group/index.astro` which contained a hardcoded redirect
- This static file was overriding the dynamic route `/patterns/[pattern]/index.astro`, causing 404 errors
- The radio-group pattern now uses the same dynamic routing as all other patterns

## Test plan
- [ ] Navigate to `/patterns/radio-group/` and verify redirect to `/patterns/radio-group/react/`
- [ ] Verify localStorage framework preference is respected (same as other patterns)
- [ ] Compare behavior with other patterns (e.g., `/patterns/button/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)