### PR TITLE
style: unify focus indicators + bump to 0.4.2

### DIFF
--- a/src/components/ui/AiGuideActions.astro
+++ b/src/components/ui/AiGuideActions.astro
@@ -34,7 +34,7 @@ const llmMdUrl = withBase(getPatternDefinitionPath(pattern, locale));
   >
     <button
       type="button"
-      class="download-btn inline-flex items-center gap-1.5 rounded-l-md px-3 py-1.5 text-sm text-blue-700 transition-colors hover:bg-blue-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:text-blue-300 dark:hover:bg-blue-900"
+      class="download-btn focus-ring inline-flex items-center gap-1.5 rounded-l-md px-3 py-1.5 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:text-blue-300 dark:hover:bg-blue-900"
       data-action="download"
     >
       <DownloadIcon class="relative -top-px size-4" aria-hidden="true" />
@@ -45,7 +45,7 @@ const llmMdUrl = withBase(getPatternDefinitionPath(pattern, locale));
 
     <details class="dropdown relative">
       <summary
-        class="dropdown-trigger inline-flex size-8 items-center justify-center rounded-r-md text-blue-700 transition-colors hover:bg-blue-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:text-blue-300 dark:hover:bg-blue-900"
+        class="dropdown-trigger focus-ring inline-flex size-8 items-center justify-center rounded-r-md text-blue-700 transition-colors hover:bg-blue-100 dark:text-blue-300 dark:hover:bg-blue-900"
         aria-label={t('ai.moreActions')}
         aria-haspopup="menu"
       >
@@ -57,7 +57,7 @@ const llmMdUrl = withBase(getPatternDefinitionPath(pattern, locale));
       >
         <button
           type="button"
-          class="hover:bg-muted/50 focus:bg-muted focus:ring-primary flex w-full items-center gap-2 rounded-t-lg px-4 py-2.5 text-left text-sm transition-colors focus:ring-2 focus:outline-none focus:ring-inset"
+          class="hover:bg-muted/50 focus:bg-muted focus-ring-inset flex w-full items-center gap-2 rounded-t-lg px-4 py-2.5 text-left text-sm transition-colors"
           role="menuitem"
           data-action="copy"
         >
@@ -66,7 +66,7 @@ const llmMdUrl = withBase(getPatternDefinitionPath(pattern, locale));
         </button>
         <button
           type="button"
-          class="hover:bg-muted/50 focus:bg-muted focus:ring-primary flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm transition-colors focus:ring-2 focus:outline-none focus:ring-inset"
+          class="hover:bg-muted/50 focus:bg-muted focus-ring-inset flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm transition-colors"
           role="menuitem"
           data-action="chatgpt"
         >
@@ -75,7 +75,7 @@ const llmMdUrl = withBase(getPatternDefinitionPath(pattern, locale));
         </button>
         <button
           type="button"
-          class="hover:bg-muted/50 focus:bg-muted focus:ring-primary flex w-full items-center gap-2 rounded-b-lg px-4 py-2.5 text-left text-sm transition-colors focus:ring-2 focus:outline-none focus:ring-inset"
+          class="hover:bg-muted/50 focus:bg-muted focus-ring-inset flex w-full items-center gap-2 rounded-b-lg px-4 py-2.5 text-left text-sm transition-colors"
           role="menuitem"
           data-action="claude"
         >

--- a/src/components/ui/CodeTabs.astro
+++ b/src/components/ui/CodeTabs.astro
@@ -108,7 +108,7 @@ const tabsId = `code-tabs-${Math.random().toString(36).slice(2, 9)}`;
   }
 
   .code-tab:focus-visible {
-    outline: 2px solid var(--primary);
+    outline: 2px solid var(--ring);
     outline-offset: -2px;
   }
 

--- a/src/components/ui/LanguageSwitcher.astro
+++ b/src/components/ui/LanguageSwitcher.astro
@@ -29,7 +29,7 @@ const alternateLanguageName = languages[alternateLocale];
   class:list={[
     'inline-flex items-center gap-1.5 rounded-md px-2 py-1.5 text-sm transition-colors',
     'text-muted-foreground hover:text-foreground hover:bg-muted',
-    'focus-visible:ring-foreground focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+    'focus-ring',
     Astro.props.class,
   ]}
   aria-label={`Switch to ${alternateLanguageName}`}

