### PR TITLE
fix(apg-watcher): grant contents:write at job level for state push

### DIFF
--- a/.github/workflows/apg-upstream-watch.yml
+++ b/.github/workflows/apg-upstream-watch.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: '副作用を出さずに実行内容を表示するか'
+        description: 'Dry run mode: state 変更を push せず Issue 作成もスキップ (watcher のみ実行)'
         type: boolean
         default: false
       since_override:
@@ -20,8 +20,9 @@ on:
         type: string
         required: false
 
-# Top-level は最小権限。state push に必要な contents:write は push step だけに
-# 限定して付与する。Issue 作成は watcher step に必要なので issues:write は付与。
+# Top-level は最小権限の default。state push に contents:write が必要だが、
+# その権限は watch job だけに付与する (job-level permissions で write に上書き)。
+# 他のジョブが将来追加されても contents:read が default として効く。
 permissions:
   contents: read
   issues: write
@@ -34,8 +35,12 @@ concurrency:
 jobs:
   watch:
     runs-on: ubuntu-latest
+    # job レベルでは state push のため contents:write が必要。token は
+    # persist-credentials: false により git config には残らず、
+    # push step だけ env 経由で受け取って remote URL に inline で渡す。
+    # `npm ci --ignore-scripts` で install scripts からの token 取得もブロック。
     permissions:
-      contents: read
+      contents: write
       issues: write
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Issue #182 の手順で wet-run 実行時に **state push が 403 で失敗** していた問題を修正します。

```
remote: Permission to masuP9/apg-patterns-examples.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/masuP9/apg-patterns-examples.git/': The requested URL returned error: 403
```

## 原因

#181 のセキュリティ修正で top-level `permissions: contents: read` に下げた際、job-level も read のままだったため `GITHUB_TOKEN` が write 権限を持たず push が拒否されていました。

## 修正

- **top-level**: `contents: read` を維持 (将来追加ジョブの default を最小に)
- **job-level (watch)**: `contents: write` に上書き (state push のため)

`persist-credentials: false` / `npm ci --ignore-scripts` / push step だけ env 経由で token を受け取り URL inline、というセキュリティ姿勢は維持されます。

## 観測された wet-run 結果 (修正前)

- Issue 作成: ✅ 成功 (issues:write はあった)
- state local commit: ✅
- **state push**: ✗ 403
- 結果: 既存 Issue は作成済み、`.github/apg-state.json` の更新は main に反映されず

## 再有効化手順 (このマージ後)

state は空のままなので、Issue #182 の手順 3 (`since_override` 付き wet-run) を再実行すれば過去 backfill が完了します。

既存 Issue は HTML marker で再利用されるため、再実行で:
- 同じ slug の同じ latest SHA を再投稿しようとする → batch marker で skip
- state baseline 記録 → 翌日の cron で差分のみ取得

## Test plan

- [ ] CI 通過確認 (この PR は yml 変更のみで lint/test に影響なし想定)
- [ ] マージ後に Issue #182 の手順で再 wet-run、state 更新の commit が main に push されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)