### PR TITLE
Reduce max-width from 4xl to 3xl on main content pages

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -3,7 +3,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout title="About">
-  <div class="mx-auto max-w-4xl">
+  <div class="mx-auto max-w-3xl">
     <header class="mb-8">
       <h1 class="mb-4 text-3xl font-bold">About APG Patterns Examples</h1>
       <p class="text-muted-foreground text-lg">

--- a/src/pages/ja/about.astro
+++ b/src/pages/ja/about.astro
@@ -5,7 +5,7 @@ const locale = 'ja';
 ---
 
 <BaseLayout title="このサイトについて" locale={locale}>
-  <div class="mx-auto max-w-4xl">
+  <div class="mx-auto max-w-3xl">
     <header class="mb-8">
       <h1 class="mb-4 text-3xl font-bold">APG パターン実装例について</h1>
       <p class="text-muted-foreground text-lg">

--- a/src/pages/ja/patterns/index.astro
+++ b/src/pages/ja/patterns/index.astro
@@ -13,7 +13,7 @@ const ogImage = withBase('/og-images/patterns.png');
 ---
 
 <BaseLayout title={t('patterns.title')} locale={locale} ogImage={ogImage}>
-  <div class="mx-auto max-w-4xl">
+  <div class="mx-auto max-w-3xl">
     <header class="mb-8">
       <h1 class="mb-4 text-3xl font-bold">APG パターン</h1>
       <p class="text-muted-foreground text-lg">

--- a/src/pages/ja/practices/index.astro
+++ b/src/pages/ja/practices/index.astro
@@ -13,7 +13,7 @@ const ogImage = withBase('/og-images/practices.png');
 ---
 
 <BaseLayout title={t('practices.title')} locale={locale} ogImage={ogImage}>
-  <div class="mx-auto max-w-4xl">
+  <div class="mx-auto max-w-3xl">
     <header class="mb-8">
       <h1 class="mb-4 text-3xl font-bold">APG プラクティス</h1>
       <p class="text-muted-foreground text-lg">

--- a/src/pages/patterns/index.astro
+++ b/src/pages/patterns/index.astro
@@ -9,7 +9,7 @@ const ogImage = withBase('/og-images/patterns.png');
 ---
 
 <BaseLayout title="Patterns" ogImage={ogImage}>
-  <div class="mx-auto max-w-4xl">
+  <div class="mx-auto max-w-3xl">
     <header class="mb-8">
       <h1 class="mb-4 text-3xl font-bold">APG Patterns</h1>
       <p class="text-muted-foreground text-lg">

--- a/src/pages/practices/index.astro
+++ b/src/pages/practices/index.astro
@@ -9,7 +9,7 @@ const ogImage = withBase('/og-images/practices.png');
 ---
 
 <BaseLayout title="Practices" ogImage={ogImage}>
-  <div class="mx-auto max-w-4xl">
+  <div class="mx-auto max-w-3xl">
     <header class="mb-8">
       <h1 class="mb-4 text-3xl font-bold">APG Practices</h1>
       <p class="text-muted-foreground text-lg">


### PR DESCRIPTION
# Pull Request

## 概要

メインコンテンツページ（About、Patterns、Practices）の最大幅を `max-w-4xl` から `max-w-3xl` に変更し、より読みやすいレイアウトを実現します。

## 変更内容

- [x] リファクタリング

以下の6ページで、コンテナの最大幅を調整しました：

- `src/pages/about.astro`
- `src/pages/ja/about.astro`
- `src/pages/patterns/index.astro`
- `src/pages/practices/index.astro`
- `src/pages/ja/patterns/index.astro`
- `src/pages/ja/practices/index.astro`

各ページの `<div class="mx-auto max-w-4xl">` を `<div class="mx-auto max-w-3xl">` に変更しました。

## APGパターン準拠チェック

- [x] 破壊的変更なし（スタイルのみの変更）

## テスト

- [x] 手動テスト完了（ブラウザでレイアウト確認）

## その他

この変更は視覚的なレイアウト調整のみで、機能やアクセシビリティに影響はありません。

https://claude.ai/code/session_01BWNNwkUvnmqcohiJJweez3