### PR TITLE
release: v0.3.6 — fix table cells unreadable in forced-colors dark mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apg-patterns-examples",
   "type": "module",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "private": false,
   "description": "Accessible UI components following WAI-ARIA APG patterns. Multi-framework implementations in React, Vue, Svelte, and Astro with documentation and tests.",
   "author": "masuP9",

--- a/src/styles/patterns/table.css
+++ b/src/styles/patterns/table.css
@@ -160,7 +160,23 @@ apg-table.apg-table > [role='table'] {
 
   .apg-table-cell,
   .apg-table-rowheader {
+    color: CanvasText;
     background: Canvas;
+  }
+
+  .apg-table-cell:hover,
+  .apg-table-rowheader:hover {
+    background: Canvas;
+    outline: 2px solid Highlight;
+    outline-offset: -2px;
+  }
+
+  .apg-table-sort-button {
+    color: ButtonText;
+  }
+
+  .apg-table-sort-button:hover {
+    color: Highlight;
   }
 
   .apg-table-sort-button:focus-visible {


### PR DESCRIPTION
## Summary

- Fix Table body cells rendering invisible text in Windows High Contrast Mode + dark color-scheme. The `forced-color-adjust: none` opt-out on `.apg-table` blocked system-color substitution, leaving `color: var(--foreground)` resolved as the light-mode (near-black) oklch value on a black `Canvas` background.
- Explicitly set `color: CanvasText` on `.apg-table-cell` / `.apg-table-rowheader` inside the forced-colors block.
- Override the cell hover so `background` stays `Canvas` (avoids clashing with the light-mode `var(--muted)` near-white value) and indicate hover with a `Highlight` outline.
- Give the sort button explicit `ButtonText` color + `Highlight` hover for the same reason.
- Grid / DataGrid / TreeGrid were verified separately: they don't set `forced-color-adjust: none`, so browser auto-substitution handles dark forced-colors correctly there — no changes needed.
- Bumps version to **0.3.6** (patch).

## Test plan

- [ ] Open `/patterns/table/{react,vue,svelte,astro}/` with Playwright `emulateMedia({ forcedColors: 'active', colorScheme: 'dark' })`:
  - All body cells render `CanvasText` (white) text on `Canvas` (black) background — names/ages/cities readable.
  - Column header still readable (`ButtonText` on `ButtonFace`).
  - Cell hover: keeps `Canvas` background, gains a 2px `Highlight` outline.
  - Sort button: `ButtonText` base, `Highlight` on hover and focus.
- [ ] Spot-check `/patterns/grid/`, `/patterns/data-grid/`, `/patterns/treegrid/` in the same emulation — all text remains readable (auto-substitution).
- [ ] forced-colors OFF: no visual regression on Table.
- [ ] `npm run test:e2e:pattern --pattern=table` passes.
- [ ] `npm run lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)