### PR TITLE
fix(apg-watcher): closed-issue dedup + state on orphan apg-state branch

### DIFF
--- a/.github/apg-state.json
+++ b/.github/apg-state.json
@@ -1,5 +1,0 @@
-{
-  "schemaVersion": 1,
-  "lastRun": null,
-  "patterns": {}
-}

--- a/.github/workflows/apg-upstream-watch.yml
+++ b/.github/workflows/apg-upstream-watch.yml
@@ -20,9 +20,9 @@ on:
         type: string
         required: false
 
-# Top-level は最小権限の default。state push に contents:write が必要だが、
-# その権限は watch job だけに付与する (job-level permissions で write に上書き)。
-# 他のジョブが将来追加されても contents:read が default として効く。
+# Top-level は最小権限の default。state push は orphan `apg-state` branch に対して
+# 行うが、ブランチに関わらず contents:write 権限がトークン側で必要なので job-level
+# で write に上書きする (main の branch protection は orphan branch には適用されない)。
 permissions:
   contents: read
   issues: write
@@ -32,23 +32,48 @@ concurrency:
   # 同時実行は重複 Issue や state push 競合の原因なので待機させる
   cancel-in-progress: false
 
+env:
+  # State は main ではなく orphan branch `apg-state` の root に置く。
+  # main の branch protection rules (PR 必須・status checks 必須) を回避し、
+  # かつ main の commit log に bot の state commit が混ざらないようにするため。
+  APG_STATE_BRANCH: apg-state
+  APG_STATE_FILE_ON_BRANCH: apg-state.json
+  APG_STATE_FILE_LOCAL: .github/apg-state.json
+
 jobs:
   watch:
     runs-on: ubuntu-latest
-    # job レベルでは state push のため contents:write が必要。token は
-    # persist-credentials: false により git config には残らず、
-    # push step だけ env 経由で受け取って remote URL に inline で渡す。
-    # `npm ci --ignore-scripts` で install scripts からの token 取得もブロック。
+    # state push のため contents:write が必要。token は persist-credentials: false
+    # により git config には残らず、push step だけ env 経由で受け取って remote URL
+    # に inline で渡す。`npm ci --ignore-scripts` で install scripts からの
+    # token 取得もブロック。
     permissions:
       contents: write
       issues: write
     steps:
       - uses: actions/checkout@v4
         with:
-          # GITHUB_TOKEN を git config に永続化しない。state push step で
+          # GITHUB_TOKEN を git config に永続化しない。state fetch / push step で
           # 必要なときだけ remote URL に inline credential として渡す。
           # これにより npm install scripts などからの token 漏えいを防ぐ。
           persist-credentials: false
+
+      - name: Fetch state from apg-state branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          AUTH_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          mkdir -p "$(dirname "${APG_STATE_FILE_LOCAL}")"
+          if git ls-remote --exit-code --heads "${AUTH_URL}" "${APG_STATE_BRANCH}" > /dev/null 2>&1; then
+            git fetch --depth 1 "${AUTH_URL}" "${APG_STATE_BRANCH}"
+            git show "FETCH_HEAD:${APG_STATE_FILE_ON_BRANCH}" > "${APG_STATE_FILE_LOCAL}"
+            echo "Fetched state from ${APG_STATE_BRANCH} branch"
+          else
+            echo "apg-state branch does not exist yet; starting with empty state"
+            echo '{"schemaVersion":1,"lastRun":null,"patterns":{}}' > "${APG_STATE_FILE_LOCAL}"
+          fi
+
       - uses: actions/setup-node@v4
         with:
           node-version-file: .node-version
@@ -58,6 +83,7 @@ jobs:
       # 実行する tsx は npm 7+ で esbuild の platform 別 optional dep が
       # 自動選択されるため、scripts なしで動作する。
       - run: npm ci --ignore-scripts
+
       - name: Run watcher
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -65,27 +91,39 @@ jobs:
           SINCE_OVERRIDE: ${{ inputs.since_override }}
           PATTERNS_FILTER: ${{ inputs.patterns }}
         run: npx tsx scripts/watch-apg-upstream.ts
