### PR TITLE
fix(apg-watcher): paginate commits API with Link header

### DIFF
--- a/scripts/watch-apg-upstream/github-client.test.ts
+++ b/scripts/watch-apg-upstream/github-client.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from 'vitest';
+import { GitHubClient } from './github-client';
+
+interface FakePage {
+  status: number;
+  commits?: Array<{
+    sha: string;
+    message?: string;
+    authorName?: string;
+    authorDate?: string;
+    committerDate?: string;
+  }>;
+  /** Full URL string to advertise as `rel="next"`. Omit to signal last page. */
+  nextLinkUrl?: string;
+}
+
+function buildCommitJson(c: NonNullable<FakePage['commits']>[number]) {
+  return {
+    sha: c.sha,
+    html_url: `https://github.com/w3c/aria-practices/commit/${c.sha}`,
+    commit: {
+      message: c.message ?? 'msg',
+      author: { name: c.authorName ?? 'a', date: c.authorDate ?? '2026-01-01T00:00:00Z' },
+      committer: { name: 'c', date: c.committerDate ?? '2026-01-02T00:00:00Z' },
+    },
+  };
+}
+
+function makeFetchImpl(pages: FakePage[]): typeof fetch {
+  // Return one Response per call, in order. Extra calls throw.
+  let i = 0;
+  return vi.fn(async () => {
+    if (i >= pages.length) {
+      throw new Error(`fetch called more times than pages were provided (i=${i})`);
+    }
+    const page = pages[i++];
+    const body =
+      page.status === 404 ? '' : JSON.stringify((page.commits ?? []).map(buildCommitJson));
+    const headers: Record<string, string> = { 'content-type': 'application/json' };
+    if (page.nextLinkUrl) {
+      headers.link = `<${page.nextLinkUrl}>; rel="next", <${page.nextLinkUrl}&_last>; rel="last"`;
+    }
+    return new Response(body, { status: page.status, headers });
+  }) as unknown as typeof fetch;
+}
+
+const baseParams = {
+  owner: 'w3c',
+  repo: 'aria-practices',
+  path: 'content/patterns/button',
+};
+
+function makeClient(pages: FakePage[]) {
+  return new GitHubClient({
+    token: 'test',
+    requestSpacingMs: 0,
+    fetchImpl: makeFetchImpl(pages),
+  });
+}
+
+describe('GitHubClient.listCommitsForPath', () => {
+  it('returns commits from a single page when there is no Link header', async () => {
+    const client = makeClient([
+      {
+        status: 200,
+        commits: [{ sha: 'a' }, { sha: 'b' }],
+      },
+    ]);
+    const commits = await client.listCommitsForPath(baseParams);
+    expect(commits.map((c) => c.sha)).toEqual(['a', 'b']);
+  });
+
+  it('returns [] when the first page is 404', async () => {
+    const client = makeClient([{ status: 404 }]);
+    const commits = await client.listCommitsForPath(baseParams);
+    expect(commits).toEqual([]);
+  });
+
+  it('follows rel="next" and concatenates commits across pages', async () => {
+    const nextUrl =
+      'https://api.github.com/repositories/123/commits?path=content/patterns/button&per_page=100&page=2';
+    const client = makeClient([
+      {
+        status: 200,
+        commits: [{ sha: 'a' }, { sha: 'b' }],
+        nextLinkUrl: nextUrl,
+      },
+      {
+        status: 200,
+        commits: [{ sha: 'c' }, { sha: 'd' }],
+      },
+    ]);
+    const commits = await client.listCommitsForPath(baseParams);
+    expect(commits.map((c) => c.sha)).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('throws when the next URL points at a different host (hijack guard)', async () => {
+    const client = makeClient([
+      {
+        status: 200,
+        commits: [{ sha: 'a' }],
+        nextLinkUrl: 'https://evil.example.com/repos/w3c/aria-practices/commits?page=2',
+      },
+    ]);
+    await expect(client.listCommitsForPath(baseParams)).rejects.toThrow(/unexpected next URL/);
+  });
+
+  it('throws when the next URL equals the current URL (infinite-loop guard)', async () => {
+    // The mock returns the same Link header on every call, which would loop
+    // forever without the defensive check.
+    const sameUrl =
+      'https://api.github.com/repos/w3c/aria-practices/commits?path=content%2Fpatterns%2Fbutton&per_page=100';
+    const client = makeClient([
+      {
+        status: 200,
+        commits: [{ sha: 'a' }],
+        nextLinkUrl: sameUrl,
+      },
+    ]);
+    await expect(client.listCommitsForPath(baseParams)).rejects.toThrow(
+      /next URL equals current URL/
+    );
+  });
+
+  it('throws after exceeding COMMITS_MAX_PAGES (default 20)', async () => {
+    // 21 pages each linking to a distinct next page; the 21st should never be
+    // fetched because the loop must throw first.
+    const pages: FakePage[] = Array.from({ length: 21 }, (_, idx) => ({
+      status: 200,
+      commits: [{ sha: `sha${idx}` }],
+      nextLinkUrl: `https://api.github.com/repos/w3c/aria-practices/commits?page=${idx + 2}`,
+    }));
+    const client = makeClient(pages);
+    await expect(client.listCommitsForPath(baseParams)).rejects.toThrow(
+      /exceeded COMMITS_MAX_PAGES=20/
+    );
+  });
+
+  it('throws when a non-first page returns 404 (unexpected mid-pagination)', async () => {
+    const client = makeClient([
+      {
+        status: 200,
+        commits: [{ sha: 'a' }],
+        nextLinkUrl: 'https://api.github.com/repos/w3c/aria-practices/commits?page=2',
+      },
+      { status: 404 },
+    ]);
+    await expect(client.listCommitsForPath(baseParams)).rejects.toThrow(/unexpected 404 on page 2/);
+  });
+
+  it('throws when the Link header next URL is malformed (cannot be parsed)', async () => {
+    const client = makeClient([
+      {
+        status: 200,
+        commits: [{ sha: 'a' }],
+        nextLinkUrl: 'not a url',
+      },
+    ]);
+    await expect(client.listCommitsForPath(baseParams)).rejects.toThrow(
+      /malformed next URL in Link header/
+    );
+  });
+});

--- a/scripts/watch-apg-upstream/github-client.ts
+++ b/scripts/watch-apg-upstream/github-client.ts
@@ -8,6 +8,22 @@
 
 const API_BASE = 'https://api.github.com';
 
+/**
+ * Hard cap on the number of pages `listCommitsForPath` will follow. Each page
+ * returns up to 100 commits, so 20 pages = ~2000 commits. Going beyond this in
+ * a single run typically means `since` was set too far in the past; the safer
+ * remedy is to narrow `since_override` rather than silently consume rate limit.
+ */
+const COMMITS_MAX_PAGES = 20;
+
+/** Parse the `rel="next"` URL out of a GitHub `Link` response header. */
+function parseNextLink(linkHeader: string | null): string | null {
+  if (!linkHeader) return null;
+  // RFC 5988 e.g.: `<https://api.github.com/...?page=2>; rel="next", <...>; rel="last"`
+  const match = linkHeader.match(/<([^>]+)>;\s*rel="next"/);
+  return match ? match[1] : null;
+}
+
 export interface CommitSummary {
   sha: string;
   message: string;
@@ -97,9 +113,13 @@ export class GitHubClient {
   }
 
   /**
-   * Fetch commits in upstream repo touching the given path since the given ISO time.
-   * `since` is inclusive on GitHub side, so we typically pass `lastSeenDate + 1s`
-   * to avoid re-yielding the previously-recorded commit.
+   * Fetch commits in upstream repo touching the given path since the given ISO
+   * time. `since` is inclusive on GitHub side, so we typically pass
+   * `lastSeenDate + 1s` to avoid re-yielding the previously-recorded commit.
+   *
+   * Follows the GitHub `Link: rel="next"` pagination header to collect all
+   * pages, with a hard cap of {@link COMMITS_MAX_PAGES} pages to guard against
+   * accidentally wide `since` windows.
    */
   async listCommitsForPath(params: {
     owner: string;
@@ -113,32 +133,106 @@ export class GitHubClient {
       per_page: String(params.perPage ?? 100),
     });
     if (params.since) qs.set('since', params.since);
-    const res = await this.request('GET', `/repos/${params.owner}/${params.repo}/commits?${qs}`);
-    if (res.status === 404) return [];
-    const json = (await res.json()) as Array<{
-      sha: string;
-      html_url: string;
-      commit: {
-        message: string;
-        author: { name: string; date: string } | null;
-        committer: { name: string; date: string } | null;
-      };
-    }>;
-    return json.map((c) => {
-      const fallbackDate = new Date().toISOString();
-      const authorDate = c.commit.author?.date ?? fallbackDate;
-      // Prefer committer date for the watermark; fall back to author date when
-      // the upstream commit lacks committer info (rare for real GitHub commits).
-      const committerDate = c.commit.committer?.date ?? authorDate;
-      return {
-        sha: c.sha,
-        message: c.commit.message,
-        authorName: c.commit.author?.name ?? 'unknown',
-        authorDate,
-        committerDate,
-        htmlUrl: c.html_url,
-      };
-    });
+
+    const initialPath = `/repos/${params.owner}/${params.repo}/commits?${qs}`;
+    const expectedHost = new URL(API_BASE).host;
+    const expectedPathnamePrefix = `/repos/${params.owner}/${params.repo}/commits`;
+
+    const all: CommitSummary[] = [];
+    let nextPath: string | null = initialPath;
+    let pageCount = 0;
+
+    while (nextPath !== null) {
+      pageCount++;
+      if (pageCount > COMMITS_MAX_PAGES) {
+        throw new Error(
+          `listCommitsForPath: exceeded COMMITS_MAX_PAGES=${COMMITS_MAX_PAGES} ` +
+            `for path=${params.path}. Narrow 'since' or run a one-off backfill.`
+        );
+      }
+
+      const res = await this.request('GET', nextPath);
+      if (res.status === 404) {
+        // 404 normally means the upstream path/repo does not exist. We only
+        // honor it on the first page; a 404 mid-pagination is unexpected.
+        if (pageCount === 1) return [];
+        throw new Error(
+          `listCommitsForPath: unexpected 404 on page ${pageCount} for path=${params.path}`
+        );
+      }
+
+      const json = (await res.json()) as Array<{
+        sha: string;
+        html_url: string;
+        commit: {
+          message: string;
+          author: { name: string; date: string } | null;
+          committer: { name: string; date: string } | null;
+        };
+      }>;
+      for (const c of json) {
+        const fallbackDate = new Date().toISOString();
+        const authorDate = c.commit.author?.date ?? fallbackDate;
+        // Prefer committer date for the watermark; fall back to author date
+        // when the upstream commit lacks committer info (rare for real GitHub
+        // commits).
+        const committerDate = c.commit.committer?.date ?? authorDate;
+        all.push({
+          sha: c.sha,
+          message: c.commit.message,
+          authorName: c.commit.author?.name ?? 'unknown',
+          authorDate,
+          committerDate,
+          htmlUrl: c.html_url,
+        });
+      }
+
+      const nextUrl = parseNextLink(res.headers.get('link'));
+      if (!nextUrl) {
+        nextPath = null;
+        break;
+      }
+
+      // Verify the next URL points back at the same commits endpoint before
+      // following it, so a malformed Link header can never redirect us to a
+      // different host or resource.
+      let parsedNext: URL;
+      try {
+        parsedNext = new URL(nextUrl);
+      } catch {
+        throw new Error(`listCommitsForPath: malformed next URL in Link header: ${nextUrl}`);
+      }
+      // GitHub may advertise the next page in either the slug form
+      // (`/repos/<owner>/<repo>/commits`) or the numeric form
+      // (`/repositories/<id>/commits`). Both are valid for the same resource.
+      const pathnameOk =
+        parsedNext.pathname === expectedPathnamePrefix ||
+        /^\/repositories\/\d+\/commits$/.test(parsedNext.pathname);
+      if (parsedNext.host !== expectedHost || !pathnameOk) {
+        throw new Error(
+          `listCommitsForPath: unexpected next URL ${nextUrl} ` +
+            `(expected host=${expectedHost}, pathname ${expectedPathnamePrefix} ` +
+            `or /repositories/<id>/commits)`
+        );
+      }
+      const candidate = parsedNext.pathname + parsedNext.search;
+      if (candidate === nextPath) {
+        // Defensive: GitHub should never advertise the current page as next,
+        // but if it ever did we would loop forever.
+        throw new Error(
+          `listCommitsForPath: next URL equals current URL (${candidate}); aborting pagination`
+        );
+      }
+      nextPath = candidate;
+    }
+
+    if (pageCount > 1) {
+      console.log(
+        `[github-client] listCommitsForPath ${params.path}: fetched ${all.length} commits across ${pageCount} pages`
+      );
+    }
+
+    return all;
   }
 
   async listIssueComments(params: {


### PR DESCRIPTION
## Summary

`GitHubClient.listCommitsForPath()` が `per_page=100` を指定しつつ **1 ページ目しか取らない** ため、長期 downtime や `since_override` 指定で 101+ commits が落ちる bug (#209) を修正。state は最新 SHA に進むので、落ちた古い commits は永遠に検知されなくなる。

### 変更内容

- `Link` header の `rel="next"` を辿る while ループに書き換え、全ページを結合して返す
- `COMMITS_MAX_PAGES = 20` の hard cap (~2000 commits)。超過時は throw して state を進めずユーザーに `since` の絞り込みを促す
- next URL の host と pathname を verify (hijack 対策)。GitHub が返す **slug 形** (`/repos/<owner>/<repo>/commits`) と **numeric 形** (`/repositories/<id>/commits`) の両方を許容
- `candidate === current URL` の infinite-loop defensive guard
- 1 ページ目以外で 404 が来たら throw (中途半端な結果で state を進めない)
- Link header が malformed なら throw
- `pageCount > 1` のときに `[github-client] ... fetched N commits across M pages` を console.log してオブザーバビリティ向上

### テスト

`github-client.test.ts` 新規作成 (8 ケース、`fetchImpl` 注入で外部依存なし):
1. single page (Link なし)
2. first page 404 → 空配列
3. 2-page concat (rel="next" を辿る)
4. hijack host で throw
5. same URL loop guard で throw
6. COMMITS_MAX_PAGES=20 超過で throw
7. mid-page 404 で throw
8. malformed Link URL で throw

### 関連 / 未対応

本 PR の対象外として、`listIssueComments()` / `searchIssuesWithLabel()` も同じく 1 ページ目しか取らない実装。Codex review で「実害あり (100 件超 comments で batch dedup を見逃す、100 件超 issues で closed latest marker を見逃す可能性)」と指摘されたが、scope を分けて別 Issue を後日起票予定。

Codex (read-only consult) と 2 ラウンドの review iteration で合意 (verdict: pass)。

Closes #209

## Test plan

- [x] `npx vitest run scripts/watch-apg-upstream` — 32 passed (既存 24 + 新規 8)
- [x] `npm run lint:types` — clean
- [ ] CI green (lint / build / test / e2e / Cloudflare Pages preview)
- [ ] マージ後の scheduled run で 1 件 commit を扱う通常運用が正常に動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)