### PR TITLE
fix(apg-watcher): persist state even when run ends with errors

### DIFF
--- a/.github/workflows/apg-upstream-watch.yml
+++ b/.github/workflows/apg-upstream-watch.yml
@@ -93,7 +93,11 @@ jobs:
         run: npx tsx scripts/watch-apg-upstream.ts
 
       - name: Push state to apg-state branch
-        if: ${{ inputs.dry_run != true }}
+        # always() && !cancelled() ensures we still push state when Run watcher
+        # exits 1 after producing side-effects (issues/comments), so the same
+        # commits are not re-detected on the next run (#206). Skipped on manual
+        # cancellation and on dry-run.
+        if: ${{ always() && !cancelled() && inputs.dry_run != true }}
         env:
           GH_TOKEN_FOR_PUSH: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/scripts/watch-apg-upstream.ts
+++ b/scripts/watch-apg-upstream.ts
@@ -96,94 +96,100 @@ async function main(): Promise<void> {
   let unchanged = 0;
   const errors: string[] = [];
 
-  for (const [apgSlug, mapping] of map) {
-    if (!shouldProcess(mapping, env.patternsFilter)) continue;
+  try {
+    for (const [apgSlug, mapping] of map) {
+      if (!shouldProcess(mapping, env.patternsFilter)) continue;
 
-    const previousSha = state.patterns[apgSlug]?.lastSeenSha ?? null;
-    const since = env.sinceOverride ?? sinceFor(state, apgSlug);
-    const firstEncounter = previousSha === null && !env.sinceOverride;
+      const previousSha = state.patterns[apgSlug]?.lastSeenSha ?? null;
+      const since = env.sinceOverride ?? sinceFor(state, apgSlug);
+      const firstEncounter = previousSha === null && !env.sinceOverride;
 
-    let commits;
-    try {
-      commits = await client.listCommitsForPath({
-        owner: UPSTREAM_OWNER,
-        repo: UPSTREAM_REPO,
-        path: `${UPSTREAM_PATH_PREFIX}/${apgSlug}`,
-        since: since ?? undefined,
-      });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      errors.push(`[${apgSlug}] ${msg}`);
-      console.error(`[${apgSlug}] API error: ${msg}`);
-      continue;
-    }
-
-    // Filter out any commit equal to lastSeenSha as a defensive cross-check
-    // (since the `since` filter is inclusive at second-resolution).
-    const newCommits = previousSha ? commits.filter((c) => c.sha !== previousSha) : commits;
-
-    if (newCommits.length === 0) {
-      console.log(`[${apgSlug}] no new commits`);
-      unchanged++;
-      continue;
-    }
-
-    const latest = newCommits[0]; // GitHub returns newest first
-
-    if (firstEncounter) {
-      console.log(
-        `[${apgSlug}] first encounter, recording baseline ${latest.sha.slice(0, 7)} ` +
-          `(skipping ${newCommits.length} historical commits)`
-      );
-      recordSeen(state, apgSlug, latest.sha, latest.committerDate);
-      baselined++;
-      continue;
-    }
-
-    const until = new Date().toISOString();
-    const draft = formatIssue({
-      mapping,
-      commits: newCommits,
-      since: since ?? 'baseline',
-      until,
-      previousSha,
-      upstreamRepo: UPSTREAM_REPO_FULL,
-    });
-    const followupBody = formatFollowupComment({
-      apgSlug,
-      commits: newCommits,
-      since: since ?? 'baseline',
-      until,
-    });
-
-    try {
-      const action = await manager.createOrComment({
-        apgSlug,
-        latestSha: latest.sha,
-        draft,
-        followupBody,
-      });
-      recordSeen(state, apgSlug, latest.sha, latest.committerDate);
-      if (action.kind === 'skip') {
-        skippedActions++;
-      } else {
-        createdOrCommented++;
+      let commits;
+      try {
+        commits = await client.listCommitsForPath({
+          owner: UPSTREAM_OWNER,
+          repo: UPSTREAM_REPO,
+          path: `${UPSTREAM_PATH_PREFIX}/${apgSlug}`,
+          since: since ?? undefined,
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        errors.push(`[${apgSlug}] ${msg}`);
+        console.error(`[${apgSlug}] API error: ${msg}`);
+        continue;
       }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      errors.push(`[${apgSlug}] issue write failed: ${msg}`);
-      console.error(`[${apgSlug}] issue write error: ${msg}`);
+
+      // Filter out any commit equal to lastSeenSha as a defensive cross-check
+      // (since the `since` filter is inclusive at second-resolution).
+      const newCommits = previousSha ? commits.filter((c) => c.sha !== previousSha) : commits;
+
+      if (newCommits.length === 0) {
+        console.log(`[${apgSlug}] no new commits`);
+        unchanged++;
+        continue;
+      }
+
+      const latest = newCommits[0]; // GitHub returns newest first
+
+      if (firstEncounter) {
+        console.log(
+          `[${apgSlug}] first encounter, recording baseline ${latest.sha.slice(0, 7)} ` +
+            `(skipping ${newCommits.length} historical commits)`
+        );
+        recordSeen(state, apgSlug, latest.sha, latest.committerDate);
+        baselined++;
+        continue;
+      }
+
+      const until = new Date().toISOString();
+      const draft = formatIssue({
+        mapping,
+        commits: newCommits,
+        since: since ?? 'baseline',
+        until,
+        previousSha,
+        upstreamRepo: UPSTREAM_REPO_FULL,
+      });
+      const followupBody = formatFollowupComment({
+        apgSlug,
+        commits: newCommits,
+        since: since ?? 'baseline',
+        until,
+      });
+
+      try {
+        const action = await manager.createOrComment({
+          apgSlug,
+          latestSha: latest.sha,
+          draft,
+          followupBody,
+        });
+        recordSeen(state, apgSlug, latest.sha, latest.committerDate);
+        if (action.kind === 'skip') {
+          skippedActions++;
+        } else {
+          createdOrCommented++;
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        errors.push(`[${apgSlug}] issue write failed: ${msg}`);
+        console.error(`[${apgSlug}] issue write error: ${msg}`);
+      }
     }
-  }
+  } finally {
+    // Always persist state so that any side-effects already produced during the
+    // loop (created issues / posted comments) are reflected on disk, even if
+    // the run ends with errors (#206). The subsequent workflow step pushes the
+    // file with `if: always() && !cancelled()` to keep this guarantee end-to-end.
+    state.lastRun = new Date().toISOString();
+    state.schemaVersion = STATE_SCHEMA_VERSION;
 
-  state.lastRun = new Date().toISOString();
-  state.schemaVersion = STATE_SCHEMA_VERSION;
-
-  if (env.dryRun) {
-    console.log('\n[dry-run] would not write state file');
-  } else {
-    saveState(state);
-    console.log(`\nState written to ${STATE_FILE}`);
+    if (env.dryRun) {
+      console.log('\n[dry-run] would not write state file');
+    } else {
+      saveState(state);
+      console.log(`\nState written to ${STATE_FILE}`);
+    }
   }
 
   console.log(


### PR DESCRIPTION
## Summary

watcher が slug ループ中に Issue 作成 / コメント投稿の副作用を出した後、別 slug の GitHub API エラーで `process.exit(1)` した場合に、現行の制御フローでは `.github/apg-state.json` が次回 run まで永続化されず、同じコミットを再検知して重複 Issue / コメントが発生しうる問題 (#206) を二段構えで修正:

- **watcher (`scripts/watch-apg-upstream.ts`)**: slug ループ全体を `try { ... } finally { ... }` で囲い、finally で必ず `state.lastRun` 更新と `saveState()` を実行。dry-run の場合のみ saveState はスキップ。エラー判定と `process.exit(1)` は finally 通過後に従来どおり。`saveState()` が throw した場合は `main().catch()` に流して fail-fast（state 保存失敗を埋もれさせない設計）。
- **workflow (`.github/workflows/apg-upstream-watch.yml`)**: `Push state to apg-state branch` step の if 条件に `always() && !cancelled()` を追加。Run watcher が exit 1 でも state ファイルがあれば push を試行する defense-in-depth。手動 cancel と dry-run では従来どおり skip。

PR #204 で導入した dedup 機構（closed issue の latest-SHA body marker / batch marker）は最後の防衛線として残し、本修正は state 永続化による一次対策。

Codex (read-only consult) と方針合意済み: try/finally + workflow `always() && !cancelled()` の二段構え、fail-fast、テスト追加見送り。

Closes #206

## Test plan

- [x] `npx vitest run scripts/watch-apg-upstream` — 23 passed
- [x] `npm run lint:types` — clean
- [x] ローカル dry-run (`DRY_RUN=true PATTERNS_FILTER=button npx tsx scripts/watch-apg-upstream.ts`) で finally に到達して `[dry-run] would not write state file` がログに出ることを確認
- [ ] CI green (lint / build / test / e2e / Cloudflare Pages preview)
- [ ] マージ後の次回 scheduled run (JST 08:17) で `State written to .github/apg-state.json` がログに出て apg-state branch にコミットが入ること

## Notes

- `state.lastRun` を finally で常に更新するが、per-slug の `lastSeenSha` / `lastSeenDate` は変わらない（PR #204 の `sinceFor` ロジックに影響なし）。全 slug エラー時でも安全
- Run watcher 到達前 (checkout / setup-node / npm ci) で失敗した場合は state ファイルが存在しないので `Push state` step の `cp` が落ちて step 失敗扱い。これは想定動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)