### PR TITLE
chore(ci): GitHub Actions を Node 24 ランタイム対応版へ更新

### DIFF
--- a/.github/workflows/apg-upstream-watch.yml
+++ b/.github/workflows/apg-upstream-watch.yml
@@ -51,7 +51,7 @@ jobs:
       contents: write
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # GITHUB_TOKEN を git config に永続化しない。state fetch / push step で
           # 必要なときだけ remote URL に inline credential として渡す。
@@ -74,7 +74,7 @@ jobs:
             echo '{"schemaVersion":1,"lastRun":null,"patterns":{}}' > "${APG_STATE_FILE_LOCAL}"
           fi
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .node-version
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
       TZ: 'Asia/Tokyo'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -33,7 +33,7 @@ jobs:
         run: npm ci --prefer-offline
 
       - name: Cache Astro build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .astro
@@ -51,13 +51,13 @@ jobs:
       # Only upload Pages artifact on main branch (for deploy)
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
 
       # Cache dist for E2E tests (all branches)
       - name: Cache dist for E2E tests
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ./dist
           key: dist-${{ github.sha }}
@@ -66,10 +66,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -84,10 +84,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -115,10 +115,10 @@ jobs:
             script: npm run test:astro
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -150,10 +150,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -162,7 +162,7 @@ jobs:
         run: npm ci --prefer-offline
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -185,10 +185,10 @@ jobs:
       E2E_FRAMEWORK: ${{ matrix.framework }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -197,14 +197,14 @@ jobs:
         run: npm ci --prefer-offline
 
       - name: Restore dist from cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ./dist
           key: dist-${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Restore Playwright browsers from cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -217,7 +217,7 @@ jobs:
         run: npm run test:e2e:ci
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report-${{ matrix.framework }}
@@ -245,10 +245,10 @@ jobs:
     needs: [build]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -257,7 +257,7 @@ jobs:
         run: npm ci --prefer-offline
 
       - name: Restore dist from cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ./dist
           key: dist-${{ github.sha }}
@@ -281,4 +281,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

Node.js 20 で動作する GitHub Actions が **2026-06-16 から Node 24 強制 / 2026-09-16 にランナーから削除**される予告（直近の CI ログに警告が出ていた）に対応し、各アクションを Node 24 ランタイムの最新メジャーへ更新します。

| action | before | after |
|--------|--------|-------|
| actions/checkout | v4 | **v6** |
| actions/setup-node | v4 | **v6** |
| actions/cache (+restore/save) | v4 | **v5** |
| actions/upload-artifact | v4 | **v7** |
| actions/upload-pages-artifact | v3 | **v5** |
| actions/deploy-pages | v4 | **v5** |

ジョブの `node-version` は既に `'24'`。本変更は CI 設定のみでアプリ・ビルド成果物には影響しません。

## Notes

- `upload-pages-artifact` / `deploy-pages` は `build`・`deploy` ジョブの `if: github.ref == 'refs/heads/main'` ガード下でのみ実行されるため、**PR の CI では走らず、main マージ後に初めて検証**されます（両者は同一メジャーで対になる設計）。
- それ以外（checkout / setup-node / cache / upload-artifact）は PR の CI で全ジョブ検証されます。

## Test plan

- [ ] PR CI が全ジョブ green（checkout/setup-node/cache/upload-artifact の新バージョンで unit・e2e・build・lint・format・validate-html が通る）
- [ ] Node 20 deprecation 警告が消えていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)