### PR TITLE
fix(checkbox): Native HTMLセクションでのエンティティ二重エスケープを修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apg-patterns-examples",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apg-patterns-examples",
-      "version": "0.3.1",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler-rs": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apg-patterns-examples",
   "type": "module",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": false,
   "description": "Accessible UI components following WAI-ARIA APG patterns. Multi-framework implementations in React, Vue, Svelte, and Astro with documentation and tests.",
   "author": "masuP9",

--- a/src/patterns/checkbox/NativeHtmlNotice.astro
+++ b/src/patterns/checkbox/NativeHtmlNotice.astro
@@ -47,11 +47,13 @@ const titles = sectionTitles[locale];
     {titles.title}
   </h2>
   <p class="mb-4">
-    <strong class="text-red-700 dark:text-red-400"
-      >{
-        nativeHtmlConsiderations?.recommendation ? t(nativeHtmlConsiderations.recommendation) : ''
-      }</strong
-    >
+    {
+      nativeHtmlConsiderations?.recommendation && (
+        <strong class="text-red-700 dark:text-red-400">
+          <Fragment set:html={t(nativeHtmlConsiderations.recommendation)} />
+        </strong>
+      )
+    }
     {nativeHtmlConsiderations?.benefits ? t(nativeHtmlConsiderations.benefits) : ''}
   </p>
   <div class="bg-muted mb-4 rounded-md p-3">


### PR DESCRIPTION
## Summary

- Checkboxパターンページの「ネイティブ HTML を優先」セクションで、`<code>&lt;input type=\"checkbox\"&gt;</code>` というマークアップが文字列のまま画面に表示されてしまっていた問題を修正
- 原因: `NativeHtmlNotice.astro` が `recommendation` を `{t(...)}` のテキスト補間で出力していたため、`accessibility-data.ts` 内のHTMLが二重エスケープされて `&lt;` / `&gt;` が文字として描画されていた
- `radio-group` / `slider` / `table` で既に採用されている `<Fragment set:html={...}>` パターンに揃え、`<code>` 要素として正しくレンダリングされるよう変更

## Test plan

- [x] `/ja/patterns/checkbox/react/` で「ネイティブ HTML を優先」セクションの冒頭文が `<input type="checkbox">` をコードスタイルで表示することを Playwright で確認
- [x] `/patterns/checkbox/react/` の英語版も同様に確認
- [x] `npm run lint:astro` が 0 errors / 0 warnings でパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)