### PR TITLE
fix(sheet): ドロワー内検索フィールドのはみ出しを修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apg-patterns-examples",
   "type": "module",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": false,
   "description": "Accessible UI components following WAI-ARIA APG patterns. Multi-framework implementations in React, Vue, Svelte, and Astro with documentation and tests.",
   "author": "masuP9",

--- a/src/components/ui/sheet/sheet-content.astro
+++ b/src/components/ui/sheet/sheet-content.astro
@@ -34,7 +34,7 @@ const dialogVariants = cva(
 
 const contentVariants = cva(
   [
-    'w-3/4 fixed z-50 bg-background flex h-full flex-col gap-4 shadow-lg',
+    'fixed z-50 bg-background flex h-full flex-col gap-4 shadow-lg',
     'transition transition-transform ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
     // Open state: on-screen
     'group-data-[state=open]/sheet:translate-x-0 group-data-[state=open]/sheet:translate-y-0',
@@ -42,11 +42,12 @@ const contentVariants = cva(
   {
     variants: {
       side: {
-        // Default off-screen position + border
-        right: 'border-l translate-x-full',
-        left: 'border-r -translate-x-full',
-        top: 'border-b -translate-y-full',
-        bottom: 'border-t translate-y-full',
+        // Default off-screen position + border. Width must mirror dialogVariants
+        // so the fixed-positioned content doesn't exceed the dialog's max width.
+        right: 'border-l translate-x-full w-3/4 sm:max-w-sm',
+        left: 'border-r -translate-x-full w-3/4 sm:max-w-sm',
+        top: 'border-b -translate-y-full w-full',
+        bottom: 'border-t translate-y-full w-full',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary

- viewport 640〜1280px の範囲でドロワー（Sheet, side=right）内の検索フィールドが右にはみ出すバグを修正
- `sheet-content.astro` の `contentVariants` を `dialogVariants` と幅指定を完全対称にした

## 原因

- `<dialog data-slot="sheet-dialog">`: `w-3/4 sm:max-w-sm` → 640px+ で 384px キャップ
- `<div data-slot="sheet-content">`: `w-3/4` のみで `max-width` 無し、かつ `position: fixed` のため containing block が viewport になり、viewport の 75% に展開
- 結果: viewport が広がるほど content の幅が dialog を超え、検索 input の右端 (`⌘K` kbd) が dialog 外に出る
- viewport <640px では sm: 非適用で両者が `w-3/4` で一致するため発生せず、viewport ≥1280px では `xl:invisible` で Sheet 自体が非表示

実機計測（viewport=690px）: content の右端が dialog より **+122px** はみ出し、検索 input の `ctrl+K` kbd が dialog 外で見切れていた。

## 修正

`contentVariants` の base から `w-3/4` を外し、per-side で width を指定:

| side | content (修正後) | dialog（参考） |
|---|---|---|
| right | `w-3/4 sm:max-w-sm` | `w-3/4 sm:max-w-sm` |
| left | `w-3/4 sm:max-w-sm` | `w-3/4 sm:max-w-sm` |
| top | `w-full` | `w-full` |
| bottom | `w-full` | `w-full` |

`dialogVariants` の `overflow-x-hidden`（"quick fix" コメント付き）は今回は残置。原因が解消されたため不要な可能性が高いが、別 PR の cleanup スコープとする。

## 検証

Playwright で以下の viewport 幅でドロワーを開き、`content.getBoundingClientRect().right === dialog.getBoundingClientRect().right` を確認:

| viewport | content.right - dialog.right |
|---|---|
| 375 | 0 |
| 639 | 0 |
| 640 | 0 |
| 690（再現条件） | **0** (修正前: +122) |
| 1279 | 0 |
| 1280 | Sheet 自体 `visibility:hidden`（既存挙動） |

スクリーンショット（viewport=690px）でも `ctrl+K` kbd が dialog 内に完全に収まることを目視確認済。

## Test plan

- [ ] viewport=690px でドロワーを開き、検索フィールド右端の `ctrl+K` が見切れないこと
- [ ] viewport=375 / 640 / 1279 でも検索フィールドが dialog 内に収まること
- [ ] viewport ≥1280 で Sheet トリガーが非表示のままであること
- [ ] ドロワーの開閉アニメーション（slide-in/out）が崩れていないこと
- [ ] ヘッダー側 PatternSearch（`className="w-56"`）に影響が無いこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)