-      - name: Commit state changes
+
+      - name: Push state to apg-state branch
         if: ${{ inputs.dry_run != true }}
         env:
-          # state push step だけ token を環境変数として受け取り、git remote
-          # の URL に inline で埋め込む。git config には残さない。
           GH_TOKEN_FOR_PUSH: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if git diff --quiet .github/apg-state.json; then
-            echo "no state change"
+          set -euo pipefail
+          AUTH_URL="https://x-access-token:${GH_TOKEN_FOR_PUSH}@github.com/${GITHUB_REPOSITORY}.git"
+
+          # Work in a separate dir so main checkout stays untouched.
+          WORKDIR="$(mktemp -d)"
+
+          if git clone --depth 1 --branch "${APG_STATE_BRANCH}" "${AUTH_URL}" "${WORKDIR}" 2>/dev/null; then
+            echo "Cloned existing ${APG_STATE_BRANCH} branch"
+          else
+            echo "Initializing orphan ${APG_STATE_BRANCH} branch"
+            cd "${WORKDIR}"
+            git init --initial-branch="${APG_STATE_BRANCH}"
+            git remote add origin "${AUTH_URL}"
+          fi
+
+          # Copy the watcher-produced state into the worktree
+          cp "${GITHUB_WORKSPACE}/${APG_STATE_FILE_LOCAL}" "${WORKDIR}/${APG_STATE_FILE_ON_BRANCH}"
+
+          cd "${WORKDIR}"
+          if git diff --quiet "${APG_STATE_FILE_ON_BRANCH}" 2>/dev/null && git rev-parse HEAD > /dev/null 2>&1; then
+            echo "No state change"
             exit 0
           fi
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add .github/apg-state.json
-          # GITHUB_TOKEN 由来の push は通常 workflow を再トリガーしないので
-          # [skip ci] は保険程度の付与。
+          git add "${APG_STATE_FILE_ON_BRANCH}"
+          # [skip ci] は保険程度 (GITHUB_TOKEN 由来の push は通常 workflow を
+          # 再トリガーしないが、orphan branch には ci.yml の trigger も適用されない)。
           git commit -m "chore: update apg-state [skip ci]"
-          # Inline credential. The remote URL with the token only lives in
-          # .git/config for the lifetime of this step and is discarded with
-          # the runner. This is the recommended pattern when checkout used
-          # persist-credentials: false.
-          AUTH_URL="https://x-access-token:${GH_TOKEN_FOR_PUSH}@github.com/${GITHUB_REPOSITORY}.git"
-          git pull --rebase "${AUTH_URL}" "${GITHUB_REF_NAME}"
-          git push "${AUTH_URL}" "HEAD:${GITHUB_REF_NAME}"
+          git push origin "HEAD:${APG_STATE_BRANCH}"

--- a/scripts/watch-apg-upstream.ts
+++ b/scripts/watch-apg-upstream.ts
@@ -91,6 +91,7 @@ async function main(): Promise<void> {
   });
 
   let createdOrCommented = 0;
+  let skippedActions = 0;
   let baselined = 0;
   let unchanged = 0;
   const errors: string[] = [];
