### PR TITLE
release: v0.3.4 — forced-colors hover/contrast fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apg-patterns-examples",
   "type": "module",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": false,
   "description": "Accessible UI components following WAI-ARIA APG patterns. Multi-framework implementations in React, Vue, Svelte, and Astro with documentation and tests.",
   "author": "masuP9",

--- a/src/styles/patterns/accordion.css
+++ b/src/styles/patterns/accordion.css
@@ -188,8 +188,8 @@
   }
 
   .apg-accordion-trigger--expanded {
-    background: Highlight;
-    color: HighlightText;
+    background: ButtonFace;
+    color: ButtonText;
   }
 
   .apg-accordion-trigger:focus {

--- a/src/styles/patterns/checkbox.css
+++ b/src/styles/patterns/checkbox.css
@@ -182,4 +182,24 @@ apg-checkbox {
     background: GrayText;
     border-color: GrayText;
   }
+
+  .apg-checkbox:hover .apg-checkbox-control {
+    border-color: Highlight;
+  }
+
+  .apg-checkbox-input:checked:hover + .apg-checkbox-control,
+  .apg-checkbox-input:indeterminate:hover + .apg-checkbox-control {
+    background: Highlight;
+    border-color: Highlight;
+  }
+
+  .apg-checkbox:has(.apg-checkbox-input:disabled):hover .apg-checkbox-control {
+    border-color: GrayText;
+  }
+
+  .apg-checkbox-input:disabled:checked:hover + .apg-checkbox-control,
+  .apg-checkbox-input:disabled:indeterminate:hover + .apg-checkbox-control {
+    background: GrayText;
+    border-color: GrayText;
+  }
 }

--- a/src/styles/patterns/combobox.css
+++ b/src/styles/patterns/combobox.css
@@ -253,9 +253,10 @@
     border-color: Highlight;
   }
 
-  .apg-combobox-option[aria-selected='true'] {
-    background: Highlight;
-    color: HighlightText;
+  .apg-combobox-option[aria-selected='true'],
+  .apg-combobox-option:hover:not([aria-disabled='true']) {
+    outline: 2px solid Highlight;
+    outline-offset: -2px;
   }
 
   .apg-combobox-option[aria-disabled='true'] {

--- a/src/styles/patterns/radio-group.css
+++ b/src/styles/patterns/radio-group.css
@@ -164,4 +164,13 @@ apg-radio-group {
     background: GrayText;
     border-color: GrayText;
   }
+
+  .apg-radio:not(.apg-radio--disabled):hover .apg-radio-control {
+    border-color: Highlight;
+  }
+
+  .apg-radio--selected:not(.apg-radio--disabled):hover .apg-radio-control {
+    background: Highlight;
+    border-color: Highlight;
+  }
 }

--- a/src/styles/patterns/switch.css
+++ b/src/styles/patterns/switch.css
@@ -200,4 +200,13 @@ apg-switch {
   .apg-switch:disabled .apg-switch-label {
     color: GrayText;
   }
+
+  .apg-switch:hover:not(:disabled) .apg-switch-track {
+    border-color: Highlight;
+  }
+
+  .apg-switch[aria-checked='true']:hover:not(:disabled) .apg-switch-track {
+    background: Highlight;
+    border-color: Highlight;
+  }
 }


### PR DESCRIPTION
## Summary

- Fix dim/unreadable hover states in Windows High Contrast Mode + dark color-scheme across **checkbox**, **radio-group**, **switch**, **combobox**, and **accordion**.
- Patterns with custom-color hover (`var(--foreground)`, `color-mix(...)`) under `forced-color-adjust: none` now use system colors explicitly.
- Combobox option `hover` / `[aria-selected='true']` switched from `Highlight` + `HighlightText` (which rendered labels as solid black blocks in Chromium dark forced-colors) to **outline-based** indication — matches the existing `prefers-contrast: high` pattern in the same file.
- Accordion expanded trigger switched to `ButtonFace`/`ButtonText` for the same readability reason.
- Bumps version to **0.3.4** (patch).

## Test plan

- [ ] Open `/patterns/checkbox/{react,vue,svelte,astro}/` with Playwright `emulateMedia({ forcedColors: 'active', colorScheme: 'dark' })` and confirm:
  - unchecked + hover → border = `Highlight` (cyan), not the dim base color
  - checked + hover → background stays `Highlight`
  - disabled + hover → border stays `GrayText`
- [ ] Same for `/patterns/radio-group/...` and `/patterns/switch/...` (border / track becomes `Highlight` on hover)
- [ ] Open `/patterns/combobox/.../` in forced-colors+dark, open the listbox, hover an option → option gets a 2px cyan outline, label remains readable (white text on black background). Verify `[aria-selected='true']` shows the same outline.
- [ ] Forced-colors OFF (normal light/dark) — no visual regression on any of the above patterns.
- [ ] `npm run test:e2e:pattern --pattern=checkbox` / `radio-group` / `switch` / `combobox` / `accordion` all pass.
- [ ] `npm run lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)