### PR TITLE
style: improve dark toggle checked state visibility (v0.4.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apg-patterns-examples",
   "type": "module",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": false,
   "description": "Accessible UI components following WAI-ARIA APG patterns. Multi-framework implementations in React, Vue, Svelte, and Astro with documentation and tests.",
   "author": "masuP9",

--- a/src/components/ui/theme-toggle/theme-toggle.astro
+++ b/src/components/ui/theme-toggle/theme-toggle.astro
@@ -67,8 +67,8 @@ const buttonStyles = cn(
     tabindex="-1"
     class={buttonStyles}
   >
-    <Icon name="moon" class="size-4 group-aria-checked:[color:oklch(0.8_0.18_90)]" />
-    <span>Dark</span>
+    <Icon name="moon" class="size-4 group-aria-checked:[color:oklch(0.8_0.18_90)] group-aria-checked:[fill:currentColor]" />
+    <span class="group-aria-checked:text-foreground">Dark</span>
   </button>
 </div>
 

--- a/src/components/ui/theme-toggle/theme-toggle.astro
+++ b/src/components/ui/theme-toggle/theme-toggle.astro
@@ -67,7 +67,10 @@ const buttonStyles = cn(
     tabindex="-1"
     class={buttonStyles}
   >
-    <Icon name="moon" class="size-4 group-aria-checked:[color:oklch(0.8_0.18_90)] group-aria-checked:[fill:currentColor]" />
+    <Icon
+      name="moon"
+      class="size-4 group-aria-checked:[fill:currentColor] group-aria-checked:[color:oklch(0.8_0.18_90)]"
+    />
     <span class="group-aria-checked:text-foreground">Dark</span>
   </button>
 </div>


### PR DESCRIPTION
## 概要

テーマトグルのダークモード選択（checked）状態の視認性を改善し、version を 0.4.3 へ bump するリリース。

## 変更内容

- moon アイコンに `group-aria-checked:[fill:currentColor]` を追加し、checked 時にアイコンの塗りを文字色に追従
- Dark ラベルに `group-aria-checked:text-foreground` を追加し、選択時のコントラストを確保
- version 0.4.2 → 0.4.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)