### PR TITLE
release: v0.3.5 — fix MenuButton caret in forced-colors mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apg-patterns-examples",
   "type": "module",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": false,
   "description": "Accessible UI components following WAI-ARIA APG patterns. Multi-framework implementations in React, Vue, Svelte, and Astro with documentation and tests.",
   "author": "masuP9",

--- a/src/styles/patterns/menu-button.css
+++ b/src/styles/patterns/menu-button.css
@@ -40,6 +40,7 @@
   border-top: 4px solid currentColor;
   margin-left: 0.25rem;
   transition: transform 0.15s ease;
+  forced-color-adjust: none;
 }
 
 .apg-menu-button-trigger[aria-expanded='true']::after {


### PR DESCRIPTION
## Summary

- Fix MenuButton caret (▼/▲) being rendered as a solid rectangle in Windows High Contrast Mode, making expand/collapse direction unreadable.
- Root cause: the caret is a CSS triangle (`width:0; height:0;` + `border-left/right: transparent; border-top: currentColor`). In forced-colors mode, browsers substitute `transparent` with a system color, so the "triangle" becomes a filled 8×4 box.
- Fix: add `forced-color-adjust: none` to `.apg-menu-button-trigger::after`. Transparent borders stay transparent; `currentColor` still inherits the trigger's `ButtonText`, so the top border renders and the 180° rotate on `[aria-expanded='true']` works as intended.
- Bumps version to **0.3.5** (patch).

## Test plan

- [ ] Open `/patterns/menu-button/{react,vue,svelte,astro}/` with Playwright `emulateMedia({ forcedColors: 'active', colorScheme: 'dark' })`:
  - Trigger collapsed: caret is a ▼ triangle (not a rectangle). `getComputedStyle(trigger, '::after')` shows `borderLeftColor`/`borderRightColor` = `rgba(0,0,0,0)` and `borderTopColor` = `ButtonText`.
  - Click trigger to expand: caret rotates to ▲ via `transform: matrix(-1, 0, 0, -1, 0, 0)` (= 180°).
- [ ] forced-colors OFF (normal light/dark): no visual regression — caret still renders as a small triangle in `currentColor`.
- [ ] `npm run test:e2e:pattern --pattern=menu-button` passes.
- [ ] `npm run lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)