@@ -156,14 +157,18 @@ async function main(): Promise<void> {
     });
 
     try {
-      await manager.createOrComment({
+      const action = await manager.createOrComment({
         apgSlug,
         latestSha: latest.sha,
         draft,
         followupBody,
       });
       recordSeen(state, apgSlug, latest.sha, latest.committerDate);
-      createdOrCommented++;
+      if (action.kind === 'skip') {
+        skippedActions++;
+      } else {
+        createdOrCommented++;
+      }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       errors.push(`[${apgSlug}] issue write failed: ${msg}`);
@@ -182,7 +187,7 @@ async function main(): Promise<void> {
   }
 
   console.log(
-    `\nSummary: created/commented=${createdOrCommented}, baselined=${baselined}, unchanged=${unchanged}, errors=${errors.length}`
+    `\nSummary: created/commented=${createdOrCommented}, skipped=${skippedActions}, baselined=${baselined}, unchanged=${unchanged}, errors=${errors.length}`
   );
   if (errors.length > 0) {
     console.error('\nErrors:');

--- a/scripts/watch-apg-upstream/github-client.ts
+++ b/scripts/watch-apg-upstream/github-client.ts
@@ -29,6 +29,7 @@ export interface IssueSummary {
   number: number;
   title: string;
   body: string;
+  state: 'open' | 'closed';
   htmlUrl: string;
 }
 
@@ -154,13 +155,16 @@ export class GitHubClient {
     return json.map((c) => ({ id: c.id, body: c.body ?? '' }));
   }
 
-  async searchOpenIssuesWithLabel(params: {
+  async searchIssuesWithLabel(params: {
     owner: string;
     repo: string;
     label: string;
+    /** 'open' | 'closed' | 'all'. Default 'all' so that issues that the user
+     *  closed as "no action needed" still match for dedup. */
+    state?: 'open' | 'closed' | 'all';
   }): Promise<IssueSummary[]> {
     const qs = new URLSearchParams({
-      state: 'open',
+      state: params.state ?? 'all',
       labels: params.label,
       per_page: '100',
     });
@@ -170,6 +174,7 @@ export class GitHubClient {
       number: number;
       title: string;
       body: string | null;
+      state: 'open' | 'closed';
       html_url: string;
       pull_request?: unknown;
     }>;
@@ -179,6 +184,7 @@ export class GitHubClient {
         number: i.number,
         title: i.title,
         body: i.body ?? '',
+        state: i.state,
         htmlUrl: i.html_url,
       }));
   }
@@ -199,12 +205,14 @@ export class GitHubClient {
       number: number;
       title: string;
       body: string | null;
+      state: 'open' | 'closed';
       html_url: string;
     };
     return {
       number: json.number,
       title: json.title,
       body: json.body ?? '',
+      state: json.state,
       htmlUrl: json.html_url,
     };
   }

--- a/scripts/watch-apg-upstream/issue-formatter.test.ts
+++ b/scripts/watch-apg-upstream/issue-formatter.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { batchMarkerFor, formatFollowupComment, formatIssue, markerFor } from './issue-formatter';
+import {
+  batchMarkerFor,
+  formatFollowupComment,
+  formatIssue,
+  latestMarkerFor,
+  markerFor,
+} from './issue-formatter';
 import type { CommitSummary } from './github-client';
 import type { SlugMapping } from './slug-resolver';
 
@@ -35,6 +41,10 @@ describe('markerFor / batchMarkerFor', () => {
       '<!-- apg-upstream-batch:slug=button;latest=abc1234 -->'
     );
   });
+
+  it('embeds the latest SHA in body-level marker (for dedup across runs)', () => {
+    expect(latestMarkerFor('abc1234')).toBe('<!-- apg-upstream:latest=abc1234 -->');
+  });
 });
 
 describe('formatIssue', () => {
@@ -50,6 +60,9 @@ describe('formatIssue', () => {
     expect(draft.title).toContain('Button');
     expect(draft.title).toContain('1 件');
     expect(draft.body).toContain('<!-- apg-upstream:slug=button -->');
+    expect(draft.body).toContain(
+      '<!-- apg-upstream:latest=abc1234def5678abc1234def5678abc1234def56 -->'
+    );
     expect(draft.body).toContain('[Button](/patterns/button/)');
     expect(draft.body).toContain('Fix focus order in arrow nav');
     expect(draft.body).toContain('[abc1234]');

--- a/scripts/watch-apg-upstream/issue-formatter.ts
+++ b/scripts/watch-apg-upstream/issue-formatter.ts
@@ -45,6 +45,15 @@ export function markerFor(apgSlug: string): string {
 }
 
 /**
+ * Marker embedded in the issue body that records the latest commit SHA the
+ * issue covers. Used by issue-manager to detect "this exact SHA was already
+ * processed" — works across runs and survives the issue being closed.
+ */
+export function latestMarkerFor(latestSha: string): string {
+  return `<!-- apg-upstream:latest=${latestSha} -->`;
+}
+
+/**
  * Per-batch marker embedded in each follow-up comment. Used by issue-manager
  * to detect "we already posted a comment for this exact latest SHA" and skip
  * re-posting on workflow retries where state push failed.
@@ -73,9 +82,10 @@ export function formatIssue(params: FormatIssueParams): IssueDraft {
   const today = formatDate(until);
   const title = `[APG Upstream] ${primary.name} に ${commits.length} 件の更新 (${today})`;
 
-  const marker = markerFor(slug);
+  const slugMarker = markerFor(slug);
   const upstreamPath = `content/patterns/${slug}`;
   const latestSha = commits[0]?.sha;
+  const latestMarker = latestSha ? latestMarkerFor(latestSha) : '';
   const compareUrl =
     previousSha && latestSha
       ? `https://github.com/${upstreamRepo}/compare/${previousSha}...${latestSha}`
@@ -104,7 +114,8 @@ export function formatIssue(params: FormatIssueParams): IssueDraft {
 
   const compareLine = compareUrl ? `- 比較: ${compareUrl}` : '';
 
-  const body = `${marker}
+  const body = `${slugMarker}
+${latestMarker}
 
 ## 概要
 W3C aria-practices の \`${upstreamPath}/\` 配下に ${commits.length} 件の新規コミットを検知しました。
@@ -131,7 +142,7 @@ ${mapping.relatedPatterns.length > 0 ? '- [ ] 関連パターンへの影響を�
 ${compareLine}
 `.trimEnd();
 
-  return { title, body, markerComment: marker };
+  return { title, body, markerComment: slugMarker };
 }
 
 /**

--- a/scripts/watch-apg-upstream/issue-manager.test.ts
+++ b/scripts/watch-apg-upstream/issue-manager.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { GitHubClient, IssueCommentSummary, IssueSummary } from './github-client';
-import { batchMarkerFor, markerFor } from './issue-formatter';
+import { batchMarkerFor, latestMarkerFor, markerFor } from './issue-formatter';
 import { IssueManager } from './issue-manager';
 
 interface FakeState {
@@ -18,7 +18,7 @@ function makeFakeClient(initial: Partial<FakeState> = {}) {
     addIssueComment: vi.fn(),
   };
   const client = {
-    searchOpenIssuesWithLabel: vi.fn(async () => state.issues),
+    searchIssuesWithLabel: vi.fn(async () => state.issues),
     listIssueComments: vi.fn(
       async ({ issueNumber }: { issueNumber: number }) => state.comments[issueNumber] ?? []
     ),
@@ -28,6 +28,7 @@ function makeFakeClient(initial: Partial<FakeState> = {}) {
         number: 999,
         title: params.title,
         body: params.body,
+        state: 'open',
         htmlUrl: `https://example/issues/999`,
       };
       state.issues.push(created);
@@ -50,10 +51,19 @@ const baseOpts = {
   logger: () => {},
 };
 
-const sampleDraft = (slug: string) => ({
+const sampleDraft = (slug: string, latestSha = 'sha1') => ({
   title: `[APG Upstream] ${slug} に 1 件の更新`,
-  body: `${markerFor(slug)}\n\nbody`,
+  body: `${markerFor(slug)}\n${latestMarkerFor(latestSha)}\n\nbody`,
   markerComment: markerFor(slug),
+});
+
+const openIssue = (overrides: Partial<IssueSummary> = {}): IssueSummary => ({
+  number: 42,
+  title: 'old',
+  body: `${markerFor('button')}\n\nbody`,
+  state: 'open',
+  htmlUrl: '',
+  ...overrides,
 });
 
 describe('IssueManager.createOrComment', () => {
@@ -72,19 +82,17 @@ describe('IssueManager.createOrComment', () => {
     expect(calls.addIssueComment).not.toHaveBeenCalled();
   });
 
-  it('comments on the existing open issue when one matches the marker', async () => {
-    const existing: IssueSummary = {
-      number: 42,
-      title: 'old',
-      body: `${markerFor('button')}\n\nbody`,
-      htmlUrl: '',
-    };
+  it('comments on the existing open issue when one matches the marker (different SHA)', async () => {
+    // existing issue body carries an *older* latest marker
+    const existing = openIssue({
+      body: `${markerFor('button')}\n${latestMarkerFor('oldsha')}\n\nbody`,
+    });
     const { client, calls } = makeFakeClient({ issues: [existing] });
     const manager = new IssueManager(client, baseOpts);
     const action = await manager.createOrComment({
       apgSlug: 'button',
-      latestSha: 'sha1',
-      draft: sampleDraft('button'),
+      latestSha: 'newsha',
+      draft: sampleDraft('button', 'newsha'),
       followupBody: 'follow-up',
     });
     expect(action).toEqual({ kind: 'comment', apgSlug: 'button', issueNumber: 42 });
@@ -94,13 +102,68 @@ describe('IssueManager.createOrComment', () => {
     expect(calls.createIssue).not.toHaveBeenCalled();
   });
 
-  it('skips re-commenting when an existing comment carries the same batch marker (retry safety)', async () => {
-    const existing: IssueSummary = {
-      number: 42,
-      title: 'old',
-      body: `${markerFor('button')}\n\nbody`,
-      htmlUrl: '',
-    };
+  it('skips when an open issue body already carries the same latest-SHA marker', async () => {
+    const existing = openIssue({
+      body: `${markerFor('button')}\n${latestMarkerFor('sha1')}\n\nbody`,
+    });
+    const { client, calls } = makeFakeClient({ issues: [existing] });
+    const manager = new IssueManager(client, baseOpts);
+    const action = await manager.createOrComment({
+      apgSlug: 'button',
+      latestSha: 'sha1',
+      draft: sampleDraft('button'),
+      followupBody: 'follow-up',
+    });
+    expect(action.kind).toBe('skip');
+    expect(action.reason).toBe('same-latest-sha-in-body');
+    expect(calls.addIssueComment).not.toHaveBeenCalled();
+    expect(calls.createIssue).not.toHaveBeenCalled();
+  });
+
+  it('skips when a CLOSED issue already covers the same SHA (does not re-create)', async () => {
+    const closed = openIssue({
+      number: 100,
+      state: 'closed',
+      body: `${markerFor('button')}\n${latestMarkerFor('sha1')}\n\nbody`,
+    });
+    const { client, calls } = makeFakeClient({ issues: [closed] });
+    const manager = new IssueManager(client, baseOpts);
+    const action = await manager.createOrComment({
+      apgSlug: 'button',
+      latestSha: 'sha1',
+      draft: sampleDraft('button'),
+      followupBody: 'follow-up',
+    });
+    expect(action.kind).toBe('skip');
+    expect(action.issueNumber).toBe(100);
+    expect(calls.createIssue).not.toHaveBeenCalled();
+    expect(calls.addIssueComment).not.toHaveBeenCalled();
+  });
+
+  it('creates a new issue when only a CLOSED issue exists for an older SHA', async () => {
+    const closed = openIssue({
+      number: 100,
+      state: 'closed',
+      body: `${markerFor('button')}\n${latestMarkerFor('oldsha')}\n\nbody`,
+    });
+    const { client, calls } = makeFakeClient({ issues: [closed] });
+    const manager = new IssueManager(client, baseOpts);
+    const action = await manager.createOrComment({
+      apgSlug: 'button',
+      latestSha: 'newsha',
+      draft: sampleDraft('button', 'newsha'),
+      followupBody: 'follow-up',
+    });
+    expect(action.kind).toBe('create');
+    expect(calls.createIssue).toHaveBeenCalledTimes(1);
+    expect(calls.addIssueComment).not.toHaveBeenCalled();
+  });
+
+  it('skips when an open issue already has a follow-up comment with the same batch marker (retry safety)', async () => {
+    const existing = openIssue({
+      // body has an older SHA, but a previous run already commented with sha1
+      body: `${markerFor('button')}\n${latestMarkerFor('oldsha')}\n\nbody`,
+    });
     const priorComment: IssueCommentSummary = {
       id: 1,
       body: `${batchMarkerFor('button', 'sha1')}\n\nold follow-up`,
@@ -117,7 +180,7 @@ describe('IssueManager.createOrComment', () => {
       followupBody: 'follow-up',
     });
     expect(action.kind).toBe('skip');
-    expect(action.reason).toBe('duplicate-batch-marker');
+    expect(action.reason).toBe('duplicate-batch-comment');
     expect(calls.addIssueComment).not.toHaveBeenCalled();
     expect(calls.createIssue).not.toHaveBeenCalled();
   });

--- a/scripts/watch-apg-upstream/issue-manager.ts
+++ b/scripts/watch-apg-upstream/issue-manager.ts
@@ -1,13 +1,34 @@
 /**
- * Decide whether to open a new issue or comment on an existing one for an APG
- * slug, using the HTML marker as a stable identifier.
+ * Decide whether to open a new issue, comment on an existing one, or skip
+ * entirely, using HTML markers as stable identifiers.
+ *
+ * Markers used:
+ * - body: `<!-- apg-upstream:slug=<slug> -->` (rough filter, every issue we
+ *   open has this)
+ * - body: `<!-- apg-upstream:latest=<sha> -->` (records the latest commit
+ *   SHA the issue covers — survives the issue being closed and is checked
+ *   even on closed issues so a closed/dismissed issue does not get
+ *   re-created for the same commits)
+ * - comment: `<!-- apg-upstream-batch:slug=<slug>;latest=<sha> -->` (extra
+ *   safety net for retries: if a follow-up comment with the same latest SHA
+ *   already exists, skip re-posting)
+ *
+ * Decision tree (for a slug with new commits whose latest SHA is `L`):
+ *   1. Search all issues (open + closed) with `apg-upstream` label and the
+ *      slug marker.
+ *   2. If any issue body or any of its comments already references latest=L
+ *      → SKIP (already covered).
+ *   3. Else if at least one matching issue is open → COMMENT on the most
+ *      recent open one (active investigation gets the new commits appended).
+ *   4. Else (no open match: either first encounter, or all matches are
+ *      closed) → CREATE a new issue.
  *
  * dry-run mode: print the action that would be taken; do NOT call any
  * mutating endpoint.
  */
-import type { GitHubClient } from './github-client';
+import type { GitHubClient, IssueSummary } from './github-client';
 import type { IssueDraft } from './issue-formatter';
-import { batchMarkerFor, markerFor } from './issue-formatter';
+import { batchMarkerFor, latestMarkerFor, markerFor } from './issue-formatter';
 
 export interface IssueAction {
   kind: 'create' | 'comment' | 'skip';
@@ -36,31 +57,21 @@ export class IssueManager {
   }
 
   /**
-   * Find open issues whose body contains the marker for `apgSlug`.
-   * Returns them oldest-first (by issue number).
+   * Find all issues (open + closed) whose body carries the slug marker.
+   * Returned newest-first by issue number so that recent activity wins when
+   * we pick a comment target.
    */
-  private async findExisting(apgSlug: string): Promise<Array<{ number: number; title: string }>> {
-    const marker = markerFor(apgSlug);
-    const all = await this.client.searchOpenIssuesWithLabel({
+  private async findMatchingIssues(apgSlug: string): Promise<IssueSummary[]> {
+    const slugMarker = markerFor(apgSlug);
+    const all = await this.client.searchIssuesWithLabel({
       owner: this.opts.owner,
       repo: this.opts.repo,
       label: this.opts.label,
+      state: 'all',
     });
-    return all
-      .filter((i) => i.body.includes(marker))
-      .map((i) => ({ number: i.number, title: i.title }))
-      .sort((a, b) => a.number - b.number);
+    return all.filter((i) => i.body.includes(slugMarker)).sort((a, b) => b.number - a.number);
   }
 
-  /**
-   * For a slug with detected new commits, decide and execute the action.
-   * Returns the planned action even in dry-run mode.
-   *
-   * `latestSha` is the newest commit SHA in this batch; we use it together
-   * with the slug as a batch marker on the follow-up comment to avoid
-   * re-posting the same comment when a previous run failed before persisting
-   * state.
-   */
   async createOrComment(params: {
     apgSlug: string;
     latestSha: string;
@@ -68,67 +79,88 @@ export class IssueManager {
     followupBody: string;
   }): Promise<IssueAction> {
     const { apgSlug, latestSha, draft, followupBody } = params;
-    const existing = await this.findExisting(apgSlug);
-
-    if (existing.length === 0) {
-      const action: IssueAction = { kind: 'create', apgSlug };
-      this.log(`[${apgSlug}] would CREATE issue: "${draft.title}"`);
-      if (!this.opts.dryRun) {
-        const created = await this.client.createIssue({
-          owner: this.opts.owner,
-          repo: this.opts.repo,
-          title: draft.title,
-          body: draft.body,
-          labels: [this.opts.label],
-        });
-        action.issueNumber = created.number;
-        this.log(`[${apgSlug}]   → created #${created.number} (${created.htmlUrl})`);
-      }
-      return action;
-    }
-
-    const target = existing[0];
-    if (existing.length > 1) {
-      this.log(
-        `[${apgSlug}]   WARN: ${existing.length} open issues match marker. Operating on oldest only.`
-      );
-    }
-
-    // Idempotency check: if a previous run already commented for this exact
-    // latest SHA (state push failed afterwards, so we're seeing the slug
-    // again), skip re-posting.
+    const matching = await this.findMatchingIssues(apgSlug);
+    const latestMarker = latestMarkerFor(latestSha);
     const batchMarker = batchMarkerFor(apgSlug, latestSha);
-    const comments = await this.client.listIssueComments({
-      owner: this.opts.owner,
-      repo: this.opts.repo,
-      issueNumber: target.number,
-    });
-    if (comments.some((c) => c.body.includes(batchMarker))) {
+
+    // (2) Skip if any matching issue body already references this SHA.
+    const sameShaInBody = matching.find((i) => i.body.includes(latestMarker));
+    if (sameShaInBody) {
       this.log(
-        `[${apgSlug}] SKIP: #${target.number} already has a comment for latest=${latestSha.slice(0, 7)}`
+        `[${apgSlug}] SKIP: ${sameShaInBody.state} issue #${sameShaInBody.number} already covers latest=${latestSha.slice(0, 7)}`
       );
       return {
         kind: 'skip',
         apgSlug,
-        issueNumber: target.number,
-        reason: 'duplicate-batch-marker',
+        issueNumber: sameShaInBody.number,
+        reason: 'same-latest-sha-in-body',
       };
     }
 
-    const action: IssueAction = {
-      kind: 'comment',
-      apgSlug,
-      issueNumber: target.number,
-    };
-    this.log(`[${apgSlug}] would COMMENT on existing #${target.number}: "${target.title}"`);
-    if (!this.opts.dryRun) {
-      await this.client.addIssueComment({
+    // (2b) Or any follow-up comment already references this batch.
+    // We only check the most recent open issue's comments — closed issues
+    // shouldn't have stale comments worth checking.
+    const openMatches = matching.filter((i) => i.state === 'open');
+    if (openMatches.length > 0) {
+      const target = openMatches[0];
+      const comments = await this.client.listIssueComments({
         owner: this.opts.owner,
         repo: this.opts.repo,
         issueNumber: target.number,
-        body: followupBody,
       });
-      this.log(`[${apgSlug}]   → comment posted to #${target.number}`);
+      if (comments.some((c) => c.body.includes(batchMarker))) {
+        this.log(
+          `[${apgSlug}] SKIP: open #${target.number} already has a comment for latest=${latestSha.slice(0, 7)}`
+        );
+        return {
+          kind: 'skip',
+          apgSlug,
+          issueNumber: target.number,
+          reason: 'duplicate-batch-comment',
+        };
+      }
+
+      // (3) Open issue exists but doesn't cover this SHA — add a follow-up.
+      if (openMatches.length > 1) {
+        this.log(
+          `[${apgSlug}]   WARN: ${openMatches.length} open issues match marker. Operating on newest only.`
+        );
+      }
+      this.log(`[${apgSlug}] would COMMENT on open #${target.number}: "${target.title}"`);
+      if (!this.opts.dryRun) {
+        await this.client.addIssueComment({
+          owner: this.opts.owner,
+          repo: this.opts.repo,
+          issueNumber: target.number,
+          body: followupBody,
+        });
+        this.log(`[${apgSlug}]   → comment posted to #${target.number}`);
+      }
+      return { kind: 'comment', apgSlug, issueNumber: target.number };
+    }
+
+    // (4) No open match. Either truly first encounter, or all prior matches
+    // were closed by the user as "no action needed". Create a fresh issue
+    // for this new batch; the latest marker in its body prevents
+    // re-creation if the watcher runs again for the same SHA.
+    const action: IssueAction = { kind: 'create', apgSlug };
+    if (matching.length > 0) {
+      this.log(
+        `[${apgSlug}] all ${matching.length} prior issue(s) closed; CREATE a new one for latest=${latestSha.slice(0, 7)}`
+      );
+    } else {
+      this.log(`[${apgSlug}] would CREATE issue: "${draft.title}"`);
+    }
+    if (!this.opts.dryRun) {
+      const created = await this.client.createIssue({
+        owner: this.opts.owner,
+        repo: this.opts.repo,
+        title: draft.title,
+        body: draft.body,
+        labels: [this.opts.label],
+      });
+      action.issueNumber = created.number;
+      this.log(`[${apgSlug}]   → created #${created.number} (${created.htmlUrl})`);
     }
     return action;
   }


### PR DESCRIPTION
## Summary

実運用で発覚した 2 つの問題を 1 PR で修正します。

### 1. main branch protection で state push が 403 失敗

main に「PR 必須 + required status checks」の Repository Rules があり、bot の `chore: update apg-state` 直接 push が拒否されていました。

**対策**: state を main ではなく **`apg-state` orphan branch** に切り出す。`gh-pages` と同じ思想で、state 専用の独立 branch (main の history と共有なし、コードも持たず `apg-state.json` 1 ファイルだけ)。

- main の commit log に bot commit が混ざらない
- branch protection は main にしか効かないので影響なし
- コードは引き続き main のみで管理 → 乖離なし

### 2. Close した Issue が再 wet-run で復活する

`searchOpenIssuesWithLabel` が open のみを返していたため、ユーザーが「対応不要」として Close した Issue を再 run で見つけられず、**同じ commits で新規 Issue が再作成**されていました。

**対策**: Issue 本文に `<!-- apg-upstream:latest=<sha> -->` の latest SHA marker を埋め込み、検索を `state=all` (open + closed) に拡張。judge ロジック:

| 条件 | 動作 |
|---|---|
| 既存 Issue body (open / closed どちらでも) に同じ latest marker | **SKIP** |
| open Issue のコメントに同じ batch marker (retry safety) | **SKIP** |
| open Issue あり + SHA 違い | **COMMENT** 追加 |
| closed のみ + SHA 違い / 該当なし | **CREATE** |

これで「Close = 対応済み or 不要」というユーザーの意思が尊重されます。

## Commits

1. `fix(apg-watcher): dedup against closed issues using latest-SHA body marker` — Issue 重複対応
2. `fix(apg-watcher): move state to orphan apg-state branch` — state 保管場所変更

## Test plan

- [x] `npm run lint`: 0 errors
- [x] vitest: 23 ケース全通過 (closed Issue ケース 2 件、batch marker retry ケース 1 件 を新規追加)
- [x] dry-run: ローカル state ファイル不在状態でも動作 (button slug で `would SKIP: open #186 already has a comment for latest=d847aad` を確認、batch marker による重複検知が機能)
- [ ] CI 通過確認
- [ ] マージ後 wet-run で:
  - apg-state branch が auto-create され `apg-state.json` が push される
  - 既存 open Issue (前回 wet-run 残) は body に latest marker がないので最初は COMMENT 追加 (今後の run では body marker で SKIP)
  - 過去 Close した Issue は再作成されない

## 関連

- 前 PR: #196 (job-level contents:write)
- 初回有効化 Issue: #182