### PR TITLE
docs: update documentation with AI guide feature and fix pattern status

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -59,6 +59,26 @@
 - モーション削減の設定への対応
 - 強制カラーモードのサポート
 
+## AI ガイド
+
+各パターンには AI コーディングアシスタント向けの定義ファイル（`llm.md`）が含まれており、Claude、Cursor、GitHub Copilot などで類似コンポーネントを実装する際のコンテキストとして利用できます。
+
+### 含まれる内容
+
+- ARIA role、property、state の要件
+- キーボード操作の仕様
+- フォーカス管理のルール
+- 検証用のテストチェックリスト
+- ローカライズ版（英語・日本語）
+
+### 使い方
+
+1. **ダウンロード**: パターンページの「AIガイドをダウンロード」ボタンをクリック
+2. **コピー**: 「AIガイドをコピー」でクリップボードにコピー
+3. **直接URL**: `https://masup9.github.io/apg-patterns-examples/ja/patterns/{pattern}/llm.md` からアクセス
+
+詳細は[ガイド](https://masup9.github.io/apg-patterns-examples/ja/guide/)をご覧ください。
+
 ## コントリビューション
 
 コントリビューションを歓迎します！詳細については、[Contributing Guide](./CONTRIBUTING.md) をご覧ください：

--- a/README.md
+++ b/README.md
@@ -59,6 +59,26 @@ Additionally, we provide styling that supports dark mode, high contrast mode, an
 - Reduced motion preferences support
 - Forced colors mode support
 
+## AI Guide
+
+Each pattern includes an AI-friendly definition file (`llm.md`) that can be used as context when implementing similar components with AI coding assistants like Claude, Cursor, or GitHub Copilot.
+
+### What's included
+
+- ARIA roles, properties, and states requirements
+- Keyboard interaction specifications
+- Focus management rules
+- Test checklist for verification
+- Localized versions (English and Japanese)
+
+### Usage
+
+1. **Download**: Click "Download for AI" button on any pattern page
+2. **Copy**: Use "Copy for AI" to copy the content to clipboard
+3. **Direct URL**: Access via `https://masup9.github.io/apg-patterns-examples/patterns/{pattern}/llm.md`
+
+For more details, see the [Guide](https://masup9.github.io/apg-patterns-examples/guide/).
+
 ## Contributing
 
 We welcome contributions! Please see our [Contributing Guide](./CONTRIBUTING.md) for details on:

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -88,10 +88,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
               ></tr
             >
             <tr class="border-b"
-              ><td class="px-4 py-2">Button</td><td class="px-4 py-2 text-center">-</td><td
-                class="px-4 py-2 text-center">-</td
-              ><td class="px-4 py-2 text-center">-</td><td class="px-4 py-2 text-center">-</td><td
-                class="px-4 py-2">Planned</td
+              ><td class="px-4 py-2">Button</td><td class="px-4 py-2 text-center">✅</td><td
+                class="px-4 py-2 text-center">✅</td
+              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
+                class="px-4 py-2">Complete</td
               ></tr
             >
             <tr class="border-b"
@@ -110,6 +110,13 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             >
             <tr class="border-b"
               ><td class="px-4 py-2">Combobox</td><td class="px-4 py-2 text-center">✅</td><td
+                class="px-4 py-2 text-center">✅</td
+              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
+                class="px-4 py-2">Complete</td
+              ></tr
+            >
+            <tr class="border-b"
+              ><td class="px-4 py-2">Data Grid</td><td class="px-4 py-2 text-center">✅</td><td
                 class="px-4 py-2 text-center">✅</td
               ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
                 class="px-4 py-2">Complete</td
@@ -201,10 +208,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             >
             <tr class="border-b"
               ><td class="px-4 py-2">Slider (Multi-Thumb)</td><td class="px-4 py-2 text-center"
-                >-</td
-              ><td class="px-4 py-2 text-center">-</td><td class="px-4 py-2 text-center">-</td><td
-                class="px-4 py-2 text-center">-</td
-              ><td class="px-4 py-2">Planned</td></tr
+                >✅</td
+              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
+                class="px-4 py-2 text-center">✅</td
+              ><td class="px-4 py-2">Complete</td></tr
             >
             <tr class="border-b"
               ><td class="px-4 py-2">Spinbutton</td><td class="px-4 py-2 text-center">✅</td><td

--- a/src/pages/guide/index.astro
+++ b/src/pages/guide/index.astro
@@ -84,7 +84,7 @@ import { withBase } from '@/lib/utils';
 
     <section class="mb-12">
       <h2 class="mb-4 text-2xl font-semibold">Available Patterns</h2>
-      <p class="text-muted-foreground mb-4">All 28 patterns have AI-friendly definition files:</p>
+      <p class="text-muted-foreground mb-4">All 32 patterns have AI-friendly definition files:</p>
       <div class="grid gap-4 md:grid-cols-2">
         <Tile variant="floating" href={withBase('/patterns/accordion/react/')}>
           <TileContent>
@@ -143,6 +143,14 @@ import { withBase } from '@/lib/utils';
             <TileTitle>Combobox</TileTitle>
             <TileDescription>
               Text input with dropdown suggestions and autocomplete.
+            </TileDescription>
+          </TileContent>
+        </Tile>
+        <Tile variant="floating" href={withBase('/patterns/data-grid/react/')}>
+          <TileContent>
+            <TileTitle>Data Grid</TileTitle>
+            <TileDescription>
+              Interactive grid with editable cells and keyboard navigation.
             </TileDescription>
           </TileContent>
         </Tile>
@@ -224,6 +232,14 @@ import { withBase } from '@/lib/utils';
           <TileContent>
             <TileTitle>Slider</TileTitle>
             <TileDescription> Input for selecting a value from a range. </TileDescription>
+          </TileContent>
+        </Tile>
+        <Tile variant="floating" href={withBase('/patterns/slider-multithumb/react/')}>
+          <TileContent>
+            <TileTitle>Slider (Multi-Thumb)</TileTitle>
+            <TileDescription>
+              Range slider with multiple handles for range selection.
+            </TileDescription>
           </TileContent>
         </Tile>
         <Tile variant="floating" href={withBase('/patterns/spinbutton/react/')}>
@@ -335,6 +351,11 @@ import { withBase } from '@/lib/utils';
             >
           </li>
           <li>
+            <a href={withBase('/patterns/data-grid/llm.md')} class="text-primary hover:underline"
+              >/patterns/data-grid/llm.md</a
+            >
+          </li>
+          <li>
             <a href={withBase('/patterns/dialog/llm.md')} class="text-primary hover:underline"
               >/patterns/dialog/llm.md</a
             >
@@ -392,6 +413,12 @@ import { withBase } from '@/lib/utils';
           <li>
             <a href={withBase('/patterns/slider/llm.md')} class="text-primary hover:underline"
               >/patterns/slider/llm.md</a
+            >
+          </li>
+          <li>
+            <a
+              href={withBase('/patterns/slider-multithumb/llm.md')}
+              class="text-primary hover:underline">/patterns/slider-multithumb/llm.md</a
             >
           </li>
           <li>

--- a/src/pages/ja/about.astro
+++ b/src/pages/ja/about.astro
@@ -90,10 +90,10 @@ const locale = 'ja';
               ></tr
             >
             <tr class="border-b"
-              ><td class="px-4 py-2">Button</td><td class="px-4 py-2 text-center">-</td><td
-                class="px-4 py-2 text-center">-</td
-              ><td class="px-4 py-2 text-center">-</td><td class="px-4 py-2 text-center">-</td><td
-                class="px-4 py-2">予定</td
+              ><td class="px-4 py-2">Button</td><td class="px-4 py-2 text-center">✅</td><td
+                class="px-4 py-2 text-center">✅</td
+              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
+                class="px-4 py-2">完了</td
               ></tr
             >
             <tr class="border-b"
@@ -112,6 +112,13 @@ const locale = 'ja';
             >
             <tr class="border-b"
               ><td class="px-4 py-2">Combobox</td><td class="px-4 py-2 text-center">✅</td><td
+                class="px-4 py-2 text-center">✅</td
+              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
+                class="px-4 py-2">完了</td
+              ></tr
+            >
+            <tr class="border-b"
+              ><td class="px-4 py-2">Data Grid</td><td class="px-4 py-2 text-center">✅</td><td
                 class="px-4 py-2 text-center">✅</td
               ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
                 class="px-4 py-2">完了</td
@@ -203,10 +210,10 @@ const locale = 'ja';
             >
             <tr class="border-b"
               ><td class="px-4 py-2">Slider (Multi-Thumb)</td><td class="px-4 py-2 text-center"
-                >-</td
-              ><td class="px-4 py-2 text-center">-</td><td class="px-4 py-2 text-center">-</td><td
-                class="px-4 py-2 text-center">-</td
-              ><td class="px-4 py-2">予定</td></tr
+                >✅</td
+              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
+                class="px-4 py-2 text-center">✅</td
+              ><td class="px-4 py-2">完了</td></tr
             >
             <tr class="border-b"
               ><td class="px-4 py-2">Spinbutton</td><td class="px-4 py-2 text-center">✅</td><td

--- a/src/pages/ja/guide/index.astro
+++ b/src/pages/ja/guide/index.astro
@@ -89,7 +89,7 @@ const locale = 'ja';
     <section class="mb-12">
       <h2 class="mb-4 text-2xl font-semibold">利用可能なパターン</h2>
       <p class="text-muted-foreground mb-4">
-        全 28 パターンに AI 向け定義ファイルが用意されています:
+        全 32 パターンに AI 向け定義ファイルが用意されています:
       </p>
       <div class="grid gap-4 md:grid-cols-2">
         <Tile variant="floating" href={withBase('/ja/patterns/accordion/react/')}>
@@ -153,6 +153,14 @@ const locale = 'ja';
             <TileTitle>Combobox</TileTitle>
             <TileDescription>
               ドロップダウン候補とオートコンプリート機能を持つテキスト入力です。
+            </TileDescription>
+          </TileContent>
+        </Tile>
+        <Tile variant="floating" href={withBase('/ja/patterns/data-grid/react/')}>
+          <TileContent>
+            <TileTitle>Data Grid</TileTitle>
+            <TileDescription>
+              編集可能なセルとキーボードナビゲーションを持つインタラクティブなグリッドです。
             </TileDescription>
           </TileContent>
         </Tile>
@@ -244,6 +252,14 @@ const locale = 'ja';
             <TileDescription> 範囲から値を選択するための入力です。 </TileDescription>
           </TileContent>
         </Tile>
+        <Tile variant="floating" href={withBase('/ja/patterns/slider-multithumb/react/')}>
+          <TileContent>
+            <TileTitle>Slider (Multi-Thumb)</TileTitle>
+            <TileDescription>
+              複数のハンドルで範囲選択ができるレンジスライダーです。
+            </TileDescription>
+          </TileContent>
+        </Tile>
         <Tile variant="floating" href={withBase('/ja/patterns/spinbutton/react/')}>
           <TileContent>
             <TileTitle>Spinbutton</TileTitle>
@@ -315,149 +331,166 @@ const locale = 'ja';
       <div class="bg-muted rounded-md p-4">
         <ul class="space-y-1 text-sm">
           <li>
-            <a href={withBase('/patterns/accordion/llm.md')} class="text-primary hover:underline"
-              >/patterns/accordion/llm.md</a
+            <a href={withBase('/ja/patterns/accordion/llm.md')} class="text-primary hover:underline"
+              >/ja/patterns/accordion/llm.md</a
             >
           </li>
           <li>
-            <a href={withBase('/patterns/alert/llm.md')} class="text-primary hover:underline"
-              >/patterns/alert/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/alert-dialog/llm.md')} class="text-primary hover:underline"
-              >/patterns/alert-dialog/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/breadcrumb/llm.md')} class="text-primary hover:underline"
-              >/patterns/breadcrumb/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/button/llm.md')} class="text-primary hover:underline"
-              >/patterns/button/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/carousel/llm.md')} class="text-primary hover:underline"
-              >/patterns/carousel/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/checkbox/llm.md')} class="text-primary hover:underline"
-              >/patterns/checkbox/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/combobox/llm.md')} class="text-primary hover:underline"
-              >/patterns/combobox/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/dialog/llm.md')} class="text-primary hover:underline"
-              >/patterns/dialog/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/disclosure/llm.md')} class="text-primary hover:underline"
-              >/patterns/disclosure/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/feed/llm.md')} class="text-primary hover:underline"
-              >/patterns/feed/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/grid/llm.md')} class="text-primary hover:underline"
-              >/patterns/grid/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/landmarks/llm.md')} class="text-primary hover:underline"
-              >/patterns/landmarks/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/link/llm.md')} class="text-primary hover:underline"
-              >/patterns/link/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/listbox/llm.md')} class="text-primary hover:underline"
-              >/patterns/listbox/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/menu-button/llm.md')} class="text-primary hover:underline"
-              >/patterns/menu-button/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/menubar/llm.md')} class="text-primary hover:underline"
-              >/patterns/menubar/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/meter/llm.md')} class="text-primary hover:underline"
-              >/patterns/meter/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/radio-group/llm.md')} class="text-primary hover:underline"
-              >/patterns/radio-group/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/slider/llm.md')} class="text-primary hover:underline"
-              >/patterns/slider/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/spinbutton/llm.md')} class="text-primary hover:underline"
-              >/patterns/spinbutton/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/switch/llm.md')} class="text-primary hover:underline"
-              >/patterns/switch/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/table/llm.md')} class="text-primary hover:underline"
-              >/patterns/table/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/tabs/llm.md')} class="text-primary hover:underline"
-              >/patterns/tabs/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/toolbar/llm.md')} class="text-primary hover:underline"
-              >/patterns/toolbar/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/tooltip/llm.md')} class="text-primary hover:underline"
-              >/patterns/tooltip/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/treegrid/llm.md')} class="text-primary hover:underline"
-              >/patterns/treegrid/llm.md</a
-            >
-          </li>
-          <li>
-            <a href={withBase('/patterns/treeview/llm.md')} class="text-primary hover:underline"
-              >/patterns/treeview/llm.md</a
+            <a href={withBase('/ja/patterns/alert/llm.md')} class="text-primary hover:underline"
+              >/ja/patterns/alert/llm.md</a
             >
           </li>
           <li>
             <a
-              href={withBase('/patterns/window-splitter/llm.md')}
-              class="text-primary hover:underline">/patterns/window-splitter/llm.md</a
+              href={withBase('/ja/patterns/alert-dialog/llm.md')}
+              class="text-primary hover:underline">/ja/patterns/alert-dialog/llm.md</a
+            >
+          </li>
+          <li>
+            <a
+              href={withBase('/ja/patterns/breadcrumb/llm.md')}
+              class="text-primary hover:underline">/ja/patterns/breadcrumb/llm.md</a
+            >
+          </li>
+          <li>
+            <a href={withBase('/ja/patterns/button/llm.md')} class="text-primary hover:underline"
+              >/ja/patterns/button/llm.md</a
+            >
+          </li>
+          <li>
+            <a href={withBase('/ja/patterns/carousel/llm.md')} class="text-primary hover:underline"
+              >/ja/patterns/carousel/llm.md</a
+            >
+          </li>
+          <li>
+            <a href={withBase('/ja/patterns/checkbox/llm.md')} class="text-primary hover:underline"
+              >/ja/patterns/checkbox/llm.md</a
+            >
+          </li>
+          <li>
+            <a href={withBase('/ja/patterns/combobox/llm.md')} class="text-primary hover:underline"
+              >/ja/patterns/combobox/llm.md</a
+            >
+          </li>
+          <li>
+            <a href={withBase('/ja/patterns/data-grid/llm.md')} class="text-primary hover:underline"
+              >/ja/patterns/data-grid/llm.md</a
+            >
+          </li>
+          <li>
+            <a href={withBase('/ja/patterns/dialog/llm.md')} class="text-primary hover:underline"
+              >/ja/patterns/dialog/llm.md</a
+            >
+          </li>
+          <li>
+            <a
+              href={withBase('/ja/patterns/disclosure/llm.md')}
+              class="text-primary hover:underline">/ja/patterns/disclosure/llm.md</a
+            >
+          </li>
+          <li>
+            <a href={withBase('/ja/patterns/feed/llm.md')} class="text-primary hover:underline"
+              >/ja/patterns/feed/llm.md</a
+            >
+          </li>
+          <li>
+            <a href={withBase('/ja/patterns/grid/llm.md')} class="text-primary hover:underline"
+              >/ja/patterns/grid/llm.md</a
+            >
+          </li>
+          <li>
+            <a href={withBase('/ja/patterns/landmarks/llm.md')} class="text-primary hover:underline"
+              >/ja/patterns/landmarks/llm.md</a
+            >
+          </li>
+          <li>
+            <a href={withBase('/ja/patterns/link/llm.md')} class="text-primary hover:underline"
+              >/ja/patterns/link/llm.md</a
+            >
+          </li>
+          <li>
+            <a href={withBase('/ja/patterns/listbox/llm.md')} class="text-primary hover:underline"
+              >/ja/patterns/listbox/llm.md</a
+            >
+          </li>
+          <li>
+            <a
+              href={withBase('/ja/patterns/menu-button/llm.md')}
+              class="text-primary hover:underline">/ja/patterns/menu-button/llm.md</a
+            >
+          </li>
+          <li>
+            <a href={withBase('/ja/patterns/menubar/llm.md')} class="text-primary hover:underline"
+              >/ja/patterns/menubar/llm.md</a
+            >
+          </li>
+          <li>
+            <a href={withBase('/ja/patterns/meter/llm.md')} class="text-primary hover:underline"
+              >/ja/patterns/meter/llm.md</a
+            >
+          </li>
+          <li>
+            <a
+              href={withBase('/ja/patterns/radio-group/llm.md')}
+              class="text-primary hover:underline">/ja/patterns/radio-group/llm.md</a
+            >
+          </li>
+          <li>
+            <a href={withBase('/ja/patterns/slider/llm.md')} class="text-primary hover:underline"
+              >/ja/patterns/slider/llm.md</a
+            >
+          </li>
+          <li>
+            <a
+              href={withBase('/ja/patterns/slider-multithumb/llm.md')}
+              class="text-primary hover:underline">/ja/patterns/slider-multithumb/llm.md</a
+            >
+          </li>
+          <li>
+            <a
+              href={withBase('/ja/patterns/spinbutton/llm.md')}
+              class="text-primary hover:underline">/ja/patterns/spinbutton/llm.md</a
+            >
+          </li>
+          <li>
+            <a href={withBase('/ja/patterns/switch/llm.md')} class="text-primary hover:underline"
+              >/ja/patterns/switch/llm.md</a
+            >
+          </li>
+          <li>
+            <a href={withBase('/ja/patterns/table/llm.md')} class="text-primary hover:underline"
+              >/ja/patterns/table/llm.md</a
+            >
+          </li>
+          <li>
+            <a href={withBase('/ja/patterns/tabs/llm.md')} class="text-primary hover:underline"
+              >/ja/patterns/tabs/llm.md</a
+            >
+          </li>
+          <li>
+            <a href={withBase('/ja/patterns/toolbar/llm.md')} class="text-primary hover:underline"
+              >/ja/patterns/toolbar/llm.md</a
+            >
+          </li>
+          <li>
+            <a href={withBase('/ja/patterns/tooltip/llm.md')} class="text-primary hover:underline"
+              >/ja/patterns/tooltip/llm.md</a
+            >
+          </li>
+          <li>
+            <a href={withBase('/ja/patterns/treegrid/llm.md')} class="text-primary hover:underline"
+              >/ja/patterns/treegrid/llm.md</a
+            >
+          </li>
+          <li>
+            <a href={withBase('/ja/patterns/treeview/llm.md')} class="text-primary hover:underline"
+              >/ja/patterns/treeview/llm.md</a
+            >
+          </li>
+          <li>
+            <a
+              href={withBase('/ja/patterns/window-splitter/llm.md')}
+              class="text-primary hover:underline">/ja/patterns/window-splitter/llm.md</a
             >
           </li>
         </ul>


### PR DESCRIPTION
## Summary
- Update Guide pages to reflect 32 patterns (previously 28)
- Fix Button and Slider (Multi-Thumb) status in About pages (Planned → Complete)
- Add Data Grid pattern to About page tables
- Add AI Guide section to README files explaining the llm.md feature
- Update Japanese guide llm.md links to use proper `/ja/patterns/` URLs

## Changes

### Guide pages (EN/JA)
- Pattern count: 28 → 32
- Added tiles for Data Grid and Slider (Multi-Thumb)
- Added llm.md direct links for new patterns
- Japanese version now uses `/ja/patterns/` for locale-aware llm.md URLs

### About pages (EN/JA)
- Button: `-` / Planned → ✅ / Complete
- Slider (Multi-Thumb): `-` / Planned → ✅ / Complete
- Added Data Grid row to component status table

### README.md / README.ja.md
- Added "AI Guide" section explaining:
  - What llm.md files contain
  - How to download/copy
  - Direct URL access

## Test plan
- [ ] Verify Guide page shows 32 patterns
- [ ] Verify About page table shows correct status
- [ ] Verify README AI Guide section renders correctly
- [ ] Verify Japanese llm.md links work with `/ja/patterns/` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)