### PR TITLE
chore: remove planned editable-grid from patterns list

### DIFF
--- a/src/lib/patterns.ts
+++ b/src/lib/patterns.ts
@@ -299,15 +299,6 @@ export const PATTERNS: Pattern[] = [
     status: 'available',
   },
   {
-    id: 'editable-grid',
-    name: 'Editable Grid',
-    description:
-      'A spreadsheet-like grid with inline cell editing, dropdowns, and validation support.',
-    icon: '✏️',
-    complexity: 'High',
-    status: 'planned',
-  },
-  {
     id: 'window-splitter',
     name: 'Window Splitter',
     description:


### PR DESCRIPTION
## Summary
- Remove `editable-grid` entry from patterns list (was marked as `planned` but not implemented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)