### PR TITLE
fix(apg-watcher): validate workflow_dispatch inputs (since_override, patterns)

### DIFF
--- a/.github/workflows/apg-upstream-watch.yml
+++ b/.github/workflows/apg-upstream-watch.yml
@@ -12,11 +12,11 @@ on:
         type: boolean
         default: false
       since_override:
-        description: 'state 無視で全 slug に適用する ISO8601 since (初回 backfill 用)'
+        description: 'state 無視で全 slug に適用する ISO 8601 date/time (例: 2026-01-01T00:00:00Z または 2026-01-01)。Date として parse できない値は fail'
         type: string
         required: false
       patterns:
-        description: '対象 patternId をカンマ区切りで指定 (省略時は全件)'
+        description: '対象 patternId をカンマ区切り (例: button,toggle-button) で指定。未知の patternId を含むと fail。省略時は全件'
         type: string
         required: false
 

--- a/scripts/watch-apg-upstream.ts
+++ b/scripts/watch-apg-upstream.ts
@@ -24,6 +24,7 @@ import {
   UPSTREAM_REPO,
   UPSTREAM_REPO_FULL,
 } from './watch-apg-upstream/config';
+import { readEnv } from './watch-apg-upstream/env';
 import { GitHubClient } from './watch-apg-upstream/github-client';
 import { formatFollowupComment, formatIssue } from './watch-apg-upstream/issue-formatter';
 import { IssueManager } from './watch-apg-upstream/issue-manager';
@@ -36,30 +37,6 @@ import {
   STATE_FILE,
   STATE_SCHEMA_VERSION,
 } from './watch-apg-upstream/state';
