### PR TITLE
feat(windowsplitter): WCAG 2.5.8 Target Size + 2.5.7 Dragging Movements

### DIFF
--- a/e2e/windowsplitter.spec.ts
+++ b/e2e/windowsplitter.spec.ts
@@ -134,7 +134,7 @@ for (const framework of frameworks) {
         expect(newValue).toBe('45');
       });
 
-      test('ArrowUp increases position on vertical splitter', async ({ page }) => {
+      test('ArrowUp moves separator up on vertical splitter', async ({ page }) => {
         const splitter = page.locator('[data-testid="vertical-splitter"]');
 
         await splitter.focus();
@@ -145,10 +145,10 @@ for (const framework of frameworks) {
         await page.waitForTimeout(50);
 
         const newValue = await splitter.getAttribute('aria-valuenow');
-        expect(newValue).toBe('55');
+        expect(newValue).toBe('45');
       });
 
-      test('ArrowDown decreases position on vertical splitter', async ({ page }) => {
+      test('ArrowDown moves separator down on vertical splitter', async ({ page }) => {
         const splitter = page.locator('[data-testid="vertical-splitter"]');
 
         await splitter.focus();
@@ -159,7 +159,7 @@ for (const framework of frameworks) {
         await page.waitForTimeout(50);
 
         const newValue = await splitter.getAttribute('aria-valuenow');
-        expect(newValue).toBe('45');
+        expect(newValue).toBe('55');
       });
 
       test('Arrow keys are ignored for wrong orientation', async ({ page }) => {

--- a/src/patterns/windowsplitter/WindowSplitter.astro
+++ b/src/patterns/windowsplitter/WindowSplitter.astro
@@ -124,26 +124,153 @@ const isVertical = orientation === 'vertical';
       class="apg-window-splitter__separator"
     >
     </div>
+    {
+      !disabled && !readonly && (
+        <div
+          class="apg-window-splitter__popup"
+          role="group"
+          aria-label={`Adjust ${ariaLabel || ''}`}
+        >
+          <button
+            type="button"
+            class="apg-window-splitter__popup-button"
+            tabindex="-1"
+            aria-label={`Collapse ${ariaLabel || ''}`}
+            data-adjust="collapse"
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 12 12"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+              style={`transform: translate(${isVertical ? '0px, -1px' : '-1px, 0px'})`}
+            >
+              <path d={isVertical ? 'M2 9L6 5L10 9M2 5L6 1L10 5' : 'M5 2L1 6L5 10M9 2L5 6L9 10'} />
+            </svg>
+          </button>
+          <button
+            type="button"
+            class="apg-window-splitter__popup-button"
+            tabindex="-1"
+            aria-label={`Shrink ${ariaLabel || ''}`}
+            data-adjust="decrease"
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 12 12"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+              style={`transform: translate(${isVertical ? '0px, -1px' : '-1px, 0px'})`}
+            >
+              <path d={isVertical ? 'M2 8L6 4L10 8' : 'M8 2L4 6L8 10'} />
+            </svg>
+          </button>
+          <button
+            type="button"
+            class="apg-window-splitter__popup-button"
+            tabindex="-1"
+            aria-label={`Expand ${ariaLabel || ''}`}
+            data-adjust="increase"
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 12 12"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+              style={`transform: translate(${isVertical ? '0px, 1px' : '1px, 0px'})`}
+            >
+              <path d={isVertical ? 'M2 4L6 8L10 4' : 'M4 2L8 6L4 10'} />
+            </svg>
+          </button>
+          <button
+            type="button"
+            class="apg-window-splitter__popup-button"
+            tabindex="-1"
+            aria-label={`Expand ${ariaLabel || ''} to maximum`}
+            data-adjust="maximize"
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 12 12"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+              style={`transform: translate(${isVertical ? '0px, 1px' : '1px, 0px'})`}
+            >
+              <path
+                d={isVertical ? 'M2 3L6 7L10 3M2 7L6 11L10 7' : 'M3 2L7 6L3 10M7 2L11 6L7 10'}
+              />
+            </svg>
+          </button>
+        </div>
+      )
+    }
   </div>
 </apg-window-splitter>
 
 <script>
+  const HOVER_DELAY = 300;
+  const DISMISS_DELAY = 300;
+  const ACTIVE_SETTLE_DELAY = 500;
+  const TAP_DISTANCE_THRESHOLD = 5;
+  const POPUP_OFFSET = 8;
+
   class ApgWindowSplitter extends HTMLElement {
     private separator: HTMLElement | null = null;
     private container: HTMLElement | null = null;
+    private popup: HTMLElement | null = null;
     private isDragging = false;
     private previousPosition: number | null = null;
     private collapsed = false;
+
+    private popupState: 'hidden' | 'showing' | 'active' = 'hidden';
+    private popupPos: { x: number; y: number } | null = null;
+    private hoverTimer: ReturnType<typeof setTimeout> | null = null;
+    private dismissTimer: ReturnType<typeof setTimeout> | null = null;
+    private activeSettleTimer: ReturnType<typeof setTimeout> | null = null;
+    private pointerStart: { x: number; y: number } | null = null;
+    private isMouseOverPopup = false;
+    private hoverPos: { x: number; y: number } | null = null;
 
     // Bound event handlers (stored to properly remove listeners)
     private boundHandleKeyDown = this.handleKeyDown.bind(this);
     private boundHandlePointerDown = this.handlePointerDown.bind(this);
     private boundHandlePointerMove = this.handlePointerMove.bind(this);
     private boundHandlePointerUp = this.handlePointerUp.bind(this);
+    private boundHandleSeparatorMouseEnter = this.handleSeparatorMouseEnter.bind(this);
+    private boundHandleSeparatorMouseLeave = this.handleSeparatorMouseLeave.bind(this);
+    private boundHandleSeparatorMouseMove = this.handleSeparatorMouseMove.bind(this);
+    private boundHandleSeparatorFocus = this.handleSeparatorFocus.bind(this);
+    private boundHandleSeparatorBlur = this.handleSeparatorBlur.bind(this);
+    private boundHandlePopupMouseEnter = this.handlePopupMouseEnter.bind(this);
+    private boundHandlePopupMouseLeave = this.handlePopupMouseLeave.bind(this);
+    private boundHandlePopupKeyDown = this.handlePopupKeyDown.bind(this);
+    private boundHandlePopupButtonClick = this.handlePopupButtonClick.bind(this);
+    private boundHandleOutsidePointerDown = this.handleOutsidePointerDown.bind(this);
 
     connectedCallback() {
       this.separator = this.querySelector('[role="separator"]');
       this.container = this.querySelector('.apg-window-splitter');
+      this.popup = this.querySelector('.apg-window-splitter__popup');
 
       // Initialize state from data attributes
       this.collapsed = this.dataset.collapsed === 'true';
@@ -156,6 +283,18 @@ const isVertical = orientation === 'vertical';
         this.separator.addEventListener('pointerdown', this.boundHandlePointerDown);
         this.separator.addEventListener('pointermove', this.boundHandlePointerMove);
         this.separator.addEventListener('pointerup', this.boundHandlePointerUp);
+        this.separator.addEventListener('mouseenter', this.boundHandleSeparatorMouseEnter);
+        this.separator.addEventListener('mouseleave', this.boundHandleSeparatorMouseLeave);
+        this.separator.addEventListener('mousemove', this.boundHandleSeparatorMouseMove);
+        this.separator.addEventListener('focus', this.boundHandleSeparatorFocus);
+        this.separator.addEventListener('blur', this.boundHandleSeparatorBlur);
+      }
+
+      if (this.popup) {
+        this.popup.addEventListener('mouseenter', this.boundHandlePopupMouseEnter);
+        this.popup.addEventListener('mouseleave', this.boundHandlePopupMouseLeave);
+        this.popup.addEventListener('keydown', this.boundHandlePopupKeyDown);
+        this.popup.addEventListener('click', this.boundHandlePopupButtonClick);
       }
     }
 
@@ -165,7 +304,22 @@ const isVertical = orientation === 'vertical';
         this.separator.removeEventListener('pointerdown', this.boundHandlePointerDown);
         this.separator.removeEventListener('pointermove', this.boundHandlePointerMove);
         this.separator.removeEventListener('pointerup', this.boundHandlePointerUp);
+        this.separator.removeEventListener('mouseenter', this.boundHandleSeparatorMouseEnter);
+        this.separator.removeEventListener('mouseleave', this.boundHandleSeparatorMouseLeave);
+        this.separator.removeEventListener('mousemove', this.boundHandleSeparatorMouseMove);
+        this.separator.removeEventListener('focus', this.boundHandleSeparatorFocus);
+        this.separator.removeEventListener('blur', this.boundHandleSeparatorBlur);
       }
+
+      if (this.popup) {
+        this.popup.removeEventListener('mouseenter', this.boundHandlePopupMouseEnter);
+        this.popup.removeEventListener('mouseleave', this.boundHandlePopupMouseLeave);
+        this.popup.removeEventListener('keydown', this.boundHandlePopupKeyDown);
+        this.popup.removeEventListener('click', this.boundHandlePopupButtonClick);
+      }
+
+      document.removeEventListener('pointerdown', this.boundHandleOutsidePointerDown);
+      this.clearAllTimers();
     }
 
     private get min(): number {
@@ -235,6 +389,36 @@ const isVertical = orientation === 'vertical';
       return Math.min(this.max, Math.max(this.min, value));
     }
 
+    private clearAllTimers() {
+      if (this.hoverTimer) clearTimeout(this.hoverTimer);
+      if (this.dismissTimer) clearTimeout(this.dismissTimer);
+      if (this.activeSettleTimer) clearTimeout(this.activeSettleTimer);
+      this.hoverTimer = null;
+      this.dismissTimer = null;
+      this.activeSettleTimer = null;
+    }
+
+    private updatePopupButtonStates() {
+      if (!this.popup) return;
+      const pos = this.currentPosition;
+      const collapseBtn = this.popup.querySelector<HTMLButtonElement>('[data-adjust="collapse"]');
+      const decreaseBtn = this.popup.querySelector<HTMLButtonElement>('[data-adjust="decrease"]');
+      const increaseBtn = this.popup.querySelector<HTMLButtonElement>('[data-adjust="increase"]');
+      const maximizeBtn = this.popup.querySelector<HTMLButtonElement>('[data-adjust="maximize"]');
+      if (collapseBtn) {
+        collapseBtn.setAttribute('aria-disabled', String(pos <= this.min));
+      }
+      if (decreaseBtn) {
+        decreaseBtn.setAttribute('aria-disabled', String(pos <= this.min));
+      }
+      if (increaseBtn) {
+        increaseBtn.setAttribute('aria-disabled', String(pos >= this.max));
+      }
+      if (maximizeBtn) {
+        maximizeBtn.setAttribute('aria-disabled', String(pos >= this.max));
+      }
+    }
+
     private updatePosition(newPosition: number) {
       if (!this.separator || this.isDisabled) return;
 
@@ -258,6 +442,9 @@ const isVertical = orientation === 'vertical';
           (clampedPosition / 100) *
           (this.isHorizontal ? this.container.offsetWidth : this.container.offsetHeight);
       }
+
+      // Update popup button disabled states
+      this.updatePopupButtonStates();
 
       // Dispatch event
       this.dispatchEvent(
@@ -299,6 +486,8 @@ const isVertical = orientation === 'vertical';
             (this.isHorizontal ? this.container.offsetWidth : this.container.offsetHeight);
         }
 
+        this.updatePopupButtonStates();
+
         this.dispatchEvent(
           new CustomEvent('positionchange', {
             detail: { position: clampedRestore, sizeInPx },
@@ -323,6 +512,8 @@ const isVertical = orientation === 'vertical';
           this.container.style.setProperty('--splitter-position', '0%');
         }
 
+        this.updatePopupButtonStates();
+
         this.dispatchEvent(
           new CustomEvent('positionchange', {
             detail: { position: 0, sizeInPx: 0 },
@@ -332,8 +523,94 @@ const isVertical = orientation === 'vertical';
       }
     }
 
+    private calcPopupPosition(clientX: number, clientY: number): { x: number; y: number } | null {
+      if (!this.separator) return null;
+      const rect = this.separator.getBoundingClientRect();
+      const popupWidth = this.popup?.offsetWidth || (this.isVertical ? 34 : 120);
+      const popupHeight = this.popup?.offsetHeight || (this.isVertical ? 120 : 34);
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+
+      let x: number;
+      let y: number;
+
+      if (this.isHorizontal) {
+        x = clientX - popupWidth / 2;
+        const belowY = clientY + POPUP_OFFSET;
+        const aboveY = clientY - POPUP_OFFSET - popupHeight;
+        y = belowY + popupHeight <= vh ? belowY : aboveY;
+      } else {
+        y = clientY - popupHeight / 2;
+        const rightX = clientX + POPUP_OFFSET;
+        const leftX = clientX - POPUP_OFFSET - popupWidth;
+        x = rightX + popupWidth <= vw ? rightX : leftX;
+      }
+
+      x = Math.min(vw - popupWidth, Math.max(0, x));
+      y = Math.min(vh - popupHeight, Math.max(0, y));
+
+      return { x, y };
+    }
+
+    private showPopup(clientX: number, clientY: number) {
+      if (this.isDisabled || this.isReadonly || !this.popup) return;
+
+      if (this.dismissTimer) {
+        clearTimeout(this.dismissTimer);
+        this.dismissTimer = null;
+      }
+
+      const pos = this.calcPopupPosition(clientX, clientY);
+      if (pos) {
+        this.popupPos = pos;
+        this.popup.style.left = `${pos.x}px`;
+        this.popup.style.top = `${pos.y}px`;
+        this.popup.style.flexDirection = this.isVertical ? 'column' : 'row';
+        this.popup.classList.add('apg-window-splitter__popup--visible');
+        this.popupState = 'showing';
+        this.updatePopupButtonStates();
+      }
+    }
+
+    private hidePopup() {
+      this.clearAllTimers();
+      document.removeEventListener('pointerdown', this.boundHandleOutsidePointerDown);
+      this.popupState = 'hidden';
+      this.popupPos = null;
+      if (this.popup) {
+        this.popup.classList.remove('apg-window-splitter__popup--visible');
+      }
+    }
+
+    private handleOutsidePointerDown(event: PointerEvent) {
+      if (this.popup && !this.popup.contains(event.target as Node)) {
+        this.hidePopup();
+      }
+    }
+
+    private scheduleDismiss() {
+      if (this.dismissTimer) clearTimeout(this.dismissTimer);
+      this.dismissTimer = setTimeout(() => {
+        const hasFocusInside =
+          this.popup?.contains(document.activeElement) || this.separator === document.activeElement;
+        if (!hasFocusInside) {
+          this.hidePopup();
+        }
+      }, DISMISS_DELAY);
+    }
+
     private handleKeyDown(event: KeyboardEvent) {
       if (this.isDisabled || this.isReadonly) return;
+
+      // Tab to popup buttons when popup is visible
+      if (event.key === 'Tab' && !event.shiftKey && this.popupState !== 'hidden') {
+        const firstBtn = this.popup?.querySelector<HTMLButtonElement>('button');
+        if (firstBtn) {
+          event.preventDefault();
+          firstBtn.focus();
+          return;
+        }
+      }
 
       const hasShift = event.shiftKey;
       const currentStep = hasShift ? this.largeStep : this.step;
@@ -356,13 +633,13 @@ const isVertical = orientation === 'vertical';
 
         case 'ArrowUp':
           if (!this.isVertical) break;
-          delta = currentStep;
+          delta = -currentStep;
           handled = true;
           break;
 
         case 'ArrowDown':
           if (!this.isVertical) break;
-          delta = -currentStep;
+          delta = currentStep;
           handled = true;
           break;
 
@@ -395,15 +672,38 @@ const isVertical = orientation === 'vertical';
 
       event.preventDefault();
 
+      this.pointerStart = { x: event.clientX, y: event.clientY };
+      this.isDragging = false;
+
       if (typeof this.separator.setPointerCapture === 'function') {
         this.separator.setPointerCapture(event.pointerId);
       }
-      this.isDragging = true;
+
+      if (this.hoverTimer) {
+        clearTimeout(this.hoverTimer);
+        this.hoverTimer = null;
+      }
+
       this.separator.focus();
     }
 
     private handlePointerMove(event: PointerEvent) {
-      if (!this.isDragging || !this.container) return;
+      const start = this.pointerStart;
+      if (!start) return;
+
+      if (!this.isDragging) {
+        const dx = event.clientX - start.x;
+        const dy = event.clientY - start.y;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+        if (distance >= TAP_DISTANCE_THRESHOLD) {
+          this.isDragging = true;
+          if (this.popupState !== 'hidden') this.hidePopup();
+        } else {
+          return;
+        }
+      }
+
+      if (!this.container) return;
 
       // Use demo container for stable measurement if available
       const demoContainer = this.container.closest(
@@ -418,7 +718,6 @@ const isVertical = orientation === 'vertical';
         percent = (x / rect.width) * 100;
       } else {
         const y = event.clientY - rect.top;
-        // For vertical, y position corresponds to primary pane height
         percent = (y / rect.height) * 100;
       }
 
@@ -441,7 +740,146 @@ const isVertical = orientation === 'vertical';
           // Ignore
         }
       }
+
+      const start = this.pointerStart;
+      if (start && !this.isDragging) {
+        this.showPopup(start.x, start.y);
+      }
+
       this.isDragging = false;
+      this.pointerStart = null;
+    }
+
+    private handleSeparatorMouseEnter(event: MouseEvent) {
+      if (this.isDisabled || this.isReadonly || this.isDragging) return;
+      this.hoverPos = { x: event.clientX, y: event.clientY };
+      if (this.popupState === 'hidden') {
+        if (this.hoverTimer) clearTimeout(this.hoverTimer);
+        this.hoverTimer = setTimeout(() => {
+          const pos = this.hoverPos;
+          if (pos) this.showPopup(pos.x, pos.y);
+        }, HOVER_DELAY);
+      }
+      if (this.dismissTimer) {
+        clearTimeout(this.dismissTimer);
+        this.dismissTimer = null;
+      }
+    }
+
+    private handleSeparatorMouseLeave() {
+      if (this.hoverTimer) {
+        clearTimeout(this.hoverTimer);
+        this.hoverTimer = null;
+      }
+      if (this.popupState !== 'hidden') this.scheduleDismiss();
+    }
+
+    private handleSeparatorMouseMove(event: MouseEvent) {
+      this.hoverPos = { x: event.clientX, y: event.clientY };
+    }
+
+    private handleSeparatorFocus() {
+      if (this.isDisabled || this.isReadonly) return;
+      if (this.popupState === 'hidden') {
+        if (this.separator) {
+          const rect = this.separator.getBoundingClientRect();
+          this.showPopup(rect.left + rect.width / 2, rect.top + rect.height / 2);
+        }
+      }
+      if (this.dismissTimer) {
+        clearTimeout(this.dismissTimer);
+        this.dismissTimer = null;
+      }
+    }
+
+    private handleSeparatorBlur() {
+      if (this.popupState !== 'hidden') {
+        setTimeout(() => {
+          if (
+            !this.popup?.contains(document.activeElement) &&
+            this.separator !== document.activeElement
+          ) {
+            this.scheduleDismiss();
+          }
+        }, 0);
+      }
+    }
+
+    private handlePopupMouseEnter() {
+      this.isMouseOverPopup = true;
+      if (this.dismissTimer) {
+        clearTimeout(this.dismissTimer);
+        this.dismissTimer = null;
+      }
+    }
+
+    private handlePopupMouseLeave() {
+      this.isMouseOverPopup = false;
+      if (this.popupState !== 'hidden') this.scheduleDismiss();
+    }
+
+    private handlePopupKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        this.hidePopup();
+        this.separator?.focus();
+      }
+      if (event.key === 'Tab' && event.shiftKey) {
+        event.preventDefault();
+        this.hidePopup();
+        this.separator?.focus();
+      }
+    }
+
+    private handlePopupButtonClick(event: Event) {
+      const target = (event.target as HTMLElement).closest<HTMLButtonElement>('[data-adjust]');
+      if (!target) return;
+      if (this.isDisabled || this.isReadonly) return;
+
+      const adjustType = target.dataset.adjust;
+      let delta: number;
+      switch (adjustType) {
+        case 'collapse':
+          delta = this.min - this.currentPosition;
+          break;
+        case 'decrease':
+          delta = -this.step;
+          break;
+        case 'increase':
+          delta = this.step;
+          break;
+        case 'maximize':
+          delta = this.max - this.currentPosition;
+          break;
+        default:
+          return;
+      }
+      const newPos = this.currentPosition + delta;
+
+      if (newPos < this.min || newPos > this.max) return;
+
+      this.updatePosition(newPos);
+      if (this.popupState !== 'active') {
+        this.popupState = 'active';
+        document.addEventListener('pointerdown', this.boundHandleOutsidePointerDown);
+      }
+
+      if (this.activeSettleTimer) clearTimeout(this.activeSettleTimer);
+      this.activeSettleTimer = setTimeout(() => {
+        if (this.popupState === 'active') {
+          if (!this.isMouseOverPopup) {
+            const pos = this.hoverPos;
+            if (pos && this.popup) {
+              const newPopupPos = this.calcPopupPosition(pos.x, pos.y);
+              if (newPopupPos) {
+                this.popup.style.left = `${newPopupPos.x}px`;
+                this.popup.style.top = `${newPopupPos.y}px`;
+              }
+            }
+          }
+          this.popupState = 'showing';
+        }
+      }, ACTIVE_SETTLE_DELAY);
     }
 
     // Public method to update position programmatically

--- a/src/patterns/windowsplitter/WindowSplitter.astro
+++ b/src/patterns/windowsplitter/WindowSplitter.astro
@@ -525,7 +525,6 @@ const isVertical = orientation === 'vertical';
 
     private calcPopupPosition(clientX: number, clientY: number): { x: number; y: number } | null {
       if (!this.separator) return null;
-      const rect = this.separator.getBoundingClientRect();
       const popupWidth = this.popup?.offsetWidth || (this.isVertical ? 34 : 120);
       const popupHeight = this.popup?.offsetHeight || (this.isVertical ? 120 : 34);
       const vw = window.innerWidth;

--- a/src/patterns/windowsplitter/WindowSplitter.svelte
+++ b/src/patterns/windowsplitter/WindowSplitter.svelte
@@ -163,7 +163,6 @@
   // Calculate popup position
   function calcPopupPosition(clientX: number, clientY: number): { x: number; y: number } | null {
     if (!splitterEl) return null;
-    const rect = splitterEl.getBoundingClientRect();
     const popupWidth = popupEl?.offsetWidth || (isVertical ? 34 : 120);
     const popupHeight = popupEl?.offsetHeight || (isVertical ? 120 : 34);
     const vw = window.innerWidth;

--- a/src/patterns/windowsplitter/WindowSplitter.svelte
+++ b/src/patterns/windowsplitter/WindowSplitter.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
+
   interface WindowSplitterProps {
     /** Primary pane ID (required for aria-controls) */
     primaryPaneId: string;
@@ -55,6 +57,13 @@
     ...restProps
   }: WindowSplitterProps = $props();
 
+  // Constants
+  const HOVER_DELAY = 300;
+  const DISMISS_DELAY = 300;
+  const ACTIVE_SETTLE_DELAY = 500;
+  const TAP_DISTANCE_THRESHOLD = 5;
+  const POPUP_OFFSET = 8;
+
   // Utility function
   function clamp(value: number, minVal: number, maxVal: number): number {
     return Math.min(maxVal, Math.max(minVal, value));
@@ -63,7 +72,7 @@
   // Refs
   let splitterEl: HTMLDivElement | null = null;
   let containerEl: HTMLDivElement | null = null;
-  let isDragging = $state(false);
+  let popupEl: HTMLDivElement | null = $state(null);
 
   // State - capture initial prop values (intentionally not reactive to prop changes)
   // Using IIFE to avoid Svelte's state_referenced_locally warning
@@ -76,6 +85,22 @@
   let position = $state(initPosition);
   let collapsed = $state(initCollapsed);
   let previousPosition: number | null = initPreviousPosition;
+  let popupState = $state<'hidden' | 'showing' | 'active'>('hidden');
+  let popupPos = $state<{ x: number; y: number } | null>(null);
+
+  // Plain variable for synchronous position tracking (for rapid popup button clicks)
+  let latestPosition = initPosition;
+
+  // Timer refs (plain variables, not reactive)
+  let hoverTimer: ReturnType<typeof setTimeout> | null = null;
+  let dismissTimer: ReturnType<typeof setTimeout> | null = null;
+  let activeSettleTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Pointer tracking
+  let pointerStart: { x: number; y: number } | null = null;
+  let isDragging = false;
+  let isMouseOverPopup = false;
+  let hoverPos: { x: number; y: number } | null = null;
 
   // Computed
   const isVertical = $derived(orientation === 'vertical');
@@ -89,10 +114,120 @@
     secondaryPaneId ? `${primaryPaneId} ${secondaryPaneId}` : primaryPaneId
   );
 
+  const splitterLabel = $derived((restProps['aria-label'] as string) || '');
+
+  const isAtMin = $derived(position <= min);
+  const isAtMax = $derived(position >= max);
+
+  const icons = $derived(
+    isVertical
+      ? {
+          collapse: { d: 'M2 9L6 5L10 9M2 5L6 1L10 5', dx: 0, dy: -1 },
+          shrink: { d: 'M2 8L6 4L10 8', dx: 0, dy: -1 },
+          expand: { d: 'M2 4L6 8L10 4', dx: 0, dy: 1 },
+          max: { d: 'M2 3L6 7L10 3M2 7L6 11L10 7', dx: 0, dy: 1 },
+        }
+      : {
+          collapse: { d: 'M5 2L1 6L5 10M9 2L5 6L9 10', dx: -1, dy: 0 },
+          shrink: { d: 'M8 2L4 6L8 10', dx: -1, dy: 0 },
+          expand: { d: 'M4 2L8 6L4 10', dx: 1, dy: 0 },
+          max: { d: 'M3 2L7 6L3 10M7 2L11 6L7 10', dx: 1, dy: 0 },
+        }
+  );
+
+  // Timer cleanup
+  function clearAllTimers() {
+    if (hoverTimer) clearTimeout(hoverTimer);
+    if (dismissTimer) clearTimeout(dismissTimer);
+    if (activeSettleTimer) clearTimeout(activeSettleTimer);
+    hoverTimer = null;
+    dismissTimer = null;
+    activeSettleTimer = null;
+  }
+
+  onMount(() => {
+    return () => clearAllTimers();
+  });
+
+  $effect(() => {
+    if (popupState !== 'active') return;
+    const handleOutsidePointerDown = (e: PointerEvent) => {
+      if (popupEl && !popupEl.contains(e.target as Node)) {
+        hidePopup();
+      }
+    };
+    document.addEventListener('pointerdown', handleOutsidePointerDown);
+    return () => document.removeEventListener('pointerdown', handleOutsidePointerDown);
+  });
+
+  // Calculate popup position
+  function calcPopupPosition(clientX: number, clientY: number): { x: number; y: number } | null {
+    if (!splitterEl) return null;
+    const rect = splitterEl.getBoundingClientRect();
+    const popupWidth = popupEl?.offsetWidth || (isVertical ? 34 : 120);
+    const popupHeight = popupEl?.offsetHeight || (isVertical ? 120 : 34);
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+
+    let x: number;
+    let y: number;
+
+    if (isHorizontal) {
+      x = clientX - popupWidth / 2;
+      const belowY = clientY + POPUP_OFFSET;
+      const aboveY = clientY - POPUP_OFFSET - popupHeight;
+      y = belowY + popupHeight <= vh ? belowY : aboveY;
+    } else {
+      y = clientY - popupHeight / 2;
+      const rightX = clientX + POPUP_OFFSET;
+      const leftX = clientX - POPUP_OFFSET - popupWidth;
+      x = rightX + popupWidth <= vw ? rightX : leftX;
+    }
+
+    x = clamp(x, 0, vw - popupWidth);
+    y = clamp(y, 0, vh - popupHeight);
+
+    return { x, y };
+  }
+
+  // Show popup
+  function showPopup(clientX: number, clientY: number) {
+    if (disabled || readonly) return;
+    if (dismissTimer) {
+      clearTimeout(dismissTimer);
+      dismissTimer = null;
+    }
+    const pos = calcPopupPosition(clientX, clientY);
+    if (pos) {
+      popupPos = pos;
+      popupState = 'showing';
+    }
+  }
+
+  // Hide popup
+  function hidePopup() {
+    clearAllTimers();
+    popupState = 'hidden';
+    popupPos = null;
+  }
+
+  // Schedule dismiss
+  function scheduleDismiss() {
+    if (dismissTimer) clearTimeout(dismissTimer);
+    dismissTimer = setTimeout(() => {
+      const hasFocusInside =
+        popupEl?.contains(document.activeElement) || splitterEl === document.activeElement;
+      if (!hasFocusInside) {
+        hidePopup();
+      }
+    }, DISMISS_DELAY);
+  }
+
   // Update position and emit
   function updatePosition(newPosition: number) {
     const clampedPosition = clamp(newPosition, min, max);
-    if (clampedPosition !== position) {
+    if (clampedPosition !== latestPosition) {
+      latestPosition = clampedPosition;
       position = clampedPosition;
 
       const sizeInPx = containerEl
@@ -104,17 +239,43 @@
     }
   }
 
+  // Handle popup button click
+  function handlePopupButtonClick(delta: number) {
+    if (disabled || readonly) return;
+    const currentPos = latestPosition;
+    const newPos = currentPos + delta;
+    if (newPos < min || newPos > max) return;
+    updatePosition(newPos);
+    popupState = 'active';
+    if (activeSettleTimer) clearTimeout(activeSettleTimer);
+    activeSettleTimer = setTimeout(() => {
+      if (popupState === 'active') {
+        if (!isMouseOverPopup) {
+          const pos = hoverPos;
+          if (pos) {
+            const newPopupPos = calcPopupPosition(pos.x, pos.y);
+            if (newPopupPos) popupPos = newPopupPos;
+          }
+        }
+        popupState = 'showing';
+      }
+    }, ACTIVE_SETTLE_DELAY);
+  }
+
   // Handle collapse/expand
   function handleToggleCollapse() {
     if (!collapsible || disabled || readonly) return;
+
+    const currentPos = latestPosition;
 
     if (collapsed) {
       // Expand: restore to previous or fallback
       const restorePosition = previousPosition ?? expandedPosition ?? defaultPosition ?? 50;
       const clampedRestore = clamp(restorePosition, min, max);
 
-      oncollapsedchange?.(false, position);
+      oncollapsedchange?.(false, currentPos);
       collapsed = false;
+      latestPosition = clampedRestore;
       position = clampedRestore;
 
       const sizeInPx = containerEl
@@ -124,9 +285,10 @@
       onpositionchange?.(clampedRestore, sizeInPx);
     } else {
       // Collapse: save current position, set to 0
-      previousPosition = position;
-      oncollapsedchange?.(true, position);
+      previousPosition = currentPos;
+      oncollapsedchange?.(true, currentPos);
       collapsed = true;
+      latestPosition = 0;
       position = 0;
       onpositionchange?.(0, 0);
     }
@@ -135,6 +297,16 @@
   // Keyboard handler
   function handleKeyDown(event: KeyboardEvent) {
     if (disabled || readonly) return;
+
+    // Tab to popup when visible
+    if (event.key === 'Tab' && !event.shiftKey && popupState !== 'hidden') {
+      const firstBtn = popupEl?.querySelector<HTMLButtonElement>('button');
+      if (firstBtn) {
+        event.preventDefault();
+        firstBtn.focus();
+        return;
+      }
+    }
 
     const hasShift = event.shiftKey;
     const currentStep = hasShift ? largeStep : step;
@@ -157,13 +329,13 @@
 
       case 'ArrowUp':
         if (!isVertical) break;
-        delta = currentStep;
+        delta = -currentStep;
         handled = true;
         break;
 
       case 'ArrowDown':
         if (!isVertical) break;
-        delta = -currentStep;
+        delta = currentStep;
         handled = true;
         break;
 
@@ -186,7 +358,7 @@
     if (handled) {
       event.preventDefault();
       if (delta !== 0) {
-        updatePosition(position + delta);
+        updatePosition(latestPosition + delta);
       }
     }
   }
@@ -198,22 +370,42 @@
     event.preventDefault();
     if (!splitterEl) return;
 
+    pointerStart = { x: event.clientX, y: event.clientY };
+    isDragging = false;
+
     if (typeof splitterEl.setPointerCapture === 'function') {
       splitterEl.setPointerCapture(event.pointerId);
     }
-    isDragging = true;
+
+    if (hoverTimer) {
+      clearTimeout(hoverTimer);
+      hoverTimer = null;
+    }
+
     splitterEl.focus();
   }
 
   function handlePointerMove(event: PointerEvent) {
-    if (!isDragging) return;
+    const start = pointerStart;
+    if (!start) return;
+
+    if (!isDragging) {
+      const dx = event.clientX - start.x;
+      const dy = event.clientY - start.y;
+      const distance = Math.sqrt(dx * dx + dy * dy);
+      if (distance >= TAP_DISTANCE_THRESHOLD) {
+        isDragging = true;
+        if (popupState !== 'hidden') hidePopup();
+      } else {
+        return;
+      }
+    }
 
     if (!containerEl) return;
 
     // Use demo container for stable measurement if available
-    const demoContainer = containerEl.closest(
-      '.apg-window-splitter-demo-container'
-    ) as HTMLElement | null;
+    const demoContainerElement = containerEl.closest('.apg-window-splitter-demo-container');
+    const demoContainer = demoContainerElement instanceof HTMLElement ? demoContainerElement : null;
     const measureElement = demoContainer || containerEl.parentElement || containerEl;
     const rect = measureElement.getBoundingClientRect();
 
@@ -223,7 +415,6 @@
       percent = (x / rect.width) * 100;
     } else {
       const y = event.clientY - rect.top;
-      // For vertical, y position corresponds to primary pane height
       percent = (y / rect.height) * 100;
     }
 
@@ -246,7 +437,97 @@
         // Ignore
       }
     }
+
+    const start = pointerStart;
+    if (start && !isDragging) {
+      // Tap detected - show popup
+      showPopup(start.x, start.y);
+    }
+
     isDragging = false;
+    pointerStart = null;
+  }
+
+  // Hover handlers for separator
+  function handleSeparatorMouseEnter(event: MouseEvent) {
+    if (disabled || readonly || isDragging) return;
+    hoverPos = { x: event.clientX, y: event.clientY };
+    if (popupState === 'hidden') {
+      if (hoverTimer) clearTimeout(hoverTimer);
+      hoverTimer = setTimeout(() => {
+        const pos = hoverPos;
+        if (pos) showPopup(pos.x, pos.y);
+      }, HOVER_DELAY);
+    }
+    if (dismissTimer) {
+      clearTimeout(dismissTimer);
+      dismissTimer = null;
+    }
+  }
+
+  function handleSeparatorMouseLeave() {
+    if (hoverTimer) {
+      clearTimeout(hoverTimer);
+      hoverTimer = null;
+    }
+    if (popupState !== 'hidden') scheduleDismiss();
+  }
+
+  function handleSeparatorMouseMove(event: MouseEvent) {
+    hoverPos = { x: event.clientX, y: event.clientY };
+  }
+
+  // Focus/blur handlers for separator
+  function handleSeparatorFocus() {
+    if (disabled || readonly) return;
+    if (popupState === 'hidden') {
+      if (splitterEl) {
+        const rect = splitterEl.getBoundingClientRect();
+        showPopup(rect.left + rect.width / 2, rect.top + rect.height / 2);
+      }
+    }
+    if (dismissTimer) {
+      clearTimeout(dismissTimer);
+      dismissTimer = null;
+    }
+  }
+
+  function handleSeparatorBlur() {
+    if (popupState !== 'hidden') {
+      setTimeout(() => {
+        if (!popupEl?.contains(document.activeElement) && splitterEl !== document.activeElement) {
+          scheduleDismiss();
+        }
+      }, 0);
+    }
+  }
+
+  // Popup mouse handlers
+  function handlePopupMouseEnter() {
+    isMouseOverPopup = true;
+    if (dismissTimer) {
+      clearTimeout(dismissTimer);
+      dismissTimer = null;
+    }
+  }
+
+  function handlePopupMouseLeave() {
+    isMouseOverPopup = false;
+    if (popupState !== 'hidden') scheduleDismiss();
+  }
+
+  // Popup keydown handler
+  function handlePopupKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      hidePopup();
+      splitterEl?.focus();
+    }
+    if (event.key === 'Tab' && event.shiftKey) {
+      event.preventDefault();
+      hidePopup();
+      splitterEl?.focus();
+    }
   }
 </script>
 
@@ -280,5 +561,116 @@
     onpointerdown={handlePointerDown}
     onpointermove={handlePointerMove}
     onpointerup={handlePointerUp}
+    onmouseenter={handleSeparatorMouseEnter}
+    onmouseleave={handleSeparatorMouseLeave}
+    onmousemove={handleSeparatorMouseMove}
+    onfocus={handleSeparatorFocus}
+    onblur={handleSeparatorBlur}
   ></div>
+  {#if !disabled && !readonly}
+    <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+    <div
+      bind:this={popupEl}
+      role="group"
+      aria-label={`Adjust ${splitterLabel}`}
+      class="apg-window-splitter__popup {popupState !== 'hidden'
+        ? 'apg-window-splitter__popup--visible'
+        : ''}"
+      style={popupPos
+        ? `position: fixed; left: ${popupPos.x}px; top: ${popupPos.y}px; flex-direction: ${isVertical ? 'column' : 'row'}`
+        : undefined}
+      onmouseenter={handlePopupMouseEnter}
+      onmouseleave={handlePopupMouseLeave}
+      onkeydown={handlePopupKeyDown}
+    >
+      <button
+        type="button"
+        class="apg-window-splitter__popup-button"
+        tabindex={-1}
+        aria-label={`Collapse ${splitterLabel}`}
+        aria-disabled={isAtMin}
+        onclick={() => !isAtMin && handlePopupButtonClick(min - latestPosition)}
+      >
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+          style="transform: translate({icons.collapse.dx}px, {icons.collapse.dy}px)"
+          ><path d={icons.collapse.d} /></svg
+        >
+      </button>
+      <button
+        type="button"
+        class="apg-window-splitter__popup-button"
+        tabindex={-1}
+        aria-label={`Shrink ${splitterLabel}`}
+        aria-disabled={isAtMin}
+        onclick={() => !isAtMin && handlePopupButtonClick(-step)}
+      >
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+          style="transform: translate({icons.shrink.dx}px, {icons.shrink.dy}px)"
+          ><path d={icons.shrink.d} /></svg
+        >
+      </button>
+      <button
+        type="button"
+        class="apg-window-splitter__popup-button"
+        tabindex={-1}
+        aria-label={`Expand ${splitterLabel}`}
+        aria-disabled={isAtMax}
+        onclick={() => !isAtMax && handlePopupButtonClick(step)}
+      >
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+          style="transform: translate({icons.expand.dx}px, {icons.expand.dy}px)"
+          ><path d={icons.expand.d} /></svg
+        >
+      </button>
+      <button
+        type="button"
+        class="apg-window-splitter__popup-button"
+        tabindex={-1}
+        aria-label={`Expand ${splitterLabel} to maximum`}
+        aria-disabled={isAtMax}
+        onclick={() => !isAtMax && handlePopupButtonClick(max - latestPosition)}
+      >
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+          style="transform: translate({icons.max.dx}px, {icons.max.dy}px)"
+          ><path d={icons.max.d} /></svg
+        >
+      </button>
+    </div>
+  {/if}
 </div>

--- a/src/patterns/windowsplitter/WindowSplitter.test.svelte.ts
+++ b/src/patterns/windowsplitter/WindowSplitter.test.svelte.ts
@@ -306,7 +306,7 @@ describe('WindowSplitter (Svelte)', () => {
 
   // 🔴 High Priority: Keyboard Interaction - Vertical
   describe('Keyboard Interaction - Vertical', () => {
-    it('increases value by step on ArrowUp', async () => {
+    it('moves separator up on ArrowUp', async () => {
       const user = userEvent.setup();
       render(WindowSplitter, {
         props: {
@@ -322,10 +322,10 @@ describe('WindowSplitter (Svelte)', () => {
       await user.click(separator);
       await user.keyboard('{ArrowUp}');
 
-      expect(separator).toHaveAttribute('aria-valuenow', '55');
+      expect(separator).toHaveAttribute('aria-valuenow', '45');
     });
 
-    it('decreases value by step on ArrowDown', async () => {
+    it('moves separator down on ArrowDown', async () => {
       const user = userEvent.setup();
       render(WindowSplitter, {
         props: {
@@ -341,7 +341,7 @@ describe('WindowSplitter (Svelte)', () => {
       await user.click(separator);
       await user.keyboard('{ArrowDown}');
 
-      expect(separator).toHaveAttribute('aria-valuenow', '45');
+      expect(separator).toHaveAttribute('aria-valuenow', '55');
     });
 
     it('ignores ArrowLeft on vertical splitter', async () => {

--- a/src/patterns/windowsplitter/WindowSplitter.test.tsx
+++ b/src/patterns/windowsplitter/WindowSplitter.test.tsx
@@ -246,7 +246,7 @@ describe('WindowSplitter', () => {
 
   // 🔴 High Priority: Keyboard Interaction - Vertical Splitter
   describe('Keyboard Interaction - Vertical Splitter', () => {
-    it('increases value by step on ArrowUp', async () => {
+    it('moves separator up on ArrowUp', async () => {
       const user = userEvent.setup();
       render(
         <WindowSplitter
@@ -262,10 +262,10 @@ describe('WindowSplitter', () => {
       await user.click(splitter);
       await user.keyboard('{ArrowUp}');
 
-      expect(splitter).toHaveAttribute('aria-valuenow', '55');
+      expect(splitter).toHaveAttribute('aria-valuenow', '45');
     });
 
-    it('decreases value by step on ArrowDown', async () => {
+    it('moves separator down on ArrowDown', async () => {
       const user = userEvent.setup();
       render(
         <WindowSplitter
@@ -281,7 +281,7 @@ describe('WindowSplitter', () => {
       await user.click(splitter);
       await user.keyboard('{ArrowDown}');
 
-      expect(splitter).toHaveAttribute('aria-valuenow', '45');
+      expect(splitter).toHaveAttribute('aria-valuenow', '55');
     });
 
     it('ArrowLeft does nothing on vertical splitter', async () => {
@@ -320,7 +320,7 @@ describe('WindowSplitter', () => {
       expect(splitter).toHaveAttribute('aria-valuenow', '50');
     });
 
-    it('increases value by largeStep on Shift+ArrowUp', async () => {
+    it('moves separator up by largeStep on Shift+ArrowUp', async () => {
       const user = userEvent.setup();
       render(
         <WindowSplitter
@@ -337,7 +337,7 @@ describe('WindowSplitter', () => {
       await user.click(splitter);
       await user.keyboard('{Shift>}{ArrowUp}{/Shift}');
 
-      expect(splitter).toHaveAttribute('aria-valuenow', '60');
+      expect(splitter).toHaveAttribute('aria-valuenow', '40');
     });
   });
 

--- a/src/patterns/windowsplitter/WindowSplitter.test.vue.ts
+++ b/src/patterns/windowsplitter/WindowSplitter.test.vue.ts
@@ -318,7 +318,7 @@ describe('WindowSplitter (Vue)', () => {
 
   // 🔴 High Priority: Keyboard Interaction - Vertical
   describe('Keyboard Interaction - Vertical', () => {
-    it('increases value by step on ArrowUp', async () => {
+    it('moves separator up on ArrowUp', async () => {
       const user = userEvent.setup();
       render(WindowSplitter, {
         props: {
@@ -334,10 +334,10 @@ describe('WindowSplitter (Vue)', () => {
       await user.click(separator);
       await user.keyboard('{ArrowUp}');
 
-      expect(separator).toHaveAttribute('aria-valuenow', '55');
+      expect(separator).toHaveAttribute('aria-valuenow', '45');
     });
 
-    it('decreases value by step on ArrowDown', async () => {
+    it('moves separator down on ArrowDown', async () => {
       const user = userEvent.setup();
       render(WindowSplitter, {
         props: {
@@ -353,7 +353,7 @@ describe('WindowSplitter (Vue)', () => {
       await user.click(separator);
       await user.keyboard('{ArrowDown}');
 
-      expect(separator).toHaveAttribute('aria-valuenow', '45');
+      expect(separator).toHaveAttribute('aria-valuenow', '55');
     });
 
     it('ignores ArrowLeft on vertical splitter', async () => {

--- a/src/patterns/windowsplitter/WindowSplitter.tsx
+++ b/src/patterns/windowsplitter/WindowSplitter.tsx
@@ -39,6 +39,23 @@ const clamp = (value: number, min: number, max: number): number => {
   return Math.min(max, Math.max(min, value));
 };
 
+const ChevronIcon = ({ d, dx = 0, dy = 0 }: { d: string; dx?: number; dy?: number }) => (
+  <svg
+    width="12"
+    height="12"
+    viewBox="0 0 12 12"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    style={dx || dy ? { transform: `translate(${dx}px, ${dy}px)` } : undefined}
+  >
+    <path d={d} />
+  </svg>
+);
+
 const HOVER_DELAY = 300;
 const DISMISS_DELAY = 300;
 const ACTIVE_SETTLE_DELAY = 500;
@@ -101,23 +118,6 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
 
   const splitterLabel = ariaLabel || '';
 
-  const ChevronIcon = ({ d, dx = 0, dy = 0 }: { d: string; dx?: number; dy?: number }) => (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 12 12"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-      style={dx || dy ? { transform: `translate(${dx}px, ${dy}px)` } : undefined}
-    >
-      <path d={d} />
-    </svg>
-  );
-
   const icons = isVertical
     ? {
         collapse: { d: 'M2 9L6 5L10 9M2 5L6 1L10 5', dx: 0, dy: -1 },
@@ -147,9 +147,7 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
 
   const calcPopupPosition = useCallback(
     (clientX: number, clientY: number) => {
-      const splitter = splitterRef.current;
-      if (!splitter) return null;
-      const rect = splitter.getBoundingClientRect();
+      if (!splitterRef.current) return null;
       const popupEl = popupRef.current;
       const popupWidth = popupEl?.offsetWidth || (isVertical ? 34 : 120);
       const popupHeight = popupEl?.offsetHeight || (isVertical ? 120 : 34);
@@ -176,7 +174,7 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
 
       return { x, y };
     },
-    [isHorizontal]
+    [isHorizontal, isVertical]
   );
 
   const showPopup = useCallback(
@@ -205,7 +203,7 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
     if (popupState !== 'active') return;
     const handleOutsidePointerDown = (e: PointerEvent) => {
       const popup = popupRef.current;
-      if (popup && !popup.contains(e.target as Node)) {
+      if (popup && e.target instanceof Node && !popup.contains(e.target)) {
         hidePopup();
       }
     };
@@ -613,6 +611,7 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
         onBlur={handleSeparatorBlur}
       />
       {!disabled && !readonly && (
+        /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */
         <div
           ref={popupRef}
           role="group"

--- a/src/patterns/windowsplitter/WindowSplitter.tsx
+++ b/src/patterns/windowsplitter/WindowSplitter.tsx
@@ -1,82 +1,51 @@
 import { clsx } from 'clsx';
 import type { CSSProperties } from 'react';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
-// CSS custom properties type for splitter position
 interface SplitterStyle extends CSSProperties {
   '--splitter-position': string;
 }
 
-// Label: one of these required (exclusive)
 type LabelProps =
   | { 'aria-label': string; 'aria-labelledby'?: never }
   | { 'aria-label'?: never; 'aria-labelledby': string };
 
 type WindowSplitterBaseProps = {
-  /** Primary pane ID (required for aria-controls) */
   primaryPaneId: string;
-
-  /** Secondary pane ID (optional, added to aria-controls) */
   secondaryPaneId?: string;
-
-  /** Initial position as % (0-100, default: 50) */
   defaultPosition?: number;
-
-  /** Initial collapsed state (default: false) */
   defaultCollapsed?: boolean;
-
-  /** Position when expanding from initial collapse */
   expandedPosition?: number;
-
-  /** Minimum position as % (default: 10) */
   min?: number;
-
-  /** Maximum position as % (default: 90) */
   max?: number;
-
-  /** Keyboard step as % (default: 5) */
   step?: number;
-
-  /** Shift+Arrow step as % (default: 10) */
   largeStep?: number;
-
-  /** Splitter orientation (default: horizontal = left-right split) */
   orientation?: 'horizontal' | 'vertical';
-
-  /** Text direction for RTL support */
   dir?: 'ltr' | 'rtl';
-
-  /** Whether pane can be collapsed (default: true) */
   collapsible?: boolean;
-
-  /** Disabled state (not focusable, not operable) */
   disabled?: boolean;
-
-  /** Readonly state (focusable but not operable) */
   readonly?: boolean;
-
-  /** Callback when position changes */
   onPositionChange?: (position: number, sizeInPx: number) => void;
-
-  /** Callback when collapsed state changes */
   onCollapsedChange?: (collapsed: boolean, previousPosition: number) => void;
-
-  /** Reference to help text */
   'aria-describedby'?: string;
-
-  /** Test id for testing */
   'data-testid'?: string;
-
   className?: string;
   id?: string;
 };
 
 export type WindowSplitterProps = WindowSplitterBaseProps & LabelProps;
 
-// Clamp value to min/max range
 const clamp = (value: number, min: number, max: number): number => {
   return Math.min(max, Math.max(min, value));
 };
+
+const HOVER_DELAY = 300;
+const DISMISS_DELAY = 300;
+const ACTIVE_SETTLE_DELAY = 500;
+const TAP_DISTANCE_THRESHOLD = 5;
+const POPUP_OFFSET = 8;
+
+type PopupState = 'hidden' | 'showing' | 'active';
 
 export const WindowSplitter: React.FC<WindowSplitterProps> = ({
   primaryPaneId,
@@ -102,68 +71,227 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
   className,
   id,
 }) => {
-  // Calculate initial position: clamp to valid range, or 0 if collapsed
   const initialPosition = defaultCollapsed ? 0 : clamp(defaultPosition, min, max);
 
   const [position, setPosition] = useState(initialPosition);
   const [collapsed, setCollapsed] = useState(defaultCollapsed);
+  const [popupState, setPopupState] = useState<PopupState>('hidden');
+  const [popupPos, setPopupPos] = useState<{ x: number; y: number } | null>(null);
 
   const splitterRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const popupRef = useRef<HTMLDivElement>(null);
   const previousPositionRef = useRef<number | null>(defaultCollapsed ? null : initialPosition);
+  const positionRef = useRef(initialPosition);
+
+  const isDraggingRef = useRef(false);
+  const isMouseOverPopupRef = useRef(false);
+  const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const activeSettleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pointerStartRef = useRef<{ x: number; y: number } | null>(null);
+  const hoverPosRef = useRef<{ x: number; y: number } | null>(null);
 
   const isHorizontal = orientation === 'horizontal';
   const isVertical = orientation === 'vertical';
 
-  // Determine RTL mode
   const isRTL =
     dir === 'rtl' ||
     (dir === undefined && typeof document !== 'undefined' && document.dir === 'rtl');
 
-  // Update position and call callback
+  const splitterLabel = ariaLabel || '';
+
+  const ChevronIcon = ({ d, dx = 0, dy = 0 }: { d: string; dx?: number; dy?: number }) => (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      style={dx || dy ? { transform: `translate(${dx}px, ${dy}px)` } : undefined}
+    >
+      <path d={d} />
+    </svg>
+  );
+
+  const icons = isVertical
+    ? {
+        collapse: { d: 'M2 9L6 5L10 9M2 5L6 1L10 5', dx: 0, dy: -1 },
+        shrink: { d: 'M2 8L6 4L10 8', dx: 0, dy: -1 },
+        expand: { d: 'M2 4L6 8L10 4', dx: 0, dy: 1 },
+        max: { d: 'M2 3L6 7L10 3M2 7L6 11L10 7', dx: 0, dy: 1 },
+      }
+    : {
+        collapse: { d: 'M5 2L1 6L5 10M9 2L5 6L9 10', dx: -1, dy: 0 },
+        shrink: { d: 'M8 2L4 6L8 10', dx: -1, dy: 0 },
+        expand: { d: 'M4 2L8 6L4 10', dx: 1, dy: 0 },
+        max: { d: 'M3 2L7 6L3 10M7 2L11 6L7 10', dx: 1, dy: 0 },
+      };
+
+  const clearAllTimers = useCallback(() => {
+    if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
+    if (dismissTimerRef.current) clearTimeout(dismissTimerRef.current);
+    if (activeSettleTimerRef.current) clearTimeout(activeSettleTimerRef.current);
+    hoverTimerRef.current = null;
+    dismissTimerRef.current = null;
+    activeSettleTimerRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    return () => clearAllTimers();
+  }, [clearAllTimers]);
+
+  const calcPopupPosition = useCallback(
+    (clientX: number, clientY: number) => {
+      const splitter = splitterRef.current;
+      if (!splitter) return null;
+      const rect = splitter.getBoundingClientRect();
+      const popupEl = popupRef.current;
+      const popupWidth = popupEl?.offsetWidth || (isVertical ? 34 : 120);
+      const popupHeight = popupEl?.offsetHeight || (isVertical ? 120 : 34);
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+
+      let x: number;
+      let y: number;
+
+      if (isHorizontal) {
+        x = clientX - popupWidth / 2;
+        const belowY = clientY + POPUP_OFFSET;
+        const aboveY = clientY - POPUP_OFFSET - popupHeight;
+        y = belowY + popupHeight <= vh ? belowY : aboveY;
+      } else {
+        y = clientY - popupHeight / 2;
+        const rightX = clientX + POPUP_OFFSET;
+        const leftX = clientX - POPUP_OFFSET - popupWidth;
+        x = rightX + popupWidth <= vw ? rightX : leftX;
+      }
+
+      x = clamp(x, 0, vw - popupWidth);
+      y = clamp(y, 0, vh - popupHeight);
+
+      return { x, y };
+    },
+    [isHorizontal]
+  );
+
+  const showPopup = useCallback(
+    (clientX: number, clientY: number) => {
+      if (disabled || readonly) return;
+      if (dismissTimerRef.current) {
+        clearTimeout(dismissTimerRef.current);
+        dismissTimerRef.current = null;
+      }
+      const pos = calcPopupPosition(clientX, clientY);
+      if (pos) {
+        setPopupPos(pos);
+        setPopupState('showing');
+      }
+    },
+    [disabled, readonly, calcPopupPosition]
+  );
+
+  const hidePopup = useCallback(() => {
+    clearAllTimers();
+    setPopupState('hidden');
+    setPopupPos(null);
+  }, [clearAllTimers]);
+
+  useEffect(() => {
+    if (popupState !== 'active') return;
+    const handleOutsidePointerDown = (e: PointerEvent) => {
+      const popup = popupRef.current;
+      if (popup && !popup.contains(e.target as Node)) {
+        hidePopup();
+      }
+    };
+    document.addEventListener('pointerdown', handleOutsidePointerDown);
+    return () => document.removeEventListener('pointerdown', handleOutsidePointerDown);
+  }, [popupState, hidePopup]);
+
+  const scheduleDismiss = useCallback(() => {
+    if (dismissTimerRef.current) clearTimeout(dismissTimerRef.current);
+    dismissTimerRef.current = setTimeout(() => {
+      const splitter = splitterRef.current;
+      const popup = popupRef.current;
+      const hasFocusInside =
+        popup?.contains(document.activeElement) || splitter === document.activeElement;
+      if (!hasFocusInside) {
+        hidePopup();
+      }
+    }, DISMISS_DELAY);
+  }, [hidePopup]);
+
   const updatePosition = useCallback(
     (newPosition: number) => {
       const clampedPosition = clamp(newPosition, min, max);
-      if (clampedPosition !== position) {
+      if (clampedPosition !== positionRef.current) {
+        positionRef.current = clampedPosition;
         setPosition(clampedPosition);
-
-        // Calculate size in px (approximation, actual calculation needs container)
         const container = containerRef.current;
         const sizeInPx = container
           ? (clampedPosition / 100) *
             (isHorizontal ? container.offsetWidth : container.offsetHeight)
           : 0;
-
         onPositionChange?.(clampedPosition, sizeInPx);
       }
     },
-    [position, min, max, isHorizontal, onPositionChange]
+    [min, max, isHorizontal, onPositionChange]
   );
 
-  // Handle collapse/expand
+  const handlePopupButtonClick = useCallback(
+    (delta: number) => {
+      if (disabled || readonly) return;
+      const currentPos = positionRef.current;
+      const newPos = currentPos + delta;
+      if (newPos < min || newPos > max) return;
+      updatePosition(newPos);
+      setPopupState('active');
+      if (activeSettleTimerRef.current) clearTimeout(activeSettleTimerRef.current);
+      activeSettleTimerRef.current = setTimeout(() => {
+        setPopupState((prev) => {
+          if (prev === 'active') {
+            if (!isMouseOverPopupRef.current) {
+              const pos = hoverPosRef.current;
+              if (pos) {
+                const newPopupPos = calcPopupPosition(pos.x, pos.y);
+                if (newPopupPos) setPopupPos(newPopupPos);
+              }
+            }
+            return 'showing';
+          }
+          return prev;
+        });
+      }, ACTIVE_SETTLE_DELAY);
+    },
+    [disabled, readonly, min, max, updatePosition, calcPopupPosition]
+  );
+
   const handleToggleCollapse = useCallback(() => {
     if (!collapsible || disabled || readonly) return;
-
+    const currentPos = positionRef.current;
     if (collapsed) {
-      // Expand: restore to previous or fallback
       const restorePosition =
         previousPositionRef.current ?? expandedPosition ?? defaultPosition ?? 50;
       const clampedRestore = clamp(restorePosition, min, max);
-
-      onCollapsedChange?.(false, position);
+      onCollapsedChange?.(false, currentPos);
       setCollapsed(false);
+      positionRef.current = clampedRestore;
       setPosition(clampedRestore);
-
       const container = containerRef.current;
       const sizeInPx = container
         ? (clampedRestore / 100) * (isHorizontal ? container.offsetWidth : container.offsetHeight)
         : 0;
       onPositionChange?.(clampedRestore, sizeInPx);
     } else {
-      // Collapse: save current position, set to 0
-      previousPositionRef.current = position;
-      onCollapsedChange?.(true, position);
+      previousPositionRef.current = currentPos;
+      onCollapsedChange?.(true, currentPos);
       setCollapsed(true);
+      positionRef.current = 0;
       setPosition(0);
       onPositionChange?.(0, 0);
     }
@@ -172,7 +300,6 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
     collapsible,
     disabled,
     readonly,
-    position,
     expandedPosition,
     defaultPosition,
     min,
@@ -182,10 +309,18 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
     onPositionChange,
   ]);
 
-  // Keyboard handler
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
       if (disabled || readonly) return;
+
+      if (event.key === 'Tab' && !event.shiftKey && popupState !== 'hidden') {
+        const firstBtn = popupRef.current?.querySelector<HTMLButtonElement>('button');
+        if (firstBtn) {
+          event.preventDefault();
+          firstBtn.focus();
+          return;
+        }
+      }
 
       const hasShift = event.shiftKey;
       const currentStep = hasShift ? largeStep : step;
@@ -194,7 +329,6 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
       let handled = false;
 
       switch (event.key) {
-        // Horizontal splitter: ArrowLeft/Right only
         case 'ArrowRight':
           if (!isHorizontal) break;
           delta = isRTL ? -currentStep : currentStep;
@@ -207,26 +341,23 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
           handled = true;
           break;
 
-        // Vertical splitter: ArrowUp/Down only
         case 'ArrowUp':
-          if (!isVertical) break;
-          delta = currentStep;
-          handled = true;
-          break;
-
-        case 'ArrowDown':
           if (!isVertical) break;
           delta = -currentStep;
           handled = true;
           break;
 
-        // Collapse/Expand
+        case 'ArrowDown':
+          if (!isVertical) break;
+          delta = currentStep;
+          handled = true;
+          break;
+
         case 'Enter':
           handleToggleCollapse();
           handled = true;
           break;
 
-        // Home/End
         case 'Home':
           updatePosition(min);
           handled = true;
@@ -241,19 +372,19 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
       if (handled) {
         event.preventDefault();
         if (delta !== 0) {
-          updatePosition(position + delta);
+          updatePosition(positionRef.current + delta);
         }
       }
     },
     [
       disabled,
       readonly,
+      popupState,
       isHorizontal,
       isVertical,
       isRTL,
       step,
       largeStep,
-      position,
       min,
       max,
       handleToggleCollapse,
@@ -261,21 +392,25 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
     ]
   );
 
-  // Pointer handlers
-  const isDraggingRef = useRef(false);
-
   const handlePointerDown = useCallback(
     (event: React.PointerEvent) => {
       if (disabled || readonly) return;
-
       event.preventDefault();
       const splitter = splitterRef.current;
       if (!splitter) return;
 
+      pointerStartRef.current = { x: event.clientX, y: event.clientY };
+      isDraggingRef.current = false;
+
       if (typeof splitter.setPointerCapture === 'function') {
         splitter.setPointerCapture(event.pointerId);
       }
-      isDraggingRef.current = true;
+
+      if (hoverTimerRef.current) {
+        clearTimeout(hoverTimerRef.current);
+        hoverTimerRef.current = null;
+      }
+
       splitter.focus();
     },
     [disabled, readonly]
@@ -283,12 +418,24 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
 
   const handlePointerMove = useCallback(
     (event: React.PointerEvent) => {
-      if (!isDraggingRef.current) return;
+      const start = pointerStartRef.current;
+      if (!start) return;
+
+      if (!isDraggingRef.current) {
+        const dx = event.clientX - start.x;
+        const dy = event.clientY - start.y;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+        if (distance >= TAP_DISTANCE_THRESHOLD) {
+          isDraggingRef.current = true;
+          if (popupState !== 'hidden') hidePopup();
+        } else {
+          return;
+        }
+      }
 
       const container = containerRef.current;
       if (!container) return;
 
-      // Use demo container for stable measurement if available
       const demoContainerElement = container.closest('.apg-window-splitter-demo-container');
       const demoContainer =
         demoContainerElement instanceof HTMLElement ? demoContainerElement : null;
@@ -301,37 +448,131 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
         percent = (x / rect.width) * 100;
       } else {
         const y = event.clientY - rect.top;
-        // For vertical, y position corresponds to primary pane height
         percent = (y / rect.height) * 100;
       }
 
-      // Clamp the percent to min/max
       const clampedPercent = clamp(percent, min, max);
-
-      // Update CSS variable directly for smooth dragging
       if (demoContainer) {
         demoContainer.style.setProperty('--splitter-position', `${clampedPercent}%`);
       }
-
       updatePosition(percent);
     },
-    [isHorizontal, min, max, updatePosition]
+    [isHorizontal, min, max, updatePosition, popupState, hidePopup]
   );
 
-  const handlePointerUp = useCallback((event: React.PointerEvent) => {
-    const splitter = splitterRef.current;
-    if (splitter && typeof splitter.releasePointerCapture === 'function') {
-      try {
-        splitter.releasePointerCapture(event.pointerId);
-      } catch {
-        // Ignore if pointer capture was not set
+  const handlePointerUp = useCallback(
+    (event: React.PointerEvent) => {
+      const splitter = splitterRef.current;
+      if (splitter && typeof splitter.releasePointerCapture === 'function') {
+        try {
+          splitter.releasePointerCapture(event.pointerId);
+        } catch {
+          // Ignore
+        }
       }
+
+      const start = pointerStartRef.current;
+      if (start && !isDraggingRef.current) {
+        showPopup(start.x, start.y);
+      }
+
+      isDraggingRef.current = false;
+      pointerStartRef.current = null;
+    },
+    [showPopup]
+  );
+
+  const handleSeparatorMouseEnter = useCallback(
+    (event: React.MouseEvent) => {
+      if (disabled || readonly || isDraggingRef.current) return;
+      hoverPosRef.current = { x: event.clientX, y: event.clientY };
+      if (popupState === 'hidden') {
+        if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
+        hoverTimerRef.current = setTimeout(() => {
+          const pos = hoverPosRef.current;
+          if (pos) showPopup(pos.x, pos.y);
+        }, HOVER_DELAY);
+      }
+      if (dismissTimerRef.current) {
+        clearTimeout(dismissTimerRef.current);
+        dismissTimerRef.current = null;
+      }
+    },
+    [disabled, readonly, popupState, showPopup]
+  );
+
+  const handleSeparatorMouseLeave = useCallback(() => {
+    if (hoverTimerRef.current) {
+      clearTimeout(hoverTimerRef.current);
+      hoverTimerRef.current = null;
     }
-    isDraggingRef.current = false;
+    if (popupState !== 'hidden') scheduleDismiss();
+  }, [popupState, scheduleDismiss]);
+
+  const handleSeparatorMouseMove = useCallback((event: React.MouseEvent) => {
+    hoverPosRef.current = { x: event.clientX, y: event.clientY };
   }, []);
 
-  // Compute aria-controls
+  const handleSeparatorFocus = useCallback(() => {
+    if (disabled || readonly) return;
+    if (popupState === 'hidden') {
+      const splitter = splitterRef.current;
+      if (splitter) {
+        const rect = splitter.getBoundingClientRect();
+        showPopup(rect.left + rect.width / 2, rect.top + rect.height / 2);
+      }
+    }
+    if (dismissTimerRef.current) {
+      clearTimeout(dismissTimerRef.current);
+      dismissTimerRef.current = null;
+    }
+  }, [disabled, readonly, popupState, showPopup]);
+
+  const handleSeparatorBlur = useCallback(() => {
+    if (popupState !== 'hidden') {
+      setTimeout(() => {
+        const popup = popupRef.current;
+        const splitter = splitterRef.current;
+        if (!popup?.contains(document.activeElement) && splitter !== document.activeElement) {
+          scheduleDismiss();
+        }
+      }, 0);
+    }
+  }, [popupState, scheduleDismiss]);
+
+  const handlePopupMouseEnter = useCallback(() => {
+    isMouseOverPopupRef.current = true;
+    if (dismissTimerRef.current) {
+      clearTimeout(dismissTimerRef.current);
+      dismissTimerRef.current = null;
+    }
+  }, []);
+
+  const handlePopupMouseLeave = useCallback(() => {
+    isMouseOverPopupRef.current = false;
+    if (popupState !== 'hidden') scheduleDismiss();
+  }, [popupState, scheduleDismiss]);
+
+  const handlePopupKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        hidePopup();
+        splitterRef.current?.focus();
+      }
+      if (event.key === 'Tab' && event.shiftKey) {
+        event.preventDefault();
+        hidePopup();
+        splitterRef.current?.focus();
+      }
+    },
+    [hidePopup]
+  );
+
   const ariaControls = secondaryPaneId ? `${primaryPaneId} ${secondaryPaneId}` : primaryPaneId;
+
+  const isAtMin = position <= min;
+  const isAtMax = position >= max;
 
   return (
     <div
@@ -344,7 +585,6 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
       )}
       style={{ '--splitter-position': `${position}%` } satisfies SplitterStyle}
     >
-      {/* role=separator as a interactive element when is focusable */}
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
       <div
         ref={splitterRef}
@@ -366,7 +606,76 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
+        onMouseEnter={handleSeparatorMouseEnter}
+        onMouseLeave={handleSeparatorMouseLeave}
+        onMouseMove={handleSeparatorMouseMove}
+        onFocus={handleSeparatorFocus}
+        onBlur={handleSeparatorBlur}
       />
+      {!disabled && !readonly && (
+        <div
+          ref={popupRef}
+          role="group"
+          aria-label={`Adjust ${splitterLabel}`}
+          className={clsx(
+            'apg-window-splitter__popup',
+            popupState !== 'hidden' && 'apg-window-splitter__popup--visible'
+          )}
+          style={
+            popupPos
+              ? {
+                  left: popupPos.x,
+                  top: popupPos.y,
+                  flexDirection: isVertical ? ('column' as const) : ('row' as const),
+                }
+              : undefined
+          }
+          onMouseEnter={handlePopupMouseEnter}
+          onMouseLeave={handlePopupMouseLeave}
+          onKeyDown={handlePopupKeyDown}
+        >
+          <button
+            type="button"
+            className="apg-window-splitter__popup-button"
+            tabIndex={-1}
+            aria-label={`Collapse ${splitterLabel}`}
+            aria-disabled={isAtMin}
+            onClick={() => !isAtMin && handlePopupButtonClick(min - positionRef.current)}
+          >
+            <ChevronIcon {...icons.collapse} />
+          </button>
+          <button
+            type="button"
+            className="apg-window-splitter__popup-button"
+            tabIndex={-1}
+            aria-label={`Shrink ${splitterLabel}`}
+            aria-disabled={isAtMin}
+            onClick={() => !isAtMin && handlePopupButtonClick(-step)}
+          >
+            <ChevronIcon {...icons.shrink} />
+          </button>
+          <button
+            type="button"
+            className="apg-window-splitter__popup-button"
+            tabIndex={-1}
+            aria-label={`Expand ${splitterLabel}`}
+            aria-disabled={isAtMax}
+            onClick={() => !isAtMax && handlePopupButtonClick(step)}
+          >
+            <ChevronIcon {...icons.expand} />
+          </button>
+          <button
+            type="button"
+            className="apg-window-splitter__popup-button"
+            tabIndex={-1}
+            aria-label={`Expand ${splitterLabel} to maximum`}
+            aria-disabled={isAtMax}
+            onClick={() => !isAtMax && handlePopupButtonClick(max - positionRef.current)}
+          >
+            <ChevronIcon {...icons.max} />
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/patterns/windowsplitter/WindowSplitter.vue
+++ b/src/patterns/windowsplitter/WindowSplitter.vue
@@ -29,12 +29,132 @@
       @pointerdown="handlePointerDown"
       @pointermove="handlePointerMove"
       @pointerup="handlePointerUp"
+      @mouseenter="handleSeparatorMouseEnter"
+      @mouseleave="handleSeparatorMouseLeave"
+      @mousemove="handleSeparatorMouseMove"
+      @focus="handleSeparatorFocus"
+      @blur="handleSeparatorBlur"
     />
+    <div
+      v-if="!disabled && !readonly"
+      ref="popupRef"
+      role="group"
+      :aria-label="`Adjust ${splitterLabel}`"
+      :class="[
+        'apg-window-splitter__popup',
+        popupState !== 'hidden' && 'apg-window-splitter__popup--visible',
+      ]"
+      :style="
+        popupPos
+          ? {
+              left: `${popupPos.x}px`,
+              top: `${popupPos.y}px`,
+              flexDirection: isVertical ? 'column' : 'row',
+            }
+          : undefined
+      "
+      @mouseenter="handlePopupMouseEnter"
+      @mouseleave="handlePopupMouseLeave"
+      @keydown="handlePopupKeyDown"
+    >
+      <button
+        type="button"
+        class="apg-window-splitter__popup-button"
+        :tabindex="-1"
+        :aria-label="`Collapse ${splitterLabel}`"
+        :aria-disabled="isAtMin"
+        @click="!isAtMin && handlePopupButtonClick(props.min - positionLocal)"
+      >
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+          :style="{ transform: `translate(${icons.collapse.dx}px, ${icons.collapse.dy}px)` }"
+        >
+          <path :d="icons.collapse.d" />
+        </svg>
+      </button>
+      <button
+        type="button"
+        class="apg-window-splitter__popup-button"
+        :tabindex="-1"
+        :aria-label="`Shrink ${splitterLabel}`"
+        :aria-disabled="isAtMin"
+        @click="!isAtMin && handlePopupButtonClick(-step)"
+      >
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+          :style="{ transform: `translate(${icons.shrink.dx}px, ${icons.shrink.dy}px)` }"
+        >
+          <path :d="icons.shrink.d" />
+        </svg>
+      </button>
+      <button
+        type="button"
+        class="apg-window-splitter__popup-button"
+        :tabindex="-1"
+        :aria-label="`Expand ${splitterLabel}`"
+        :aria-disabled="isAtMax"
+        @click="!isAtMax && handlePopupButtonClick(step)"
+      >
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+          :style="{ transform: `translate(${icons.expand.dx}px, ${icons.expand.dy}px)` }"
+        >
+          <path :d="icons.expand.d" />
+        </svg>
+      </button>
+      <button
+        type="button"
+        class="apg-window-splitter__popup-button"
+        :tabindex="-1"
+        :aria-label="`Expand ${splitterLabel} to maximum`"
+        :aria-disabled="isAtMax"
+        @click="!isAtMax && handlePopupButtonClick(props.max - positionLocal)"
+      >
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+          :style="{ transform: `translate(${icons.max.dx}px, ${icons.max.dy}px)` }"
+        >
+          <path :d="icons.max.d" />
+        </svg>
+      </button>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, getCurrentInstance, onUnmounted, ref, watch } from 'vue';
 
 defineOptions({
   inheritAttrs: false,
@@ -92,6 +212,15 @@ const emit = defineEmits<{
   collapsedChange: [collapsed: boolean, previousPosition: number];
 }>();
 
+const instance = getCurrentInstance();
+
+// Constants
+const HOVER_DELAY = 300;
+const DISMISS_DELAY = 300;
+const ACTIVE_SETTLE_DELAY = 500;
+const TAP_DISTANCE_THRESHOLD = 5;
+const POPUP_OFFSET = 8;
+
 // Utility function
 const clamp = (value: number, minVal: number, maxVal: number): number => {
   return Math.min(maxVal, Math.max(minVal, value));
@@ -100,7 +229,7 @@ const clamp = (value: number, minVal: number, maxVal: number): number => {
 // Refs
 const splitterRef = ref<HTMLDivElement | null>(null);
 const containerRef = ref<HTMLDivElement | null>(null);
-const isDragging = ref(false);
+const popupRef = ref<HTMLDivElement | null>(null);
 const previousPosition = ref<number | null>(
   props.defaultCollapsed ? null : clamp(props.defaultPosition, props.min, props.max)
 );
@@ -111,6 +240,18 @@ const initialPosition = props.defaultCollapsed
   : clamp(props.defaultPosition, props.min, props.max);
 const position = ref(initialPosition);
 const collapsed = ref(props.defaultCollapsed);
+const popupState = ref<'hidden' | 'showing' | 'active'>('hidden');
+const popupPos = ref<{ x: number; y: number } | null>(null);
+
+// Non-reactive variables for immediate tracking (avoid reactivity overhead)
+let positionLocal = initialPosition;
+let isDragging = false;
+let isMouseOverPopup = false;
+let hoverTimer: ReturnType<typeof setTimeout> | null = null;
+let dismissTimer: ReturnType<typeof setTimeout> | null = null;
+let activeSettleTimer: ReturnType<typeof setTimeout> | null = null;
+let pointerStart: { x: number; y: number } | null = null;
+let hoverPos: { x: number; y: number } | null = null;
 
 // Computed
 const isVertical = computed(() => props.orientation === 'vertical');
@@ -132,10 +273,124 @@ const ariaControls = computed(() => {
   return props.primaryPaneId;
 });
 
+const splitterLabel = computed(() => {
+  return (instance?.attrs['aria-label'] as string) || '';
+});
+
+const isAtMin = computed(() => position.value <= props.min);
+const isAtMax = computed(() => position.value >= props.max);
+
+const icons = computed(() =>
+  isVertical.value
+    ? {
+        collapse: { d: 'M2 9L6 5L10 9M2 5L6 1L10 5', dx: 0, dy: -1 },
+        shrink: { d: 'M2 8L6 4L10 8', dx: 0, dy: -1 },
+        expand: { d: 'M2 4L6 8L10 4', dx: 0, dy: 1 },
+        max: { d: 'M2 3L6 7L10 3M2 7L6 11L10 7', dx: 0, dy: 1 },
+      }
+    : {
+        collapse: { d: 'M5 2L1 6L5 10M9 2L5 6L9 10', dx: -1, dy: 0 },
+        shrink: { d: 'M8 2L4 6L8 10', dx: -1, dy: 0 },
+        expand: { d: 'M4 2L8 6L4 10', dx: 1, dy: 0 },
+        max: { d: 'M3 2L7 6L3 10M7 2L11 6L7 10', dx: 1, dy: 0 },
+      }
+);
+
+// Timer management
+const clearAllTimers = () => {
+  if (hoverTimer) clearTimeout(hoverTimer);
+  if (dismissTimer) clearTimeout(dismissTimer);
+  if (activeSettleTimer) clearTimeout(activeSettleTimer);
+  hoverTimer = null;
+  dismissTimer = null;
+  activeSettleTimer = null;
+};
+
+onUnmounted(() => {
+  clearAllTimers();
+});
+
+watch(popupState, (state, _, onCleanup) => {
+  if (state !== 'active') return;
+  const handleOutsidePointerDown = (e: PointerEvent) => {
+    if (popupRef.value && !popupRef.value.contains(e.target as Node)) {
+      hidePopup();
+    }
+  };
+  document.addEventListener('pointerdown', handleOutsidePointerDown);
+  onCleanup(() => document.removeEventListener('pointerdown', handleOutsidePointerDown));
+});
+
+// Popup position calculation
+const calcPopupPosition = (clientX: number, clientY: number) => {
+  const splitter = splitterRef.value;
+  if (!splitter) return null;
+  const rect = splitter.getBoundingClientRect();
+  const popupEl = popupRef.value;
+  const popupWidth = popupEl?.offsetWidth || (isVertical.value ? 34 : 120);
+  const popupHeight = popupEl?.offsetHeight || (isVertical.value ? 120 : 34);
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+
+  let x: number;
+  let y: number;
+
+  if (isHorizontal.value) {
+    x = clientX - popupWidth / 2;
+    const belowY = clientY + POPUP_OFFSET;
+    const aboveY = clientY - POPUP_OFFSET - popupHeight;
+    y = belowY + popupHeight <= vh ? belowY : aboveY;
+  } else {
+    y = clientY - popupHeight / 2;
+    const rightX = clientX + POPUP_OFFSET;
+    const leftX = clientX - POPUP_OFFSET - popupWidth;
+    x = rightX + popupWidth <= vw ? rightX : leftX;
+  }
+
+  x = clamp(x, 0, vw - popupWidth);
+  y = clamp(y, 0, vh - popupHeight);
+
+  return { x, y };
+};
+
+// Popup show/hide
+const showPopup = (clientX: number, clientY: number) => {
+  if (props.disabled || props.readonly) return;
+  if (dismissTimer) {
+    clearTimeout(dismissTimer);
+    dismissTimer = null;
+  }
+  const pos = calcPopupPosition(clientX, clientY);
+  if (pos) {
+    popupPos.value = pos;
+    popupState.value = 'showing';
+  }
+};
+
+const hidePopup = () => {
+  clearAllTimers();
+  popupState.value = 'hidden';
+  popupPos.value = null;
+};
+
+const scheduleDismiss = () => {
+  if (dismissTimer) clearTimeout(dismissTimer);
+  dismissTimer = setTimeout(() => {
+    const splitter = splitterRef.value;
+    const popup = popupRef.value;
+    const hasFocusInside =
+      popup?.contains(document.activeElement) || splitter === document.activeElement;
+    if (!hasFocusInside) {
+      hidePopup();
+    }
+  }, DISMISS_DELAY);
+};
+
 // Update position and emit
 const updatePosition = (newPosition: number) => {
   const clampedPosition = clamp(newPosition, props.min, props.max);
-  if (clampedPosition !== position.value) {
+  if (clampedPosition !== positionLocal) {
+    positionLocal = clampedPosition;
     position.value = clampedPosition;
 
     const container = containerRef.value;
@@ -146,6 +401,29 @@ const updatePosition = (newPosition: number) => {
 
     emit('positionChange', clampedPosition, sizeInPx);
   }
+};
+
+// Popup button click handler
+const handlePopupButtonClick = (delta: number) => {
+  if (props.disabled || props.readonly) return;
+  const currentPos = positionLocal;
+  const newPos = currentPos + delta;
+  if (newPos < props.min || newPos > props.max) return;
+  updatePosition(newPos);
+  popupState.value = 'active';
+  if (activeSettleTimer) clearTimeout(activeSettleTimer);
+  activeSettleTimer = setTimeout(() => {
+    if (popupState.value === 'active') {
+      if (!isMouseOverPopup) {
+        const pos = hoverPos;
+        if (pos) {
+          const newPopupPos = calcPopupPosition(pos.x, pos.y);
+          if (newPopupPos) popupPos.value = newPopupPos;
+        }
+      }
+      popupState.value = 'showing';
+    }
+  }, ACTIVE_SETTLE_DELAY);
 };
 
 // Handle collapse/expand
@@ -160,6 +438,7 @@ const handleToggleCollapse = () => {
 
     emit('collapsedChange', false, position.value);
     collapsed.value = false;
+    positionLocal = clampedRestore;
     position.value = clampedRestore;
 
     const container = containerRef.value;
@@ -173,6 +452,7 @@ const handleToggleCollapse = () => {
     previousPosition.value = position.value;
     emit('collapsedChange', true, position.value);
     collapsed.value = true;
+    positionLocal = 0;
     position.value = 0;
     emit('positionChange', 0, 0);
   }
@@ -181,6 +461,16 @@ const handleToggleCollapse = () => {
 // Keyboard handler
 const handleKeyDown = (event: KeyboardEvent) => {
   if (props.disabled || props.readonly) return;
+
+  // Tab moves focus to popup if visible
+  if (event.key === 'Tab' && !event.shiftKey && popupState.value !== 'hidden') {
+    const firstBtn = popupRef.value?.querySelector<HTMLButtonElement>('button');
+    if (firstBtn) {
+      event.preventDefault();
+      firstBtn.focus();
+      return;
+    }
+  }
 
   const hasShift = event.shiftKey;
   const currentStep = hasShift ? props.largeStep : props.step;
@@ -203,13 +493,13 @@ const handleKeyDown = (event: KeyboardEvent) => {
 
     case 'ArrowUp':
       if (!isVertical.value) break;
-      delta = currentStep;
+      delta = -currentStep;
       handled = true;
       break;
 
     case 'ArrowDown':
       if (!isVertical.value) break;
-      delta = -currentStep;
+      delta = currentStep;
       handled = true;
       break;
 
@@ -232,7 +522,7 @@ const handleKeyDown = (event: KeyboardEvent) => {
   if (handled) {
     event.preventDefault();
     if (delta !== 0) {
-      updatePosition(position.value + delta);
+      updatePosition(positionLocal + delta);
     }
   }
 };
@@ -245,23 +535,43 @@ const handlePointerDown = (event: PointerEvent) => {
   const splitter = splitterRef.value;
   if (!splitter) return;
 
+  pointerStart = { x: event.clientX, y: event.clientY };
+  isDragging = false;
+
   if (typeof splitter.setPointerCapture === 'function') {
     splitter.setPointerCapture(event.pointerId);
   }
-  isDragging.value = true;
+
+  if (hoverTimer) {
+    clearTimeout(hoverTimer);
+    hoverTimer = null;
+  }
+
   splitter.focus();
 };
 
 const handlePointerMove = (event: PointerEvent) => {
-  if (!isDragging.value) return;
+  const start = pointerStart;
+  if (!start) return;
+
+  if (!isDragging) {
+    const dx = event.clientX - start.x;
+    const dy = event.clientY - start.y;
+    const distance = Math.sqrt(dx * dx + dy * dy);
+    if (distance >= TAP_DISTANCE_THRESHOLD) {
+      isDragging = true;
+      if (popupState.value !== 'hidden') hidePopup();
+    } else {
+      return;
+    }
+  }
 
   const container = containerRef.value;
   if (!container) return;
 
   // Use demo container for stable measurement if available
-  const demoContainer = container.closest(
-    '.apg-window-splitter-demo-container'
-  ) as HTMLElement | null;
+  const demoContainerElement = container.closest('.apg-window-splitter-demo-container');
+  const demoContainer = demoContainerElement instanceof HTMLElement ? demoContainerElement : null;
   const measureElement = demoContainer || container.parentElement || container;
   const rect = measureElement.getBoundingClientRect();
 
@@ -295,6 +605,98 @@ const handlePointerUp = (event: PointerEvent) => {
       // Ignore
     }
   }
-  isDragging.value = false;
+
+  const start = pointerStart;
+  if (start && !isDragging) {
+    showPopup(start.x, start.y);
+  }
+
+  isDragging = false;
+  pointerStart = null;
+};
+
+// Separator mouse handlers for hover popup
+const handleSeparatorMouseEnter = (event: MouseEvent) => {
+  if (props.disabled || props.readonly || isDragging) return;
+  hoverPos = { x: event.clientX, y: event.clientY };
+  if (popupState.value === 'hidden') {
+    if (hoverTimer) clearTimeout(hoverTimer);
+    hoverTimer = setTimeout(() => {
+      const pos = hoverPos;
+      if (pos) showPopup(pos.x, pos.y);
+    }, HOVER_DELAY);
+  }
+  if (dismissTimer) {
+    clearTimeout(dismissTimer);
+    dismissTimer = null;
+  }
+};
+
+const handleSeparatorMouseLeave = () => {
+  if (hoverTimer) {
+    clearTimeout(hoverTimer);
+    hoverTimer = null;
+  }
+  if (popupState.value !== 'hidden') scheduleDismiss();
+};
+
+const handleSeparatorMouseMove = (event: MouseEvent) => {
+  hoverPos = { x: event.clientX, y: event.clientY };
+};
+
+// Separator focus/blur handlers
+const handleSeparatorFocus = () => {
+  if (props.disabled || props.readonly) return;
+  if (popupState.value === 'hidden') {
+    const splitter = splitterRef.value;
+    if (splitter) {
+      const rect = splitter.getBoundingClientRect();
+      showPopup(rect.left + rect.width / 2, rect.top + rect.height / 2);
+    }
+  }
+  if (dismissTimer) {
+    clearTimeout(dismissTimer);
+    dismissTimer = null;
+  }
+};
+
+const handleSeparatorBlur = () => {
+  if (popupState.value !== 'hidden') {
+    setTimeout(() => {
+      const popup = popupRef.value;
+      const splitter = splitterRef.value;
+      if (!popup?.contains(document.activeElement) && splitter !== document.activeElement) {
+        scheduleDismiss();
+      }
+    }, 0);
+  }
+};
+
+// Popup mouse handlers
+const handlePopupMouseEnter = () => {
+  isMouseOverPopup = true;
+  if (dismissTimer) {
+    clearTimeout(dismissTimer);
+    dismissTimer = null;
+  }
+};
+
+const handlePopupMouseLeave = () => {
+  isMouseOverPopup = false;
+  if (popupState.value !== 'hidden') scheduleDismiss();
+};
+
+// Popup keydown handler
+const handlePopupKeyDown = (event: KeyboardEvent) => {
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    hidePopup();
+    splitterRef.value?.focus();
+  }
+  if (event.key === 'Tab' && event.shiftKey) {
+    event.preventDefault();
+    hidePopup();
+    splitterRef.value?.focus();
+  }
 };
 </script>

--- a/src/patterns/windowsplitter/WindowSplitter.vue
+++ b/src/patterns/windowsplitter/WindowSplitter.vue
@@ -274,7 +274,8 @@ const ariaControls = computed(() => {
 });
 
 const splitterLabel = computed(() => {
-  return (instance?.attrs['aria-label'] as string) || '';
+  const label = instance?.attrs['aria-label'];
+  return typeof label === 'string' ? label : '';
 });
 
 const isAtMin = computed(() => position.value <= props.min);
@@ -323,9 +324,7 @@ watch(popupState, (state, _, onCleanup) => {
 
 // Popup position calculation
 const calcPopupPosition = (clientX: number, clientY: number) => {
-  const splitter = splitterRef.value;
-  if (!splitter) return null;
-  const rect = splitter.getBoundingClientRect();
+  if (!splitterRef.value) return null;
   const popupEl = popupRef.value;
   const popupWidth = popupEl?.offsetWidth || (isVertical.value ? 34 : 120);
   const popupHeight = popupEl?.offsetHeight || (isVertical.value ? 120 : 34);

--- a/src/styles/patterns/windowsplitter.css
+++ b/src/styles/patterns/windowsplitter.css
@@ -23,9 +23,10 @@ apg-window-splitter {
 
 /* Separator (the draggable divider) */
 .apg-window-splitter__separator {
+  box-sizing: content-box;
   position: relative;
   flex-shrink: 0;
-  background: var(--border, #e5e7eb);
+  background-color: var(--border, #e5e7eb);
   cursor: col-resize;
   touch-action: none;
   outline: none;
@@ -38,6 +39,9 @@ apg-window-splitter {
 .apg-window-splitter:not(.apg-window-splitter--vertical) .apg-window-splitter__separator {
   width: 4px;
   align-self: stretch;
+  padding-inline: 10px;
+  margin-inline: -10px;
+  background-clip: content-box;
 }
 
 /* Vertical separator */
@@ -45,18 +49,86 @@ apg-window-splitter {
   height: 4px;
   align-self: stretch;
   cursor: row-resize;
+  padding-block: 10px;
+  margin-block: -10px;
+  background-clip: content-box;
 }
 
 /* Separator Hover State */
 .apg-window-splitter__separator:hover {
-  background: var(--primary, #3b82f6);
+  background-color: var(--primary, #3b82f6);
 }
 
 /* Separator Focus State */
 .apg-window-splitter__separator:focus-visible {
-  background: var(--ring, #3b82f6);
-  box-shadow: 0 0 0 2px var(--ring, #3b82f6);
+  background-color: var(--ring, #3b82f6);
   z-index: 1;
+}
+
+.apg-window-splitter__separator:focus-visible::after {
+  content: '';
+  position: absolute;
+  box-shadow: 0 0 0 2px var(--ring, #3b82f6);
+  pointer-events: none;
+}
+
+.apg-window-splitter:not(.apg-window-splitter--vertical)
+  .apg-window-splitter__separator:focus-visible::after {
+  inset-block: 0;
+  inset-inline: 10px;
+}
+
+.apg-window-splitter--vertical .apg-window-splitter__separator:focus-visible::after {
+  inset-block: 10px;
+  inset-inline: 0;
+}
+
+/* =============================================================================
+   ADJUST POPUP (WCAG 2.5.7 Dragging Movements alternative)
+   ============================================================================= */
+
+.apg-window-splitter__popup {
+  position: fixed;
+  display: none;
+  gap: 4px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  z-index: 10;
+}
+
+.apg-window-splitter__popup--visible {
+  display: flex;
+}
+
+.apg-window-splitter__popup-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 50%;
+  background-color: var(--background, #ffffff);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
+  color: var(--foreground, #111827);
+  font-size: 0.625rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.apg-window-splitter__popup-button:hover {
+  background-color: var(--muted, #f3f4f6);
+}
+
+.apg-window-splitter__popup-button:active {
+  background-color: var(--border, #e5e7eb);
+}
+
+.apg-window-splitter__popup-button[aria-disabled='true'] {
+  opacity: 0.4;
+  cursor: default;
 }
 
 /* =============================================================================
@@ -221,7 +293,7 @@ apg-window-splitter {
    ============================================================================= */
 
 .dark .apg-window-splitter__separator {
-  background: var(--border, #374151);
+  background-color: var(--border, #374151);
 }
 
 .dark .apg-window-splitter-pane {
@@ -230,6 +302,24 @@ apg-window-splitter {
 
 .dark .apg-window-splitter-keyboard-hints {
   background: var(--muted, #1f2937);
+}
+
+.dark .apg-window-splitter__popup {
+  background: transparent;
+}
+
+.dark .apg-window-splitter__popup-button {
+  background-color: var(--background, #111827);
+  border-color: var(--border, #374151);
+  color: var(--foreground, #f9fafb);
+}
+
+.dark .apg-window-splitter__popup-button:hover {
+  background-color: var(--muted, #1f2937);
+}
+
+.dark .apg-window-splitter__popup-button:active {
+  background-color: var(--border, #374151);
 }
 
 /* =============================================================================
@@ -241,31 +331,63 @@ apg-window-splitter {
   .apg-window-splitter__separator {
     transition: none;
   }
+
+  .apg-window-splitter__popup-button {
+    transition: none;
+  }
 }
 
 /* Windows High Contrast Mode (Forced Colors) */
 @media (forced-colors: active) {
   .apg-window-splitter__separator {
-    background: ButtonBorder;
+    background-color: ButtonBorder;
     forced-color-adjust: none;
   }
 
   .apg-window-splitter__separator:hover {
-    background: Highlight;
+    background-color: Highlight;
   }
 
   .apg-window-splitter__separator:focus-visible {
+    box-shadow: none;
+  }
+
+  .apg-window-splitter__separator:focus-visible::after {
     outline: 2px solid Highlight;
     outline-offset: 2px;
     box-shadow: none;
   }
 
   .apg-window-splitter--disabled .apg-window-splitter__separator {
-    background: GrayText;
+    background-color: GrayText;
   }
 
   .apg-window-splitter-pane {
     background: Canvas;
     border: 1px solid CanvasText;
+  }
+
+  .apg-window-splitter__popup {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+  }
+
+  .apg-window-splitter__popup-button {
+    background-color: Canvas;
+    border: 1px solid ButtonBorder;
+    color: ButtonText;
+    forced-color-adjust: none;
+  }
+
+  .apg-window-splitter__popup-button:hover {
+    background-color: Highlight;
+    color: HighlightText;
+    border-color: Highlight;
+  }
+
+  .apg-window-splitter__popup-button:focus-visible {
+    outline: 2px solid Highlight;
+    outline-offset: 2px;
   }
 }


### PR DESCRIPTION
## Summary

- **WCAG 2.5.8 Target Size**: セパレーターのヒットエリアを 4px → 24px に拡張（padding + negative-margin + background-clip で見た目は維持）
- **WCAG 2.5.7 Dragging Movements**: ドラッグ操作の代替としてフローティングポップアップに 4 つの調整ボタン（collapse/shrink/expand/maximize）を追加
- **垂直 splitter のキーボード修正**: ArrowUp/Down が視覚方向と一致するよう修正
- **全 4 フレームワーク対応**: React, Vue, Svelte, Astro

### ポップアップの仕様

- hover 300ms 遅延 / focus 即表示 / タップ（移動距離 5px 未満）で表示
- ボタン操作中はポップアップ位置固定（連打しやすい）
- ポップアップ外クリックで active なポップアップを閉じる
- Escape キーで閉じ（WCAG 1.4.13 準拠）
- SVG シェブロンアイコン（1px 光学補正付き）
- 水平: カーソル下に横並び / 垂直: カーソル右に縦並び
- min/max で該当ボタンを aria-disabled
- Dark mode / forced-colors / reduced-motion 対応

## Test plan

- [ ] `npm test` で 203 テスト全パス
- [ ] `npm run build` で 553 ページビルド成功
- [ ] 各フレームワーク（React/Vue/Svelte/Astro）でポップアップの表示・操作を確認
- [ ] ボタン連打でポップアップ位置が安定していること
- [ ] ドラッグ操作時にポップアップが表示されないこと
- [ ] キーボード操作（Tab→ボタン移動、Escape→閉じ）を確認
- [ ] 垂直 splitter の ArrowUp/Down が視覚方向と一致すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)