--- a/src/components/ui/PracticeDownload.astro
+++ b/src/components/ui/PracticeDownload.astro
@@ -29,7 +29,7 @@ const mdFileName = locale === 'ja' ? `${practice}.ja.md` : `${practice}.md`;
   >
     <button
       type="button"
-      class="download-btn inline-flex items-center gap-1.5 rounded-l-md px-3 py-1.5 text-sm text-blue-700 transition-colors hover:bg-blue-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:text-blue-300 dark:hover:bg-blue-900"
+      class="download-btn focus-ring inline-flex items-center gap-1.5 rounded-l-md px-3 py-1.5 text-sm text-blue-700 transition-colors hover:bg-blue-100 dark:text-blue-300 dark:hover:bg-blue-900"
       data-action="download"
     >
       <DownloadIcon class="relative -top-px size-4" aria-hidden="true" />
@@ -40,7 +40,7 @@ const mdFileName = locale === 'ja' ? `${practice}.ja.md` : `${practice}.md`;
 
     <details class="dropdown relative">
       <summary
-        class="dropdown-trigger inline-flex size-8 items-center justify-center rounded-r-md text-blue-700 transition-colors hover:bg-blue-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:text-blue-300 dark:hover:bg-blue-900"
+        class="dropdown-trigger focus-ring inline-flex size-8 items-center justify-center rounded-r-md text-blue-700 transition-colors hover:bg-blue-100 dark:text-blue-300 dark:hover:bg-blue-900"
         aria-label={t('ai.moreActions')}
         aria-haspopup="menu"
       >
@@ -52,7 +52,7 @@ const mdFileName = locale === 'ja' ? `${practice}.ja.md` : `${practice}.md`;
       >
         <button
           type="button"
-          class="hover:bg-muted/50 focus:bg-muted focus:ring-primary flex w-full items-center gap-2 rounded-t-lg px-4 py-2.5 text-left text-sm transition-colors focus:ring-2 focus:outline-none focus:ring-inset"
+          class="hover:bg-muted/50 focus:bg-muted focus-ring-inset flex w-full items-center gap-2 rounded-t-lg px-4 py-2.5 text-left text-sm transition-colors"
           role="menuitem"
           data-action="copy"
         >
@@ -61,7 +61,7 @@ const mdFileName = locale === 'ja' ? `${practice}.ja.md` : `${practice}.md`;
         </button>
         <button
           type="button"
-          class="hover:bg-muted/50 focus:bg-muted focus:ring-primary flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm transition-colors focus:ring-2 focus:outline-none focus:ring-inset"
+          class="hover:bg-muted/50 focus:bg-muted focus-ring-inset flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm transition-colors"
           role="menuitem"
           data-action="chatgpt"
         >
@@ -70,7 +70,7 @@ const mdFileName = locale === 'ja' ? `${practice}.ja.md` : `${practice}.md`;
         </button>
         <button
           type="button"
-          class="hover:bg-muted/50 focus:bg-muted focus:ring-primary flex w-full items-center gap-2 rounded-b-lg px-4 py-2.5 text-left text-sm transition-colors focus:ring-2 focus:outline-none focus:ring-inset"
+          class="hover:bg-muted/50 focus:bg-muted focus-ring-inset flex w-full items-center gap-2 rounded-b-lg px-4 py-2.5 text-left text-sm transition-colors"
           role="menuitem"
           data-action="claude"
         >