-
-interface Env {
-  token: string;
-  dryRun: boolean;
-  sinceOverride: string | null;
-  patternsFilter: Set<string> | null;
-}
-
-function readEnv(): Env {
-  const token = process.env.GITHUB_TOKEN;
-  if (!token) throw new Error('GITHUB_TOKEN is required');
-  const dryRun = process.env.DRY_RUN === 'true';
-  const sinceOverride = process.env.SINCE_OVERRIDE?.trim() || null;
-  const patternsFilterRaw = process.env.PATTERNS_FILTER?.trim();
-  const patternsFilter = patternsFilterRaw
-    ? new Set(
-        patternsFilterRaw
-          .split(',')
-          .map((s) => s.trim())
-          .filter(Boolean)
-      )
-    : null;
-  return { token, dryRun, sinceOverride, patternsFilter };
-}
 
 function shouldProcess(mapping: SlugMapping, filter: Set<string> | null): boolean {
   if (!filter) return true;
@@ -197,6 +174,21 @@ async function main(): Promise<void> {
   console.log(
     `\nSummary: created/commented=${createdOrCommented}, skipped=${skippedActions}, baselined=${baselined}, unchanged=${unchanged}, errors=${errors.length}`
   );
+
+  // Defense-in-depth: readEnv() already rejects unknown patternIds. A
+  // remaining failure mode is "all requested patternIds are valid but have no
+  // APG URL in their meta" (so buildSlugMap skipped them and the loop matched
+  // zero slugs). Treat that as a hard failure for manual dispatch so the user
+  // sees the typo / config gap immediately.
+  const processedCount = createdOrCommented + skippedActions + baselined + unchanged;
+  if (env.patternsFilter && processedCount === 0) {
+    console.error(
+      `\nPATTERNS_FILTER=${[...env.patternsFilter].join(',')} matched 0 slugs with APG URLs. ` +
+        `Check that the requested patterns have an apgUrl defined in their meta.ts.`
+    );
+    process.exit(1);
+  }
+
   if (errors.length > 0) {
     console.error('\nErrors:');
     for (const e of errors) console.error(`  - ${e}`);

--- a/scripts/watch-apg-upstream/env.test.ts
+++ b/scripts/watch-apg-upstream/env.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { readEnv } from './env';
+
+const tokenEnv = { GITHUB_TOKEN: 'test-token' } satisfies NodeJS.ProcessEnv;
+
+describe('readEnv', () => {
+  it('returns parsed Env for a valid set of inputs', () => {
+    const env = readEnv({
+      ...tokenEnv,
+      DRY_RUN: 'true',
+      SINCE_OVERRIDE: '2026-01-01T00:00:00Z',
+      PATTERNS_FILTER: 'button,accordion',
+    });
+    expect(env.token).toBe('test-token');
+    expect(env.dryRun).toBe(true);
+    expect(env.sinceOverride).toBe('2026-01-01T00:00:00Z');
+    expect(env.patternsFilter).toEqual(new Set(['button', 'accordion']));
+  });
+
+  it('returns null filters when no override / filter is set', () => {
+    const env = readEnv({ ...tokenEnv });
+    expect(env.dryRun).toBe(false);
+    expect(env.sinceOverride).toBeNull();
+    expect(env.patternsFilter).toBeNull();
+  });
+
+  it('throws when GITHUB_TOKEN is missing', () => {
+    expect(() => readEnv({})).toThrow(/GITHUB_TOKEN/);
+  });
+
+  it('throws on an invalid ISO 8601 SINCE_OVERRIDE', () => {
+    expect(() => readEnv({ ...tokenEnv, SINCE_OVERRIDE: 'not-a-date' })).toThrow(
+      /SINCE_OVERRIDE is not a valid ISO 8601 date/
+    );
+  });
+
+  it('throws on an unknown patternId in PATTERNS_FILTER (single)', () => {
+    expect(() => readEnv({ ...tokenEnv, PATTERNS_FILTER: 'nonexistent' })).toThrow(
+      /unknown patternId\(s\): nonexistent/
+    );
+  });
+
+  it('throws and lists all unknown patternIds when multiple typos exist', () => {
+    // Includes one valid id (`button`) to confirm only unknowns are reported.
+    expect(() => readEnv({ ...tokenEnv, PATTERNS_FILTER: 'foo,bar,button' })).toThrow(
+      /unknown patternId\(s\): foo, bar/
+    );
+  });
+
+  it('treats trailing / surrounding commas and whitespace as empty entries (not unknown ids)', () => {
+    // Input that humans easily produce in CI UIs. The trim+filter chain should
+    // ignore the empty tokens so we do not flag them as `unknown patternId(s): `.
+    const env = readEnv({ ...tokenEnv, PATTERNS_FILTER: 'button, ,accordion,' });
+    expect(env.patternsFilter).toEqual(new Set(['button', 'accordion']));
+  });
+
+  it('treats a PATTERNS_FILTER containing only whitespace / commas as no filter', () => {
+    const env = readEnv({ ...tokenEnv, PATTERNS_FILTER: ' , , ' });
+    expect(env.patternsFilter).toBeNull();
+  });
+});

--- a/scripts/watch-apg-upstream/env.ts
+++ b/scripts/watch-apg-upstream/env.ts
@@ -1,0 +1,70 @@
+/**
+ * Environment variable parsing for the APG upstream watcher entrypoint.
+ *
+ * Kept separate from `watch-apg-upstream.ts` so that the validation can be
+ * unit-tested without executing the watcher's `main()` at module load.
+ */
+import { PATTERNS } from '../../src/lib/patterns';
+
+export interface Env {
+  token: string;
+  dryRun: boolean;
+  sinceOverride: string | null;
+  patternsFilter: Set<string> | null;
+}
+
+/**
+ * Parse and validate the watcher's environment inputs.
+ *
+ * @param env  Process environment to read from. Defaults to `process.env`;
+ *             tests pass a plain object so they do not have to mutate global
+ *             state.
+ *
+ * Throws (`Error`) on:
+ * - missing `GITHUB_TOKEN`
+ * - `SINCE_OVERRIDE` that is not a valid ISO 8601 / `Date`-parsable string
+ * - `PATTERNS_FILTER` containing any patternId that is not in `PATTERNS`
+ *   (all unknown ids are reported in a single error so multiple typos can be
+ *   fixed at once)
+ */
+export function readEnv(env: NodeJS.ProcessEnv = process.env): Env {
+  const token = env.GITHUB_TOKEN;
+  if (!token) throw new Error('GITHUB_TOKEN is required');
+
+  const dryRun = env.DRY_RUN === 'true';
+
+  const sinceOverrideRaw = env.SINCE_OVERRIDE?.trim() || null;
+  let sinceOverride: string | null = null;
+  if (sinceOverrideRaw) {
+    const parsed = new Date(sinceOverrideRaw);
+    if (Number.isNaN(parsed.getTime())) {
+      throw new Error(
+        `SINCE_OVERRIDE is not a valid ISO 8601 date: ${JSON.stringify(sinceOverrideRaw)}`
+      );
+    }
+    sinceOverride = sinceOverrideRaw;
+  }
+
+  const patternsFilterRaw = env.PATTERNS_FILTER?.trim();
+  let patternsFilter: Set<string> | null = null;
+  if (patternsFilterRaw) {
+    const requested = patternsFilterRaw
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (requested.length > 0) {
+      const validIds = new Set(PATTERNS.map((p) => p.id));
+      const unknown = requested.filter((id) => !validIds.has(id));
+      if (unknown.length > 0) {
+        const sortedValid = [...validIds].sort().join(', ');
+        throw new Error(
+          `PATTERNS_FILTER contains unknown patternId(s): ${unknown.join(', ')}. ` +
+            `Valid ids: ${sortedValid}`
+        );
+      }
+      patternsFilter = new Set(requested);
+    }
+  }
+
+  return { token, dryRun, sinceOverride, patternsFilter };
+}


### PR DESCRIPTION
## Summary

手動 `workflow_dispatch` で `since_override` の typo や `patterns` の不正 id が渡された場合に、現状は静かに無視 (前者) or 0 件マッチで silent skip (後者) になり、原因調査が困難だった問題 (#208) を修正。fail fast で運用ミスを即検知。

### 変更内容

- `readEnv()` を `scripts/watch-apg-upstream/env.ts` に extract し、`readEnv(env = process.env)` 形に refactor (副作用排除 + testability)
- **`SINCE_OVERRIDE`**: `new Date()` で parse、NaN なら値を含む明確なエラーで throw
- **`PATTERNS_FILTER`**: `src/lib/patterns.ts` の `PATTERNS` と照合し、未知の id があれば **全部列挙** して throw (typo を一度に修正できる)。さらに valid ids 32 件を併記して直感的な修正ヒントを提示
- main 後段に defense-in-depth として `patternsFilter && processedCount === 0` の fail を追加。validation を通った patternId でも `apgUrl` 欠落で `buildSlugMap` が skip するケースを catch
- `.github/workflows/apg-upstream-watch.yml` の `since_override` / `patterns` の description を補強

### テスト

`env.test.ts` 新規作成 (8 ケース、外部依存なし):
1. 正常入力 (DRY_RUN/SINCE_OVERRIDE/PATTERNS_FILTER 全部指定)
2. 何も指定しない場合 null
3. GITHUB_TOKEN 欠如で throw
4. 不正 ISO で throw
5. unknown patternId 1 件で throw
6. unknown patternId 複数で全部列挙して throw
7. 末尾カンマ・空エントリは無視
8. カンマ・空白だけは null filter 扱い

### 手動検証 (DRY_RUN=true)

| シナリオ | 結果 |
|---|---|
| `PATTERNS_FILTER=button` | exit 0、button の baseline 処理 |
| `SINCE_OVERRIDE=not-a-date` | exit 1、`Fatal: Error: SINCE_OVERRIDE is not a valid ISO 8601 date: "not-a-date"` |
| `PATTERNS_FILTER=nonexistent` | exit 1、`unknown patternId(s): nonexistent. Valid ids: accordion, alert, ...` |
| `PATTERNS_FILTER=foo,bar,button` | exit 1、`unknown patternId(s): foo, bar` (button は valid なので除外) |

### Notes

- 直前にマージされた PR #215 (commits API pagination) と整合 — validation は commits fetch 前に落ちるので相互独立
- Codex review で「未来日 `SINCE_OVERRIDE` を `warning or fail` するか」が conditional 指摘されたが、スコープ外として本 PR では見送り (必要なら別 Issue)

Codex (read-only consult) と 2 ラウンドの review iteration で合意 (verdict: pass)。

Closes #208

## Test plan

- [x] `npx vitest run scripts/watch-apg-upstream` — 40 passed (既存 32 + 新規 8)
- [x] `npm run lint:types` — clean
- [x] ローカル dry-run で 4 シナリオ全部期待通り
- [ ] CI green (lint / build / test / e2e / Cloudflare Pages preview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)