### PR TITLE
chore(apg-watcher): clarify dedup layers, add sinceFor boundary test

### DIFF
--- a/scripts/watch-apg-upstream.ts
+++ b/scripts/watch-apg-upstream.ts
@@ -119,8 +119,10 @@ async function main(): Promise<void> {
         continue;
       }
 
-      // Filter out any commit equal to lastSeenSha as a defensive cross-check
-      // (since the `since` filter is inclusive at second-resolution).
+      // Defensive watermark check for the exact lastSeenSha only. sinceFor()
+      // advances past lastSeenDate by one second so the same commit is not
+      // normally re-yielded; IssueManager's latest-SHA body marker covers
+      // duplicate Issue/comment creation for the latest batch SHA.
       const newCommits = previousSha ? commits.filter((c) => c.sha !== previousSha) : commits;
 
       if (newCommits.length === 0) {

--- a/scripts/watch-apg-upstream/state.test.ts
+++ b/scripts/watch-apg-upstream/state.test.ts
@@ -80,6 +80,16 @@ describe('sinceFor', () => {
     recordSeen(state, 'button', 'abc', '2026-05-23T10:00:00.000Z');
     expect(sinceFor(state, 'button')).toBe('2026-05-23T10:00:01.000Z');
   });
+
+  it('preserves milliseconds when advancing the watermark by one second', () => {
+    // Regression guard: GitHub's `since` is second-resolution so the offset
+    // must be exactly +1s. If this is ever changed (e.g., +1ms or rounded to
+    // whole seconds), duplicate notifications for commits sharing the same
+    // second as lastSeenDate become much more likely (Issue #207 context).
+    const state = loadState(statePath);
+    recordSeen(state, 'button', 'abc', '2026-05-23T10:00:00.500Z');
+    expect(sinceFor(state, 'button')).toBe('2026-05-23T10:00:01.500Z');
+  });
 });
 
 describe('recordSeen', () => {


### PR DESCRIPTION
## Summary

Issue #207 (APG watcher: state の since 判定に author date ではなく committer date を使う) の最終 close に向けた整理。

### 既に完了している対応 (PR #5124406)

- `commit.committer.date` を `CommitSummary` に保持
- `state.lastSeenDate` には `committerDate` を保存して次回 `since` 計算に使用

### 残っていた検討事項 (本 PR で結論)

Issue body の対応案 (3) 「処理済み SHA 配列の保持 or compare API ベース検知」は **見送り**。理由は下記の 4 層 dedup で重複通知の主要シナリオが既にカバーされており、追加実装の費用対効果が低いため:

| # | 層 | 場所 | 防げるもの | 限界 |
|---|---|---|---|---|
| 1 | `sinceFor()` +1秒 | `state.ts:64` | 同一秒の watermark commit 再取得 | second-resolution の制約 |
| 2 | `previousSha` filter | `watch-apg-upstream.ts:124` | watermark exact 再取得 | latest 1 SHA のみ |
| 3 | latest body marker `<!-- apg-upstream:latest=<sha> -->` | `issue-manager.ts:87-98` | batch latest SHA への Issue/comment 重複作成 | batch 内 oldest SHA は対象外 |
| 4 | batch marker `<!-- apg-upstream-batch:slug=<slug>;latest=<sha> -->` | `issue-manager.ts:111-121` | state push 失敗時の重複 comment | 同上 |
| (+) | state 永続化 (PR #212) | `watch-apg-upstream.ts` + workflow | エラー時の state 取りこぼし | — |

**Option B (処理済み SHA 配列)**: state schema bump + migration が必要。工数 2-3h。主たる防御である `sinceFor` +1秒 で実用上再取得されないため見送り。

**Option C (compare API ベース)**: API 呼び出し増 (slug 数 = N+1 calls) で rate limit リスク。工数 3-4h。現状で実害なし。

### 本 PR の変更内容

- `scripts/watch-apg-upstream.ts:121-125` の `previousSha` filter コメントを補強し、主たる防御が `sinceFor()` の +1秒 オフセットであること、IssueManager の latest-SHA body marker は別レイヤーであることを明記 (将来のリファクタで誤解を防ぐ)
- `scripts/watch-apg-upstream/state.test.ts` に sinceFor の同一秒 (ミリ秒保持) 境界テスト 1 件追加。将来 +1秒 を変更した際の回帰防止

Codex (read-only consult, 2 iteration) で plan を review し、quality: good で合意。

Closes #207

## Test plan

- [x] `npx vitest run scripts/watch-apg-upstream` — 24 passed (既存 23 + 新規 1)
- [x] `npm run lint:types` — clean
- [ ] CI green (lint / build / test / e2e / Cloudflare Pages preview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)