--- a/src/components/ui/button/button.astro
+++ b/src/components/ui/button/button.astro
@@ -14,13 +14,12 @@ type Props = VariantProps<typeof variants> &
   };
 
 const variants = cva(
-  "focus-visible:border-ring text-foreground focus-visible:ring-foreground aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-colors outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "text-foreground aria-invalid:border-destructive focus-ring inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-colors disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
         default: 'bg-primary text-primary-foreground hover:bg-primary/90',
-        destructive:
-          'bg-destructive hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60 text-white',
+        destructive: 'bg-destructive hover:bg-destructive/90 dark:bg-destructive/60 text-white',
         outline:
           'bg-background hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 border shadow-xs',
         secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',

--- a/src/components/ui/footer/footer-menu-link.astro
+++ b/src/components/ui/footer/footer-menu-link.astro
@@ -14,7 +14,7 @@ const slot = await Astro.slots.render('default');
   slot?.trim().length > 0 && (
     <a
       class={cn(
-        "text-muted-foreground hover:text-foreground inline-flex items-center gap-2 text-sm leading-5 underline transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        "text-muted-foreground hover:text-foreground focus-ring inline-flex items-center gap-2 text-sm leading-5 underline transition-colors [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/src/components/ui/logo/logo.astro
+++ b/src/components/ui/logo/logo.astro
@@ -16,7 +16,7 @@ const slot = await Astro.slots.render('default');
   slot?.trim().length > 0 && (
     <Comp
       class={cn(
-        'focus-visible:ring-foreground -mx-2 flex h-8 items-center justify-start gap-2.5 rounded-md px-2 text-base font-semibold whitespace-nowrap focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+        'focus-ring -mx-2 flex h-8 items-center justify-start gap-2.5 rounded-md px-2 text-base font-semibold whitespace-nowrap',
         className
       )}
       href={href}

--- a/src/components/ui/native-select/native-select.astro
+++ b/src/components/ui/native-select/native-select.astro
@@ -16,8 +16,8 @@ const { class: className, ...props } = Astro.props;
   <select
     data-slot="native-select"
     class={cn(
-      'border-input placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 dark:hover:bg-input/50 h-9 w-full min-w-0 appearance-none rounded-md border bg-transparent px-3 py-2 pr-9 text-sm shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed',
-      'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+      'border-input placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 dark:hover:bg-input/50 h-9 w-full min-w-0 appearance-none rounded-md border bg-transparent px-3 py-2 pr-9 text-sm shadow-xs transition-[color,box-shadow] disabled:pointer-events-none disabled:cursor-not-allowed',
+      'focus-ring',
       'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
       className
     )}

--- a/src/components/ui/navigation-menu/navigation-menu-link.astro
+++ b/src/components/ui/navigation-menu/navigation-menu-link.astro
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const variants = cva(
-  'underline leading-none focus-visible:ring-foreground inline-flex items-center justify-start rounded-md transition-colors outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+  'underline leading-none focus-ring inline-flex items-center justify-start rounded-md transition-colors',
   {
     variants: {
       variant: {

--- a/src/components/ui/navigation-menu/navigation-menu-trigger.astro
+++ b/src/components/ui/navigation-menu/navigation-menu-trigger.astro
@@ -18,7 +18,7 @@ const Comp = href ? 'a' : 'button';
     <Comp
       data-slot="navigation-menu-trigger"
       class={cn(
-        'bg-background hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-foreground inline-flex h-8 w-max items-center justify-center rounded-md px-4 py-1 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50',
+        'bg-background hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-ring inline-flex h-8 w-max items-center justify-center rounded-md px-4 py-1 text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50',
         'navigation-menu-trigger cursor-pointer [&:where(button)]:border-none [&:where(button)]:bg-transparent',
         className
       )}

--- a/src/components/ui/pattern-breadcrumb/PatternBreadcrumb.astro
+++ b/src/components/ui/pattern-breadcrumb/PatternBreadcrumb.astro
@@ -31,7 +31,7 @@ const currentPattern = getPatternById(pattern);
     <li class="relative">
       <Collapsible class="inline-block">
         <CollapsibleTrigger
-          class="text-primary focus-visible:ring-ring inline-flex items-center gap-1 rounded-sm hover:underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+          class="text-primary focus-ring inline-flex items-center gap-1 rounded-sm hover:underline"
           showChevron={false}
         >
           <span>{t('patterns.title')}</span>
@@ -44,7 +44,7 @@ const currentPattern = getPatternById(pattern);
         >
           <a
             href={withBase(getLocalizedPath('/patterns/', locale))}
-            class="hover:bg-muted/50 focus:bg-muted focus:ring-primary flex items-center gap-2 rounded-t-lg px-4 py-2 text-sm transition-colors focus:ring-2 focus:outline-none focus:ring-inset"
+            class="hover:bg-muted/50 focus:bg-muted focus-ring-inset flex items-center gap-2 rounded-t-lg px-4 py-2 text-sm transition-colors"
           >
             <span class="inline-flex w-5 justify-center text-base" aria-hidden="true">📚</span>
             <span>{t('patterns.available')}</span>
@@ -57,7 +57,7 @@ const currentPattern = getPatternById(pattern);
                   <a
                     href={withBase(getLocalizedPath(`/patterns/${p.id}/${framework}/`, locale))}
                     class:list={[
-                      'hover:bg-muted/50 focus:bg-muted focus:ring-primary flex items-center gap-2 px-4 py-2 text-sm transition-colors focus:ring-2 focus:outline-none focus:ring-inset',
+                      'hover:bg-muted/50 focus:bg-muted focus-ring-inset flex items-center gap-2 px-4 py-2 text-sm transition-colors',
                       pattern === p.id && 'bg-muted font-medium',
                     ]}
                     aria-current={pattern === p.id ? 'page' : undefined}

--- a/src/components/ui/pattern-search/PatternSearch.tsx
+++ b/src/components/ui/pattern-search/PatternSearch.tsx
@@ -328,9 +328,9 @@ export function PatternSearch({
             type="text"
             role="combobox"
             className={cn(
-              'bg-background border-input placeholder:text-muted-foreground focus-visible:ring-foreground',
+              'bg-background border-input placeholder:text-muted-foreground',
               'flex h-9 w-full rounded-md border py-2 pr-3 pl-9 text-sm',
-              'focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+              'focus-ring',
               'disabled:cursor-not-allowed disabled:opacity-50'
             )}
             autoComplete="off"

--- a/src/components/ui/sheet/sheet-content.astro
+++ b/src/components/ui/sheet/sheet-content.astro
@@ -78,7 +78,7 @@ const slot = await Astro.slots.render('default');
         <button
           type="button"
           data-slot="sheet-close"
-          class="focus-visible:outline-ring text-foreground absolute top-2 right-5.25 cursor-pointer rounded-sm border-0 bg-transparent p-3.5 opacity-70 transition-opacity hover:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-2"
+          class="focus-ring text-foreground absolute top-2 right-5.25 cursor-pointer rounded-sm border-0 bg-transparent p-3.5 opacity-70 transition-opacity hover:opacity-100"
           aria-label="Close"
         >
           <XIcon class="size-4" />

--- a/src/components/ui/sidebar/sidebar-menu-button.astro
+++ b/src/components/ui/sidebar/sidebar-menu-button.astro
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const variants = cva(
-  'hover:bg-accent hover:text-accent-foreground active:bg-accent active:text-accent-foreground flex w-full items-baseline gap-2 rounded-md p-2 text-left text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary disabled:pointer-events-none disabled:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0',
+  'hover:bg-accent hover:text-accent-foreground active:bg-accent active:text-accent-foreground focus-ring-inset flex w-full items-baseline gap-2 rounded-md p-2 text-left text-sm transition-colors disabled:pointer-events-none disabled:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0',
   {
     variants: {
       variant: {

--- a/src/components/ui/sidebar/sidebar-menu-sub-button.astro
+++ b/src/components/ui/sidebar/sidebar-menu-sub-button.astro
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const variants = cva(
-  'hover:bg-accent hover:text-accent-foreground flex min-h-7 min-w-0 -translate-x-px items-baseline gap-2 rounded-md px-2 transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 disabled:pointer-events-none disabled:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0',
+  'hover:bg-accent hover:text-accent-foreground focus-ring flex min-h-7 min-w-0 -translate-x-px items-baseline gap-2 rounded-md px-2 transition-colors disabled:pointer-events-none disabled:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0',
   {
     variants: {
       size: {

--- a/src/components/ui/theme-toggle/theme-toggle.astro
+++ b/src/components/ui/theme-toggle/theme-toggle.astro
@@ -33,20 +33,12 @@ const buttonStyles = cn(
   // Checked state
   'aria-checked:bg-background',
   'aria-checked:shadow-sm',
-  // Focus state
-  'focus-visible:outline-none',
-  'focus-visible:ring-2',
-  'focus-visible:ring-offset-2',
-  'focus-visible:ring-foreground',
+  // Focus state (outline + var(--ring); forced-colors でシステム色に追従)
+  'focus-ring',
   // Forced colors: checked state
   'forced-colors:aria-checked:outline-2',
   'forced-colors:aria-checked:outline-[SelectedItem]',
-  'forced-colors:aria-checked:-outline-offset-2',
-  // Forced colors: focus state
-  'forced-colors:focus-visible:outline-2',
-  'forced-colors:focus-visible:outline-[Highlight]',
-  'forced-colors:focus-visible:-outline-offset-2',
-  'forced-colors:focus-visible:ring-0'
+  'forced-colors:aria-checked:-outline-offset-2'
 );
 ---
 

--- a/src/components/ui/tile/tile.astro
+++ b/src/components/ui/tile/tile.astro
@@ -7,7 +7,7 @@ import { cn } from '@/lib/utils';
 type Props = VariantProps<typeof variants> & HTMLAttributes<'div'> & HTMLAttributes<'a'>;
 
 const variants = cva(
-  'group/tile focus-visible:border-ring focus-visible:ring-ring/50 [a]:hover:ring-accent/50 relative flex flex-col items-start gap-6 outline-none focus-visible:ring-[3px] [a]:transition-all',
+  'group/tile focus-ring [a]:hover:ring-accent/50 relative flex flex-col items-start gap-6 [a]:transition-all',
   {
     variants: {
       variant: {

--- a/src/components/ui/toc/TableOfContents.astro
+++ b/src/components/ui/toc/TableOfContents.astro
@@ -24,7 +24,7 @@ const t = useTranslation(locale);
         <li>
           <a
             href={`#${item.id}`}
-            class="toc-link text-muted-foreground hover:text-foreground block py-1 transition-colors"
+            class="toc-link focus-ring text-muted-foreground hover:text-foreground block rounded-sm py-1 transition-colors"
             data-toc-id={item.id}
           >
             {item.text}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -53,7 +53,7 @@
   --destructive-foreground: oklch(1 0 0);
   --border: oklch(0.922 0 0);
   --input: oklch(0.6674 0.0012 17.19);
-  --ring: oklch(0.708 0 0);
+  --ring: oklch(0.145 0 0);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
@@ -89,7 +89,7 @@
   --destructive-foreground: oklch(1 0 0);
   --border: oklch(1 0 0 / 40%);
   --input: oklch(1 0 0 / 40%);
-  --ring: oklch(0.556 0 0);
+  --ring: oklch(0.985 0 0);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
@@ -194,6 +194,24 @@ html {
 html.no-transitions * {
   transition: none !important;
   transition-duration: 0s !important;
+}
+
+/* Focus indicator utilities (site UI).
+   APG パターン本体 (src/styles/patterns/*.css) と同じ outline + var(--ring) 方式に統一。
+   ring-* (box-shadow) は forced-colors で消えるため outline ベースを採用する。 */
+@utility focus-ring {
+  &:focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
+  }
+}
+
+/* メニュー項目など外側 offset がクリップ/隣接干渉する箇所用 */
+@utility focus-ring-inset {
+  &:focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: -2px;
+  }
 }
 
 /* Base styles */


### PR DESCRIPTION
## 概要

サイト UI のフォーカスインジケーターを outline ベースのユーティリティに統一し、あわせて pattern-search の調整と version 0.4.2 への bump を含むリリース。

## 変更内容

### フォーカスインジケーターの統一
- `global.css` に `focus-ring` / `focus-ring-inset` ユーティリティを追加（`outline: 2px solid var(--ring)`、offset は `2px` / `-2px`）
- サイト UI 各コンポーネントの shadcn 由来 `focus-visible:ring-*`（box-shadow ベース）を統一ユーティリティへ置換（18ファイル）
- `--ring` を高コントラスト値へ更新（light: `oklch(0.145)`, dark: `oklch(0.985)`）

**理由**: box-shadow ベースの `ring-*` は forced-colors モードで消えてしまうため、APG パターン本体と同じ outline ベースに揃え、強制カラーモードでもフォーカス枠が残るようにした。

### その他
- pattern-search のアイコンラベル調整
- version 0.4.1 → 0.4.2

## 検証

- ✅ 移行漏れスキャン（旧 `focus-visible:ring` 等の残存）: 0件
- ✅ 本番ビルド（cloudflare-pages）: 555ページ成功
- ✅ light / dark / forced-colors の3モードで Playwright 実表示確認（outline が正しく描画され、forced-colors でも残存）

🤖 Generated with [Claude Code](https://claude.com/claude-code)