### PR TITLE
docs: simplify about page with full APG pattern coverage announcement

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -45,238 +45,26 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     </section>
 
     <section class="mb-12">
-      <h2 class="mb-4 text-2xl font-semibold">Component Status</h2>
-      <div class="overflow-x-auto">
-        <table class="w-full border-collapse text-sm">
-          <thead>
-            <tr class="border-b">
-              <th class="px-4 py-2 text-left font-semibold">Pattern</th>
-              <th class="px-4 py-2 text-center font-semibold">React</th>
-              <th class="px-4 py-2 text-center font-semibold">Vue</th>
-              <th class="px-4 py-2 text-center font-semibold">Svelte</th>
-              <th class="px-4 py-2 text-center font-semibold">Astro</th>
-              <th class="px-4 py-2 text-left font-semibold">Status</th>
-            </tr>
-          </thead>
-          <tbody class="text-muted-foreground">
-            <tr class="border-b"
-              ><td class="px-4 py-2">Accordion</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Alert</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Alert Dialog</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Breadcrumb</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Button</td><td class="px-4 py-2 text-center">-</td><td
-                class="px-4 py-2 text-center">-</td
-              ><td class="px-4 py-2 text-center">-</td><td class="px-4 py-2 text-center">-</td><td
-                class="px-4 py-2">Planned</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Carousel</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Checkbox</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Combobox</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Dialog</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Disclosure</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Feed</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Grid</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Landmarks</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Link</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Listbox</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Menubar</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Menu Button</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Meter</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Radio Group</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Slider</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Slider (Multi-Thumb)</td><td class="px-4 py-2 text-center"
-                >-</td
-              ><td class="px-4 py-2 text-center">-</td><td class="px-4 py-2 text-center">-</td><td
-                class="px-4 py-2 text-center">-</td
-              ><td class="px-4 py-2">Planned</td></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Spinbutton</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Switch</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Table</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Tabs</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Toggle Button</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Toolbar</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Tooltip</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Tree View</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Treegrid</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">Complete</td
-              ></tr
-            >
-            <tr
-              ><td class="px-4 py-2">Window Splitter</td><td class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2">Complete</td></tr
-            >
-          </tbody>
-        </table>
+      <h2 class="mb-4 text-2xl font-semibold">Pattern Coverage</h2>
+      <div class="text-muted-foreground space-y-4">
+        <p>
+          This project provides implementations for <strong>all 30 patterns</strong> defined in the
+          <a
+            href="https://www.w3.org/WAI/ARIA/apg/patterns/"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-primary hover:underline"
+          >
+            WAI-ARIA APG
+          </a>, plus 2 additional patterns (Toggle Button and Data Grid) — <strong
+            >32 patterns in total</strong
+          >.
+        </p>
+        <p>
+          Each pattern is implemented across all four frameworks: <strong>React</strong>, <strong
+            >Vue</strong
+          >, <strong>Svelte</strong>, and <strong>Astro</strong> (Web Components).
+        </p>
       </div>
     </section>
 

--- a/src/pages/ja/about.astro
+++ b/src/pages/ja/about.astro
@@ -47,238 +47,26 @@ const locale = 'ja';
     </section>
 
     <section class="mb-12">
-      <h2 class="mb-4 text-2xl font-semibold">コンポーネント実装状況</h2>
-      <div class="overflow-x-auto">
-        <table class="w-full border-collapse text-sm">
-          <thead>
-            <tr class="border-b">
-              <th class="px-4 py-2 text-left font-semibold">パターン</th>
-              <th class="px-4 py-2 text-center font-semibold">React</th>
-              <th class="px-4 py-2 text-center font-semibold">Vue</th>
-              <th class="px-4 py-2 text-center font-semibold">Svelte</th>
-              <th class="px-4 py-2 text-center font-semibold">Astro</th>
-              <th class="px-4 py-2 text-left font-semibold">状態</th>
-            </tr>
-          </thead>
-          <tbody class="text-muted-foreground">
-            <tr class="border-b"
-              ><td class="px-4 py-2">Accordion</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Alert</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Alert Dialog</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Breadcrumb</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Button</td><td class="px-4 py-2 text-center">-</td><td
-                class="px-4 py-2 text-center">-</td
-              ><td class="px-4 py-2 text-center">-</td><td class="px-4 py-2 text-center">-</td><td
-                class="px-4 py-2">予定</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Carousel</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Checkbox</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Combobox</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Dialog</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Disclosure</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Feed</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Grid</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Landmarks</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Link</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Listbox</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Menubar</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Menu Button</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Meter</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Radio Group</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Slider</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Slider (Multi-Thumb)</td><td class="px-4 py-2 text-center"
-                >-</td
-              ><td class="px-4 py-2 text-center">-</td><td class="px-4 py-2 text-center">-</td><td
-                class="px-4 py-2 text-center">-</td
-              ><td class="px-4 py-2">予定</td></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Spinbutton</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Switch</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Table</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Tabs</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Toggle Button</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Toolbar</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Tooltip</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Tree View</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr class="border-b"
-              ><td class="px-4 py-2">Treegrid</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2">完了</td
-              ></tr
-            >
-            <tr
-              ><td class="px-4 py-2">Window Splitter</td><td class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2 text-center">✅</td><td class="px-4 py-2 text-center">✅</td><td
-                class="px-4 py-2 text-center">✅</td
-              ><td class="px-4 py-2">完了</td></tr
-            >
-          </tbody>
-        </table>
+      <h2 class="mb-4 text-2xl font-semibold">パターン対応状況</h2>
+      <div class="text-muted-foreground space-y-4">
+        <p>
+          このプロジェクトでは、
+          <a
+            href="https://www.w3.org/WAI/ARIA/apg/patterns/"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-primary hover:underline"
+          >
+            WAI-ARIA APG
+          </a>
+          で定義されている<strong>全 30 パターン</strong>に加え、2 つの追加パターン（Toggle
+          Button、Data Grid）を実装しています — <strong>合計 32 パターン</strong>。
+        </p>
+        <p>
+          各パターンは <strong>React</strong>、<strong>Vue</strong>、<strong>Svelte</strong
+          >、<strong>Astro</strong>（Web Components）の 4
+          つのフレームワークすべてで実装されています。
+        </p>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- Replace verbose component status table (32 rows) with concise pattern coverage section
- Announce full coverage of all 30 WAI-ARIA APG patterns
- Note 2 additional patterns (Toggle Button, Data Grid) for 32 total
- Update both English and Japanese versions

## Changes
- **Before**: Large table listing each pattern with framework checkmarks
- **After**: Simple paragraph stating "all 30 APG patterns + 2 additional = 32 total"

## Test plan
- [ ] Verify about page renders correctly in English
- [ ] Verify about page renders correctly in Japanese
- [ ] Confirm pattern coverage statement is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)