### PR TITLE
refactor: simplify patterns.ts by removing complexity and status fields

### DIFF
--- a/scripts/generate-pattern-og-images.ts
+++ b/scripts/generate-pattern-og-images.ts
@@ -15,7 +15,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
 import { dirname, join, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
-import { getAvailablePatterns, type Pattern } from '../src/lib/patterns';
+import { getPatterns, type Pattern } from '../src/lib/patterns';
 
 const require = createRequire(import.meta.url);
 
@@ -173,8 +173,8 @@ function loadFontBold() {
 async function generatePatternOGImages() {
   console.log('Generating pattern OGP images...\n');
 
-  // Get available patterns from patterns.ts
-  const patterns = getAvailablePatterns();
+  // Get patterns from patterns.ts
+  const patterns = getPatterns();
   console.log(`Found ${patterns.length} available patterns\n`);
 
   // Ensure output directory exists

--- a/src/components/ui/pattern-breadcrumb/PatternBreadcrumb.astro
+++ b/src/components/ui/pattern-breadcrumb/PatternBreadcrumb.astro
@@ -1,7 +1,7 @@
 ---
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
 import { type Framework } from '@/lib/frameworks';
-import { getAvailablePatterns, getPatternById } from '@/lib/patterns';
+import { getPatterns, getPatternById } from '@/lib/patterns';
 import { withBase } from '@/lib/utils';
 import ChevronDownIcon from 'lucide-static/icons/chevron-down.svg';
 import {
@@ -22,7 +22,7 @@ const { pattern, framework } = Astro.props;
 const locale = Astro.props.locale ?? getLocaleFromUrl(Astro.url);
 const t = useTranslation(locale);
 
-const availablePatterns = getAvailablePatterns();
+const patterns = getPatterns();
 const currentPattern = getPatternById(pattern);
 ---
 
@@ -52,7 +52,7 @@ const currentPattern = getPatternById(pattern);
           <hr class="border-border" />
           <ul class="py-1">
             {
-              availablePatterns.map((p) => (
+              patterns.map((p) => (
                 <li>
                   <a
                     href={withBase(getLocalizedPath(`/patterns/${p.id}/${framework}/`, locale))}

--- a/src/components/ui/pattern-search/PatternSearch.tsx
+++ b/src/components/ui/pattern-search/PatternSearch.tsx
@@ -5,7 +5,7 @@ import {
   getPreferredFramework,
   type Locale,
 } from '@/lib/pattern-search';
-import { getAvailablePatterns, type Pattern } from '@/lib/patterns';
+import { getPatterns, type Pattern } from '@/lib/patterns';
 import { getPatternDescription } from '@/i18n/patterns';
 import type { KeyboardEvent, ReactElement } from 'react';
 import { Search } from 'lucide-react';
@@ -43,21 +43,21 @@ export function PatternSearch({
   const listboxRef = useRef<HTMLUListElement>(null);
 
   // Get available patterns
-  const availablePatterns = useMemo(() => getAvailablePatterns(), []);
+  const patterns = useMemo(() => getPatterns(), []);
 
   // Filter patterns based on query
   const filteredPatterns = useMemo(() => {
     if (!query.trim()) {
-      return availablePatterns;
+      return patterns;
     }
 
     const lowerQuery = query.toLowerCase();
-    return availablePatterns.filter(
+    return patterns.filter(
       (pattern) =>
         pattern.name.toLowerCase().includes(lowerQuery) ||
         pattern.description.toLowerCase().includes(lowerQuery)
     );
-  }, [availablePatterns, query]);
+  }, [patterns, query]);
 
   // Group patterns alphabetically and get sorted keys
   const { groupedPatterns, groupKeys } = useMemo(() => {

--- a/src/components/ui/pattern-sidebar/PatternSidebar.astro
+++ b/src/components/ui/pattern-sidebar/PatternSidebar.astro
@@ -1,6 +1,6 @@
 ---
 import { FRAMEWORK_INFO, type Framework } from '@/lib/frameworks';
-import { getAvailablePatterns, getPlannedPatterns } from '@/lib/patterns';
+import { getPatterns } from '@/lib/patterns';
 import { SidebarMenu, SidebarMenuItem, SidebarMenuButton } from '@/components/ui/sidebar';
 import { withBase } from '@/lib/utils';
 import FrameworkIcon from '@/components/ui/FrameworkIcon.astro';
@@ -22,8 +22,7 @@ const { currentPattern, currentFramework } = Astro.props;
 const locale = Astro.props.locale ?? getLocaleFromUrl(Astro.url);
 const t = useTranslation(locale);
 
-const availablePatterns = getAvailablePatterns();
-const plannedPatterns = getPlannedPatterns();
+const patterns = getPatterns();
 const frameworkInfo = FRAMEWORK_INFO[currentFramework];
 ---
 
@@ -41,7 +40,7 @@ const frameworkInfo = FRAMEWORK_INFO[currentFramework];
 
   <SidebarMenu>
     {
-      availablePatterns.map((pattern) => (
+      patterns.map((pattern) => (
         <SidebarMenuItem>
           <SidebarMenuButton
             href={withBase(
@@ -61,31 +60,6 @@ const frameworkInfo = FRAMEWORK_INFO[currentFramework];
       ))
     }
   </SidebarMenu>
-
-  {
-    plannedPatterns.length > 0 && (
-      <>
-        <div class="mt-6 mb-2">
-          <h3 class="text-muted-foreground px-2 text-xs font-medium tracking-wider uppercase">
-            {t('status.planned')}
-          </h3>
-        </div>
-        <ul class="flex w-full min-w-0 flex-col gap-1 pb-8">
-          {plannedPatterns.map((pattern) => (
-            <li class="group/menu-item relative">
-              <span class="text-muted-foreground flex h-7 w-full cursor-default items-center gap-2 overflow-hidden rounded-md px-2 text-left text-sm opacity-60">
-                <span class="inline-flex w-5 justify-center text-xs" aria-hidden="true">
-                  {pattern.icon}
-                </span>
-                <span class="truncate">{getPatternName(pattern.id, pattern.name, locale)}</span>
-                <span class="sr-only">({t('status.planned')})</span>
-              </span>
-            </li>
-          ))}
-        </ul>
-      </>
-    )
-  }
 </nav>
 
 <style>

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -60,14 +60,8 @@ export const ui = {
     'table.value': 'Value',
     'table.description': 'Description',
 
-    // Complexity
-    'complexity.low': 'Low',
-    'complexity.medium': 'Medium',
-    'complexity.high': 'High',
-
     // Status
     'status.available': 'Available',
-    'status.planned': 'Planned',
 
     // Language
     'language.switch': 'Language',
@@ -131,14 +125,8 @@ export const ui = {
     'table.value': '値',
     'table.description': '説明',
 
-    // Complexity
-    'complexity.low': '低',
-    'complexity.medium': '中',
-    'complexity.high': '高',
-
     // Status
     'status.available': '実装済み',
-    'status.planned': '実装予定',
 
     // Language
     'language.switch': '言語',

--- a/src/lib/patterns.ts
+++ b/src/lib/patterns.ts
@@ -6,11 +6,6 @@
  */
 
 /**
- * Pattern status
- */
-export type PatternStatus = 'available' | 'planned';
-
-/**
  * Pattern definition
  */
 export interface Pattern {
@@ -18,12 +13,10 @@ export interface Pattern {
   name: string;
   description: string;
   icon: string;
-  complexity: 'Low' | 'Medium' | 'High';
-  status: PatternStatus;
 }
 
 /**
- * All patterns (available and planned)
+ * All patterns
  * Based on WAI-ARIA APG: https://www.w3.org/WAI/ARIA/apg/patterns/
  */
 export const PATTERNS: Pattern[] = [
@@ -33,8 +26,6 @@ export const PATTERNS: Pattern[] = [
     description:
       'A vertically stacked set of interactive headings that each reveal a section of content.',
     icon: '🪗',
-    complexity: 'Medium',
-    status: 'available',
   },
   {
     id: 'alert',
@@ -42,8 +33,6 @@ export const PATTERNS: Pattern[] = [
     description:
       "An element that displays a brief, important message in a way that attracts the user's attention without interrupting the user's task.",
     icon: '⚠️',
-    complexity: 'Low',
-    status: 'available',
   },
   {
     id: 'alert-dialog',
@@ -51,16 +40,12 @@ export const PATTERNS: Pattern[] = [
     description:
       "A modal dialog that interrupts the user's workflow to communicate an important message and acquire a response.",
     icon: '🚨',
-    complexity: 'High',
-    status: 'available',
   },
   {
     id: 'breadcrumb',
     name: 'Breadcrumb',
     description: 'A list of links to the parent pages of the current page in hierarchical order.',
     icon: '🔗',
-    complexity: 'Low',
-    status: 'available',
   },
   {
     id: 'button',
@@ -68,8 +53,6 @@ export const PATTERNS: Pattern[] = [
     description:
       'An element with role="button" that enables users to trigger an action. Demonstrates why native <button> is recommended.',
     icon: '🔘',
-    complexity: 'Low',
-    status: 'available',
   },
   {
     id: 'toggle-button',
@@ -77,8 +60,6 @@ export const PATTERNS: Pattern[] = [
     description:
       'A two-state button that can be either pressed or not pressed, using aria-pressed to communicate state.',
     icon: '🔀',
-    complexity: 'Low',
-    status: 'available',
   },
   {
     id: 'carousel',
@@ -86,8 +67,6 @@ export const PATTERNS: Pattern[] = [
     description:
       'Presents a set of items, referred to as slides, by sequentially displaying a subset of one or more slides.',
     icon: '🎠',
-    complexity: 'High',
-    status: 'available',
   },
   {
     id: 'checkbox',
@@ -95,8 +74,6 @@ export const PATTERNS: Pattern[] = [
     description:
       'Supports dual-state (checked/unchecked) and tri-state (checked/unchecked/partially checked) checkboxes.',
     icon: '☑️',
-    complexity: 'Low',
-    status: 'available',
   },
   {
     id: 'combobox',
@@ -104,24 +81,18 @@ export const PATTERNS: Pattern[] = [
     description:
       'An input widget with an associated popup that enables users to select a value from a collection.',
     icon: '🔽',
-    complexity: 'High',
-    status: 'available',
   },
   {
     id: 'dialog',
     name: 'Dialog (Modal)',
     description: 'A window overlaid on the primary window, rendering the content underneath inert.',
     icon: '💬',
-    complexity: 'High',
-    status: 'available',
   },
   {
     id: 'disclosure',
     name: 'Disclosure',
     description: 'A button that controls the visibility of a section of content.',
     icon: '▼',
-    complexity: 'Low',
-    status: 'available',
   },
   {
     id: 'feed',
@@ -129,8 +100,6 @@ export const PATTERNS: Pattern[] = [
     description:
       'A section of a page that automatically loads new sections of content as the user scrolls.',
     icon: '📰',
-    complexity: 'High',
-    status: 'available',
   },
   {
     id: 'grid',
@@ -138,24 +107,18 @@ export const PATTERNS: Pattern[] = [
     description:
       'A container that enables users to navigate the information or interactive elements using directional navigation keys.',
     icon: '📊',
-    complexity: 'High',
-    status: 'available',
   },
   {
     id: 'landmarks',
     name: 'Landmarks',
     description: 'A set of eight roles that identify the major sections of a page.',
     icon: '🗺️',
-    complexity: 'Low',
-    status: 'available',
   },
   {
     id: 'link',
     name: 'Link',
     description: 'A widget that provides an interactive reference to a resource.',
     icon: '↗️',
-    complexity: 'Low',
-    status: 'available',
   },
   {
     id: 'listbox',
@@ -163,8 +126,6 @@ export const PATTERNS: Pattern[] = [
     description:
       'A widget that allows the user to select one or more items from a list of choices.',
     icon: '📝',
-    complexity: 'Medium',
-    status: 'available',
   },
   {
     id: 'menubar',
@@ -172,24 +133,18 @@ export const PATTERNS: Pattern[] = [
     description:
       'A horizontal menu bar with dropdown menus, submenus, checkbox items, and radio groups for application-style navigation.',
     icon: '🖥️',
-    complexity: 'High',
-    status: 'available',
   },
   {
     id: 'menu-button',
     name: 'Menu Button',
     description: 'A button that opens a menu of actions or options.',
     icon: '☰',
-    complexity: 'Medium',
-    status: 'available',
   },
   {
     id: 'meter',
     name: 'Meter',
     description: 'A graphical display of a numeric value that varies within a defined range.',
     icon: '📶',
-    complexity: 'Low',
-    status: 'available',
   },
   {
     id: 'radio-group',
@@ -197,16 +152,12 @@ export const PATTERNS: Pattern[] = [
     description:
       'A set of checkable buttons, known as radio buttons, where only one can be checked at a time.',
     icon: '🔘',
-    complexity: 'Medium',
-    status: 'available',
   },
   {
     id: 'slider',
     name: 'Slider',
     description: 'An input where the user selects a value from within a given range.',
     icon: '🎚️',
-    complexity: 'Medium',
-    status: 'available',
   },
   {
     id: 'slider-multithumb',
@@ -214,8 +165,6 @@ export const PATTERNS: Pattern[] = [
     description:
       'A slider with two thumbs that allows users to select a range of values within a given range.',
     icon: '↔️',
-    complexity: 'High',
-    status: 'available',
   },
   {
     id: 'spinbutton',
@@ -223,8 +172,6 @@ export const PATTERNS: Pattern[] = [
     description:
       'An input widget for selecting from a range of discrete values, typically with increment/decrement buttons.',
     icon: '🔢',
-    complexity: 'Medium',
-    status: 'available',
   },
   {
     id: 'switch',
@@ -232,8 +179,6 @@ export const PATTERNS: Pattern[] = [
     description:
       'A type of checkbox that represents on/off values, as opposed to checked/unchecked.',
     icon: '🌓',
-    complexity: 'Low',
-    status: 'available',
   },
   {
     id: 'table',
@@ -241,8 +186,6 @@ export const PATTERNS: Pattern[] = [
     description:
       'A static tabular structure containing one or more rows that each contain one or more cells.',
     icon: '🧮',
-    complexity: 'Medium',
-    status: 'available',
   },
   {
     id: 'tabs',
@@ -250,8 +193,6 @@ export const PATTERNS: Pattern[] = [
     description:
       'A set of layered sections of content, known as tab panels, that display one panel at a time.',
     icon: '🗂️',
-    complexity: 'Medium',
-    status: 'available',
   },
   {
     id: 'toolbar',
@@ -259,8 +200,6 @@ export const PATTERNS: Pattern[] = [
     description:
       'A container for grouping a set of controls, such as buttons, toggle buttons, or checkboxes.',
     icon: '🔧',
-    complexity: 'Medium',
-    status: 'available',
   },
   {
     id: 'tooltip',
@@ -268,8 +207,6 @@ export const PATTERNS: Pattern[] = [
     description:
       'A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.',
     icon: '💡',
-    complexity: 'Medium',
-    status: 'available',
   },
   {
     id: 'tree-view',
@@ -277,8 +214,6 @@ export const PATTERNS: Pattern[] = [
     description:
       'A widget that presents a hierarchical list with nested groups that can be collapsed and expanded.',
     icon: '🌲',
-    complexity: 'High',
-    status: 'available',
   },
   {
     id: 'treegrid',
@@ -286,8 +221,6 @@ export const PATTERNS: Pattern[] = [
     description:
       'A widget that presents a hierarchical data grid consisting of tabular information that is editable or interactive.',
     icon: '📊',
-    complexity: 'High',
-    status: 'available',
   },
   {
     id: 'data-grid',
@@ -295,17 +228,6 @@ export const PATTERNS: Pattern[] = [
     description:
       'An advanced grid for displaying and manipulating tabular data with sorting, filtering, and row selection.',
     icon: '📋',
-    complexity: 'High',
-    status: 'available',
-  },
-  {
-    id: 'editable-grid',
-    name: 'Editable Grid',
-    description:
-      'A spreadsheet-like grid with inline cell editing, dropdowns, and validation support.',
-    icon: '✏️',
-    complexity: 'High',
-    status: 'planned',
   },
   {
     id: 'window-splitter',
@@ -313,23 +235,14 @@ export const PATTERNS: Pattern[] = [
     description:
       'A moveable separator between two sections, or panes, that enables users to change the relative size of the panes.',
     icon: '↔️',
-    complexity: 'Medium',
-    status: 'available',
   },
 ];
 
 /**
- * Get available patterns only
+ * Get all patterns
  */
-export function getAvailablePatterns(): Pattern[] {
-  return PATTERNS.filter((p) => p.status === 'available');
-}
-
-/**
- * Get planned patterns only
- */
-export function getPlannedPatterns(): Pattern[] {
-  return PATTERNS.filter((p) => p.status === 'planned');
+export function getPatterns(): Pattern[] {
+  return PATTERNS;
 }
 
 /**

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,9 +2,9 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { Tile, TileContent, TileTitle, TileDescription } from '@/components/ui/tile';
 import { withBase } from '@/lib/utils';
-import { getAvailablePatterns } from '@/lib/patterns';
+import { getPatterns } from '@/lib/patterns';
 
-const availablePatterns = getAvailablePatterns();
+const patterns = getPatterns();
 ---
 
 <BaseLayout title="Home">
@@ -25,7 +25,7 @@ const availablePatterns = getAvailablePatterns();
       <h2 class="mb-6 text-2xl font-bold">Available Patterns</h2>
       <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         {
-          availablePatterns.map((pattern) => (
+          patterns.map((pattern) => (
             <Tile variant="floating" href={withBase(`/patterns/${pattern.id}/`)}>
               <TileContent class="flex flex-row items-center gap-4 text-left">
                 <div class="bg-muted flex h-12 w-12 shrink-0 items-center justify-center rounded-full text-2xl">

--- a/src/pages/ja/index.astro
+++ b/src/pages/ja/index.astro
@@ -2,12 +2,12 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { Tile, TileContent, TileTitle, TileDescription } from '@/components/ui/tile';
 import { withBase } from '@/lib/utils';
-import { getAvailablePatterns } from '@/lib/patterns';
+import { getPatterns } from '@/lib/patterns';
 import { getLocalizedPath, useTranslation, getPatternName, getPatternDescription } from '@/i18n';
 
 const locale = 'ja';
 const t = useTranslation(locale);
-const availablePatterns = getAvailablePatterns();
+const patterns = getPatterns();
 ---
 
 <BaseLayout title={t('nav.patterns')} locale={locale}>
@@ -31,7 +31,7 @@ const availablePatterns = getAvailablePatterns();
       <h2 class="mb-6 text-2xl font-bold">{t('patterns.available')}</h2>
       <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         {
-          availablePatterns.map((pattern) => (
+          patterns.map((pattern) => (
             <Tile
               variant="floating"
               href={withBase(getLocalizedPath(`/patterns/${pattern.id}/`, locale))}

--- a/src/pages/ja/patterns/[pattern]/[file].md.ts
+++ b/src/pages/ja/patterns/[pattern]/[file].md.ts
@@ -1,10 +1,10 @@
 import type { APIRoute, GetStaticPaths } from 'astro';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
-import { getAvailablePatterns } from '@/lib/patterns';
+import { getPatterns } from '@/lib/patterns';
 
 // Get pattern IDs from the centralized patterns definition
-const patterns = getAvailablePatterns().map((p) => p.id);
+const patterns = getPatterns().map((p) => p.id);
 
 export const getStaticPaths: GetStaticPaths = () => {
   // Generate paths where file equals {pattern}.ja (e.g., /ja/patterns/accordion/accordion.ja.md)

--- a/src/pages/ja/patterns/[pattern]/index.astro
+++ b/src/pages/ja/patterns/[pattern]/index.astro
@@ -3,14 +3,14 @@
 // This single file handles redirects for all patterns
 
 import { FRAMEWORKS, DEFAULT_FRAMEWORK } from '@/lib/frameworks';
-import { getAvailablePatterns } from '@/lib/patterns';
+import { getPatterns } from '@/lib/patterns';
 import { withBase } from '@/lib/utils';
 import { getLocalizedPath } from '@/i18n';
 
 const locale = 'ja';
 
 export function getStaticPaths() {
-  return getAvailablePatterns().map((p) => ({ params: { pattern: p.id } }));
+  return getPatterns().map((p) => ({ params: { pattern: p.id } }));
 }
 
 const { pattern } = Astro.params;

--- a/src/pages/ja/patterns/index.astro
+++ b/src/pages/ja/patterns/index.astro
@@ -1,21 +1,14 @@
 ---
 import BaseLayout from '../../../layouts/BaseLayout.astro';
 import { Tile, TileContent, TileTitle, TileDescription } from '@/components/ui/tile';
-import { getAvailablePatterns, getPlannedPatterns } from '@/lib/patterns';
+import { getPatterns } from '@/lib/patterns';
 import { withBase } from '@/lib/utils';
 import { getLocalizedPath, useTranslation, getPatternName, getPatternDescription } from '@/i18n';
 
 const locale = 'ja';
 const t = useTranslation(locale);
 
-const availablePatterns = getAvailablePatterns();
-const plannedPatterns = getPlannedPatterns();
-
-const complexityLabels = {
-  Low: t('complexity.low'),
-  Medium: t('complexity.medium'),
-  High: t('complexity.high'),
-};
+const patterns = getPatterns();
 ---
 
 <BaseLayout title={t('patterns.title')} locale={locale}>
@@ -32,7 +25,7 @@ const complexityLabels = {
       <h2 class="mb-4 text-xl font-semibold">{t('patterns.available')}</h2>
       <div class="grid gap-4 md:grid-cols-2">
         {
-          availablePatterns.map((pattern) => (
+          patterns.map((pattern) => (
             <Tile
               variant="floating"
               href={withBase(getLocalizedPath(`/patterns/${pattern.id}/`, locale))}
@@ -46,35 +39,6 @@ const complexityLabels = {
                   <TileDescription>
                     {getPatternDescription(pattern.id, pattern.description, locale)}
                   </TileDescription>
-                  <div class="text-muted-foreground mt-2 text-xs">
-                    複雑度: {complexityLabels[pattern.complexity]}
-                  </div>
-                </div>
-              </TileContent>
-            </Tile>
-          ))
-        }
-      </div>
-    </section>
-
-    <section class="mb-12">
-      <h2 class="text-muted-foreground mb-4 text-xl font-semibold">{t('patterns.planned')}</h2>
-      <div class="grid gap-4 md:grid-cols-2">
-        {
-          plannedPatterns.map((pattern) => (
-            <Tile variant="floating" class="cursor-default opacity-60">
-              <TileContent class="flex flex-row items-start gap-4">
-                <div class="bg-muted flex h-12 w-12 shrink-0 items-center justify-center rounded-full text-2xl">
-                  {pattern.icon}
-                </div>
-                <div class="flex-1">
-                  <TileTitle>{getPatternName(pattern.id, pattern.name, locale)}</TileTitle>
-                  <TileDescription>
-                    {getPatternDescription(pattern.id, pattern.description, locale)}
-                  </TileDescription>
-                  <div class="text-muted-foreground mt-2 text-xs">
-                    複雑度: {complexityLabels[pattern.complexity]}
-                  </div>
                 </div>
               </TileContent>
             </Tile>

--- a/src/pages/patterns/[pattern]/[file].md.ts
+++ b/src/pages/patterns/[pattern]/[file].md.ts
@@ -1,10 +1,10 @@
 import type { APIRoute, GetStaticPaths } from 'astro';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
-import { getAvailablePatterns } from '@/lib/patterns';
+import { getPatterns } from '@/lib/patterns';
 
 // Get pattern IDs from the centralized patterns definition
-const patterns = getAvailablePatterns().map((p) => p.id);
+const patterns = getPatterns().map((p) => p.id);
 
 export const getStaticPaths: GetStaticPaths = () => {
   // Generate paths where file equals pattern name (e.g., /patterns/accordion/accordion.md)

--- a/src/pages/patterns/[pattern]/index.astro
+++ b/src/pages/patterns/[pattern]/index.astro
@@ -3,11 +3,11 @@
 // This single file handles redirects for all patterns
 
 import { FRAMEWORKS, DEFAULT_FRAMEWORK } from '@/lib/frameworks';
-import { getAvailablePatterns } from '@/lib/patterns';
+import { getPatterns } from '@/lib/patterns';
 import { withBase } from '@/lib/utils';
 
 export function getStaticPaths() {
-  return getAvailablePatterns().map((p) => ({ params: { pattern: p.id } }));
+  return getPatterns().map((p) => ({ params: { pattern: p.id } }));
 }
 
 const { pattern } = Astro.params;

--- a/src/pages/patterns/index.astro
+++ b/src/pages/patterns/index.astro
@@ -1,11 +1,10 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { Tile, TileContent, TileTitle, TileDescription } from '@/components/ui/tile';
-import { getAvailablePatterns, getPlannedPatterns } from '@/lib/patterns';
+import { getPatterns } from '@/lib/patterns';
 import { withBase } from '@/lib/utils';
 
-const availablePatterns = getAvailablePatterns();
-const plannedPatterns = getPlannedPatterns();
+const patterns = getPatterns();
 ---
 
 <BaseLayout title="Patterns">
@@ -22,7 +21,7 @@ const plannedPatterns = getPlannedPatterns();
       <h2 class="mb-4 text-xl font-semibold">Available</h2>
       <div class="grid gap-4 md:grid-cols-2">
         {
-          availablePatterns.map((pattern) => (
+          patterns.map((pattern) => (
             <Tile variant="floating" href={withBase(`/patterns/${pattern.id}/`)}>
               <TileContent class="flex flex-row items-start gap-4">
                 <div class="bg-muted flex h-12 w-12 shrink-0 items-center justify-center rounded-full text-2xl">
@@ -31,33 +30,6 @@ const plannedPatterns = getPlannedPatterns();
                 <div class="flex-1">
                   <TileTitle>{pattern.name}</TileTitle>
                   <TileDescription>{pattern.description}</TileDescription>
-                  <div class="text-muted-foreground mt-2 text-xs">
-                    Complexity: {pattern.complexity}
-                  </div>
-                </div>
-              </TileContent>
-            </Tile>
-          ))
-        }
-      </div>
-    </section>
-
-    <section class="mb-12">
-      <h2 class="text-muted-foreground mb-4 text-xl font-semibold">Planned</h2>
-      <div class="grid gap-4 md:grid-cols-2">
-        {
-          plannedPatterns.map((pattern) => (
-            <Tile variant="floating" class="cursor-default opacity-60">
-              <TileContent class="flex flex-row items-start gap-4">
-                <div class="bg-muted flex h-12 w-12 shrink-0 items-center justify-center rounded-full text-2xl">
-                  {pattern.icon}
-                </div>
-                <div class="flex-1">
-                  <TileTitle>{pattern.name}</TileTitle>
-                  <TileDescription>{pattern.description}</TileDescription>
-                  <div class="text-muted-foreground mt-2 text-xs">
-                    Complexity: {pattern.complexity}
-                  </div>
                 </div>
               </TileContent>
             </Tile>

--- a/src/patterns/feed/FeedDemo.astro
+++ b/src/patterns/feed/FeedDemo.astro
@@ -1,29 +1,28 @@
 ---
 import Feed, { type FeedArticle } from './Feed.astro';
 import KeyboardHints from './KeyboardHints.astro';
-import { getAvailablePatterns, type Pattern } from '@/lib/patterns';
+import { getPatterns, type Pattern } from '@/lib/patterns';
 
-const availablePatterns = getAvailablePatterns();
+const patterns = getPatterns();
 
 const generateArticleFromPattern = (pattern: Pattern): FeedArticle => ({
   id: `article-${pattern.id}`,
   title: `${pattern.icon} ${pattern.name}`,
-  description: `Complexity: ${pattern.complexity}`,
+  description: pattern.description,
   content: `${pattern.description}\n\nView ${pattern.name} pattern: /patterns/${pattern.id}/astro/`,
 });
 
-const initialArticles: FeedArticle[] = availablePatterns
+const initialArticles: FeedArticle[] = patterns
   .slice(0, 3)
   .map((pattern) => generateArticleFromPattern(pattern));
 
 // Pass patterns data to client-side script
 const patternsJson = JSON.stringify(
-  availablePatterns.map((p) => ({
+  patterns.map((p) => ({
     id: p.id,
     name: p.name,
     icon: p.icon,
     description: p.description,
-    complexity: p.complexity,
   }))
 );
 ---
@@ -84,7 +83,6 @@ const patternsJson = JSON.stringify(
     name: string;
     icon: string;
     description: string;
-    complexity: string;
   }
 
   class ApgFeedInfiniteDemo extends HTMLElement {
@@ -194,7 +192,7 @@ const patternsJson = JSON.stringify(
           }
           if (desc) {
             desc.id = descId;
-            desc.textContent = `Complexity: ${pattern.complexity}`;
+            desc.textContent = pattern.description;
           }
           if (content) {
             content.textContent = `${pattern.description}\n\nView ${pattern.name} pattern: /patterns/${pattern.id}/astro/`;

--- a/src/patterns/feed/FeedDemo.svelte
+++ b/src/patterns/feed/FeedDemo.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
   import Feed, { type FeedArticle } from './Feed.svelte';
   import KeyboardHints from './KeyboardHints.svelte';
-  import { getAvailablePatterns, type Pattern } from '@/lib/patterns';
+  import { getPatterns, type Pattern } from '@/lib/patterns';
 
-  const availablePatterns = getAvailablePatterns();
+  const patterns = getPatterns();
 
   const generateArticleFromPattern = (pattern: Pattern): FeedArticle => ({
     id: `article-${pattern.id}`,
     title: `${pattern.icon} ${pattern.name}`,
     description: pattern.description,
-    content: `${pattern.description}\n\nComplexity: ${pattern.complexity}\n\nView ${pattern.name} pattern: /patterns/${pattern.id}/svelte/`,
+    content: `${pattern.description}\n\nView ${pattern.name} pattern: /patterns/${pattern.id}/svelte/`,
   });
 
-  const initialArticles: FeedArticle[] = availablePatterns
+  const initialArticles: FeedArticle[] = patterns
     .slice(0, 3)
     .map((pattern) => generateArticleFromPattern(pattern));
 
@@ -28,13 +28,13 @@
 
     setTimeout(() => {
       const currentLength = articles.length;
-      const nextPatterns = availablePatterns.slice(currentLength, currentLength + 2);
+      const nextPatterns = patterns.slice(currentLength, currentLength + 2);
       const newArticles = nextPatterns.map((pattern) => generateArticleFromPattern(pattern));
 
       articles = [...articles, ...newArticles];
       loading = false;
 
-      if (currentLength + newArticles.length >= availablePatterns.length) {
+      if (currentLength + newArticles.length >= patterns.length) {
         hasMore = false;
       }
     }, 1000);
@@ -42,8 +42,8 @@
 
   function addArticle() {
     const currentLength = articles.length;
-    if (currentLength < availablePatterns.length) {
-      const nextPattern = availablePatterns[currentLength];
+    if (currentLength < patterns.length) {
+      const nextPattern = patterns[currentLength];
       articles = [...articles, generateArticleFromPattern(nextPattern)];
     }
   }

--- a/src/patterns/feed/FeedDemo.tsx
+++ b/src/patterns/feed/FeedDemo.tsx
@@ -1,13 +1,13 @@
 import { useState, useCallback, useRef } from 'react';
 import { Feed, type FeedArticle } from './Feed';
-import { getAvailablePatterns, type Pattern } from '@/lib/patterns';
+import { getPatterns, type Pattern } from '@/lib/patterns';
 
-const availablePatterns = getAvailablePatterns();
+const patterns = getPatterns();
 
 const generateArticleFromPattern = (pattern: Pattern): FeedArticle => ({
   id: `article-${pattern.id}`,
   title: `${pattern.icon} ${pattern.name}`,
-  description: `Complexity: ${pattern.complexity}`,
+  description: pattern.description,
   content: (
     <>
       <p>{pattern.description}</p>
@@ -18,7 +18,7 @@ const generateArticleFromPattern = (pattern: Pattern): FeedArticle => ({
   ),
 });
 
-const initialArticles: FeedArticle[] = availablePatterns
+const initialArticles: FeedArticle[] = patterns
   .slice(0, 3)
   .map((pattern) => generateArticleFromPattern(pattern));
 
@@ -64,14 +64,14 @@ export function FeedDemo() {
     // Simulate API call
     setTimeout(() => {
       const currentLength = articles.length;
-      const nextPatterns = availablePatterns.slice(currentLength, currentLength + 2);
+      const nextPatterns = patterns.slice(currentLength, currentLength + 2);
       const newArticles = nextPatterns.map((pattern) => generateArticleFromPattern(pattern));
 
       setArticles((prev) => [...prev, ...newArticles]);
       setLoading(false);
 
       // Stop when all patterns are loaded
-      if (currentLength + newArticles.length >= availablePatterns.length) {
+      if (currentLength + newArticles.length >= patterns.length) {
         setHasMore(false);
       }
     }, 1000);
@@ -79,8 +79,8 @@ export function FeedDemo() {
 
   const addArticle = useCallback(() => {
     const currentLength = articles.length;
-    if (currentLength < availablePatterns.length) {
-      const nextPattern = availablePatterns[currentLength];
+    if (currentLength < patterns.length) {
+      const nextPattern = patterns[currentLength];
       setArticles((prev) => [...prev, generateArticleFromPattern(nextPattern)]);
     }
   }, [articles.length]);

--- a/src/patterns/feed/FeedDemo.vue
+++ b/src/patterns/feed/FeedDemo.vue
@@ -56,18 +56,18 @@
 import { ref } from 'vue';
 import Feed, { type FeedArticle } from './Feed.vue';
 import KeyboardHints from './KeyboardHints.vue';
-import { getAvailablePatterns, type Pattern } from '@/lib/patterns';
+import { getPatterns, type Pattern } from '@/lib/patterns';
 
-const availablePatterns = getAvailablePatterns();
+const patterns = getPatterns();
 
 const generateArticleFromPattern = (pattern: Pattern): FeedArticle => ({
   id: `article-${pattern.id}`,
   title: `${pattern.icon} ${pattern.name}`,
   description: pattern.description,
-  content: `${pattern.description}\n\nComplexity: ${pattern.complexity}\n\nView ${pattern.name} pattern: /patterns/${pattern.id}/vue/`,
+  content: `${pattern.description}\n\nView ${pattern.name} pattern: /patterns/${pattern.id}/vue/`,
 });
 
-const initialArticles: FeedArticle[] = availablePatterns
+const initialArticles: FeedArticle[] = patterns
   .slice(0, 3)
   .map((pattern) => generateArticleFromPattern(pattern));
 
@@ -83,13 +83,13 @@ const loadMore = () => {
 
   setTimeout(() => {
     const currentLength = articles.value.length;
-    const nextPatterns = availablePatterns.slice(currentLength, currentLength + 2);
+    const nextPatterns = patterns.slice(currentLength, currentLength + 2);
     const newArticles = nextPatterns.map((pattern) => generateArticleFromPattern(pattern));
 
     articles.value.push(...newArticles);
     loading.value = false;
 
-    if (currentLength + newArticles.length >= availablePatterns.length) {
+    if (currentLength + newArticles.length >= patterns.length) {
       hasMore.value = false;
     }
   }, 1000);
@@ -97,8 +97,8 @@ const loadMore = () => {
 
 const addArticle = () => {
   const currentLength = articles.value.length;
-  if (currentLength < availablePatterns.length) {
-    const nextPattern = availablePatterns[currentLength];
+  if (currentLength < patterns.length) {
+    const nextPattern = patterns[currentLength];
     articles.value.push(generateArticleFromPattern(nextPattern));
   }
 };

--- a/src/patterns/feed/FeedDemoJa.astro
+++ b/src/patterns/feed/FeedDemoJa.astro
@@ -1,29 +1,28 @@
 ---
 import Feed, { type FeedArticle } from './Feed.astro';
 import KeyboardHintsJa from './KeyboardHintsJa.astro';
-import { getAvailablePatterns, type Pattern } from '@/lib/patterns';
+import { getPatterns, type Pattern } from '@/lib/patterns';
 
-const availablePatterns = getAvailablePatterns();
+const patterns = getPatterns();
 
 const generateArticleFromPattern = (pattern: Pattern): FeedArticle => ({
   id: `article-${pattern.id}`,
   title: `${pattern.icon} ${pattern.name}`,
-  description: `複雑度: ${pattern.complexity}`,
+  description: pattern.description,
   content: `${pattern.description}\n\n${pattern.name} パターンを見る: /ja/patterns/${pattern.id}/astro/`,
 });
 
-const initialArticles: FeedArticle[] = availablePatterns
+const initialArticles: FeedArticle[] = patterns
   .slice(0, 3)
   .map((pattern) => generateArticleFromPattern(pattern));
 
 // Pass patterns data to client-side script
 const patternsJson = JSON.stringify(
-  availablePatterns.map((p) => ({
+  patterns.map((p) => ({
     id: p.id,
     name: p.name,
     icon: p.icon,
     description: p.description,
-    complexity: p.complexity,
   }))
 );
 ---
@@ -82,7 +81,6 @@ const patternsJson = JSON.stringify(
     name: string;
     icon: string;
     description: string;
-    complexity: string;
   }
 
   class ApgFeedInfiniteDemoJa extends HTMLElement {
@@ -192,7 +190,7 @@ const patternsJson = JSON.stringify(
           }
           if (desc) {
             desc.id = descId;
-            desc.textContent = `複雑度: ${pattern.complexity}`;
+            desc.textContent = pattern.description;
           }
           if (content) {
             content.textContent = `${pattern.description}\n\n${pattern.name} パターンを見る: /ja/patterns/${pattern.id}/astro/`;

--- a/src/patterns/feed/FeedDemoJa.svelte
+++ b/src/patterns/feed/FeedDemoJa.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
   import Feed, { type FeedArticle } from './Feed.svelte';
   import KeyboardHintsJa from './KeyboardHintsJa.svelte';
-  import { getAvailablePatterns, type Pattern } from '@/lib/patterns';
+  import { getPatterns, type Pattern } from '@/lib/patterns';
 
-  const availablePatterns = getAvailablePatterns();
+  const patterns = getPatterns();
 
   const generateArticleFromPattern = (pattern: Pattern): FeedArticle => ({
     id: `article-${pattern.id}`,
     title: `${pattern.icon} ${pattern.name}`,
     description: pattern.description,
-    content: `${pattern.description}\n\n複雑度: ${pattern.complexity}\n\n${pattern.name} パターンを見る: /ja/patterns/${pattern.id}/svelte/`,
+    content: `${pattern.description}\n\n${pattern.name} パターンを見る: /ja/patterns/${pattern.id}/svelte/`,
   });
 
-  const initialArticles: FeedArticle[] = availablePatterns
+  const initialArticles: FeedArticle[] = patterns
     .slice(0, 3)
     .map((pattern) => generateArticleFromPattern(pattern));
 
@@ -28,13 +28,13 @@
 
     setTimeout(() => {
       const currentLength = articles.length;
-      const nextPatterns = availablePatterns.slice(currentLength, currentLength + 2);
+      const nextPatterns = patterns.slice(currentLength, currentLength + 2);
       const newArticles = nextPatterns.map((pattern) => generateArticleFromPattern(pattern));
 
       articles = [...articles, ...newArticles];
       loading = false;
 
-      if (currentLength + newArticles.length >= availablePatterns.length) {
+      if (currentLength + newArticles.length >= patterns.length) {
         hasMore = false;
       }
     }, 1000);
@@ -42,8 +42,8 @@
 
   function addArticle() {
     const currentLength = articles.length;
-    if (currentLength < availablePatterns.length) {
-      const nextPattern = availablePatterns[currentLength];
+    if (currentLength < patterns.length) {
+      const nextPattern = patterns[currentLength];
       articles = [...articles, generateArticleFromPattern(nextPattern)];
     }
   }

--- a/src/patterns/feed/FeedDemoJa.tsx
+++ b/src/patterns/feed/FeedDemoJa.tsx
@@ -1,13 +1,13 @@
 import { useState, useCallback, useRef } from 'react';
 import { Feed, type FeedArticle } from './Feed';
-import { getAvailablePatterns, type Pattern } from '@/lib/patterns';
+import { getPatterns, type Pattern } from '@/lib/patterns';
 
-const availablePatterns = getAvailablePatterns();
+const patterns = getPatterns();
 
 const generateArticleFromPattern = (pattern: Pattern): FeedArticle => ({
   id: `article-${pattern.id}`,
   title: `${pattern.icon} ${pattern.name}`,
-  description: `複雑度: ${pattern.complexity}`,
+  description: pattern.description,
   content: (
     <>
       <p>{pattern.description}</p>
@@ -18,7 +18,7 @@ const generateArticleFromPattern = (pattern: Pattern): FeedArticle => ({
   ),
 });
 
-const initialArticles: FeedArticle[] = availablePatterns
+const initialArticles: FeedArticle[] = patterns
   .slice(0, 3)
   .map((pattern) => generateArticleFromPattern(pattern));
 
@@ -64,14 +64,14 @@ export function FeedDemoJa() {
     // Simulate API call
     setTimeout(() => {
       const currentLength = articles.length;
-      const nextPatterns = availablePatterns.slice(currentLength, currentLength + 2);
+      const nextPatterns = patterns.slice(currentLength, currentLength + 2);
       const newArticles = nextPatterns.map((pattern) => generateArticleFromPattern(pattern));
 
       setArticles((prev) => [...prev, ...newArticles]);
       setLoading(false);
 
       // Stop when all patterns are loaded
-      if (currentLength + newArticles.length >= availablePatterns.length) {
+      if (currentLength + newArticles.length >= patterns.length) {
         setHasMore(false);
       }
     }, 1000);
@@ -79,8 +79,8 @@ export function FeedDemoJa() {
 
   const addArticle = useCallback(() => {
     const currentLength = articles.length;
-    if (currentLength < availablePatterns.length) {
-      const nextPattern = availablePatterns[currentLength];
+    if (currentLength < patterns.length) {
+      const nextPattern = patterns[currentLength];
       setArticles((prev) => [...prev, generateArticleFromPattern(nextPattern)]);
     }
   }, [articles.length]);

--- a/src/patterns/feed/FeedDemoJa.vue
+++ b/src/patterns/feed/FeedDemoJa.vue
@@ -56,18 +56,18 @@
 import { ref } from 'vue';
 import Feed, { type FeedArticle } from './Feed.vue';
 import KeyboardHintsJa from './KeyboardHintsJa.vue';
-import { getAvailablePatterns, type Pattern } from '@/lib/patterns';
+import { getPatterns, type Pattern } from '@/lib/patterns';
 
-const availablePatterns = getAvailablePatterns();
+const patterns = getPatterns();
 
 const generateArticleFromPattern = (pattern: Pattern): FeedArticle => ({
   id: `article-${pattern.id}`,
   title: `${pattern.icon} ${pattern.name}`,
   description: pattern.description,
-  content: `${pattern.description}\n\n複雑度: ${pattern.complexity}\n\n${pattern.name} パターンを見る: /ja/patterns/${pattern.id}/vue/`,
+  content: `${pattern.description}\n\n${pattern.name} パターンを見る: /ja/patterns/${pattern.id}/vue/`,
 });
 
-const initialArticles: FeedArticle[] = availablePatterns
+const initialArticles: FeedArticle[] = patterns
   .slice(0, 3)
   .map((pattern) => generateArticleFromPattern(pattern));
 
@@ -83,13 +83,13 @@ const loadMore = () => {
 
   setTimeout(() => {
     const currentLength = articles.value.length;
-    const nextPatterns = availablePatterns.slice(currentLength, currentLength + 2);
+    const nextPatterns = patterns.slice(currentLength, currentLength + 2);
     const newArticles = nextPatterns.map((pattern) => generateArticleFromPattern(pattern));
 
     articles.value.push(...newArticles);
     loading.value = false;
 
-    if (currentLength + newArticles.length >= availablePatterns.length) {
+    if (currentLength + newArticles.length >= patterns.length) {
       hasMore.value = false;
     }
   }, 1000);
@@ -97,8 +97,8 @@ const loadMore = () => {
 
 const addArticle = () => {
   const currentLength = articles.value.length;
-  if (currentLength < availablePatterns.length) {
-    const nextPattern = availablePatterns[currentLength];
+  if (currentLength < patterns.length) {
+    const nextPattern = patterns[currentLength];
     articles.value.push(generateArticleFromPattern(nextPattern));
   }
 };


### PR DESCRIPTION
## Summary
- Remove `PatternStatus` type and `complexity`/`status` fields from `Pattern` interface
- Remove `editable-grid` entry (only planned pattern)
- Rename `getAvailablePatterns()` to `getPatterns()` and remove `getPlannedPatterns()`
- Remove Planned sections from pattern list pages and sidebar
- Remove Complexity displays from FeedDemo components
- Remove unused i18n keys (`complexity.*`, `status.planned`)

## Test plan
- [x] Type check passes (`npm run lint:types`)
- [x] Build succeeds (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [ ] Visual verification of pattern list pages (no Planned section, no Complexity)
- [ ] Visual verification of Feed demo (no Complexity display)

🤖 Generated with [Claude Code](https://claude.com/claude-code)