### PR TITLE
fix(windowsplitter): collapsed状態でのボタン/キー操作と視覚反映を修正

### DIFF
--- a/e2e/windowsplitter.spec.ts
+++ b/e2e/windowsplitter.spec.ts
@@ -260,6 +260,84 @@ for (const framework of frameworks) {
         const expandedValue = await splitter.getAttribute('aria-valuenow');
         expect(expandedValue).toBe('50');
       });
+
+      test('initially collapsed splitter expands via an expand-direction arrow key', async ({
+        page,
+      }) => {
+        const splitter = page.locator('[data-testid="collapsed-splitter"]');
+
+        await splitter.focus();
+        expect(await splitter.getAttribute('aria-valuenow')).toBe('0');
+
+        // Expand direction wakes the collapsed splitter and restores to expandedPosition (50)
+        await page.keyboard.press('ArrowRight');
+        await page.waitForTimeout(50);
+
+        expect(await splitter.getAttribute('aria-valuenow')).toBe('50');
+      });
+
+      test('initially collapsed splitter ignores a shrink-direction arrow key', async ({
+        page,
+      }) => {
+        const splitter = page.locator('[data-testid="collapsed-splitter"]');
+
+        await splitter.focus();
+
+        await page.keyboard.press('ArrowLeft');
+        await page.waitForTimeout(50);
+
+        // Shrink direction is a no-op while collapsed
+        expect(await splitter.getAttribute('aria-valuenow')).toBe('0');
+      });
+
+      test('expanding a collapsed splitter visually widens the primary pane', async ({ page }) => {
+        const splitter = page.locator('[data-testid="collapsed-splitter"]');
+        const primaryPane = page.locator('#collapsed-primary');
+
+        // Primary pane starts collapsed (width ~0)
+        const initialBox = await primaryPane.boundingBox();
+        if (!initialBox) throw new Error('Collapsed primary pane not found');
+        expect(initialBox.width).toBeLessThan(5);
+
+        // Expand via an expand-direction arrow key
+        await splitter.focus();
+        await page.keyboard.press('ArrowRight');
+        await page.waitForTimeout(50);
+
+        // The pane must actually grow, not just aria-valuenow
+        const expandedBox = await primaryPane.boundingBox();
+        if (!expandedBox) throw new Error('Collapsed primary pane not found after expand');
+        expect(expandedBox.width).toBeGreaterThan(100);
+
+        // Re-collapsing via Enter shrinks the pane back to ~0
+        await page.keyboard.press('Enter');
+        await page.waitForTimeout(50);
+        const recollapsedBox = await primaryPane.boundingBox();
+        if (!recollapsedBox) throw new Error('Collapsed primary pane not found after re-collapse');
+        expect(recollapsedBox.width).toBeLessThan(5);
+      });
+
+      test('Expand popup button visually widens a collapsed primary pane', async ({ page }) => {
+        const collapsedDemo = page.locator('[data-testid="collapsed-demo"]');
+        const splitter = page.locator('[data-testid="collapsed-splitter"]');
+        const primaryPane = page.locator('#collapsed-primary');
+        const expandButton = collapsedDemo.getByRole('button', { name: 'Expand', exact: true });
+
+        const initialBox = await primaryPane.boundingBox();
+        if (!initialBox) throw new Error('Collapsed primary pane not found');
+        expect(initialBox.width).toBeLessThan(5);
+
+        // Reveal the popup, then click the Expand chevron button
+        await splitter.hover();
+        await expect(expandButton).toBeVisible();
+        await expandButton.click();
+        await page.waitForTimeout(50);
+
+        expect(await splitter.getAttribute('aria-valuenow')).toBe('50');
+        const expandedBox = await primaryPane.boundingBox();
+        if (!expandedBox) throw new Error('Collapsed primary pane not found after expand');
+        expect(expandedBox.width).toBeGreaterThan(100);
+      });
     });
 
     // 🔴 High Priority: Disabled State

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apg-patterns-examples",
   "type": "module",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": false,
   "description": "Accessible UI components following WAI-ARIA APG patterns. Multi-framework implementations in React, Vue, Svelte, and Astro with documentation and tests.",
   "author": "masuP9",

--- a/src/patterns/windowsplitter/WindowSplitter.astro
+++ b/src/patterns/windowsplitter/WindowSplitter.astro
@@ -296,6 +296,9 @@ const isVertical = orientation === 'vertical';
         this.popup.addEventListener('keydown', this.boundHandlePopupKeyDown);
         this.popup.addEventListener('click', this.boundHandlePopupButtonClick);
       }
+
+      // Reflect the initial collapsed/min/max state on the popup buttons.
+      this.updatePopupButtonStates();
     }
 
     disconnectedCallback() {
@@ -405,17 +408,21 @@ const isVertical = orientation === 'vertical';
       const decreaseBtn = this.popup.querySelector<HTMLButtonElement>('[data-adjust="decrease"]');
       const increaseBtn = this.popup.querySelector<HTMLButtonElement>('[data-adjust="increase"]');
       const maximizeBtn = this.popup.querySelector<HTMLButtonElement>('[data-adjust="maximize"]');
+      // While collapsed the splitter sits below `min`, so the shrink direction is
+      // disabled (already minimal) and the expand direction stays enabled.
+      const shrinkDisabled = this.collapsed || pos <= this.min;
+      const expandDisabled = !this.collapsed && pos >= this.max;
       if (collapseBtn) {
-        collapseBtn.setAttribute('aria-disabled', String(pos <= this.min));
+        collapseBtn.setAttribute('aria-disabled', String(shrinkDisabled));
       }
       if (decreaseBtn) {
-        decreaseBtn.setAttribute('aria-disabled', String(pos <= this.min));
+        decreaseBtn.setAttribute('aria-disabled', String(shrinkDisabled));
       }
       if (increaseBtn) {
-        increaseBtn.setAttribute('aria-disabled', String(pos >= this.max));
+        increaseBtn.setAttribute('aria-disabled', String(expandDisabled));
       }
       if (maximizeBtn) {
-        maximizeBtn.setAttribute('aria-disabled', String(pos >= this.max));
+        maximizeBtn.setAttribute('aria-disabled', String(expandDisabled));
       }
     }
 
@@ -455,72 +462,80 @@ const isVertical = orientation === 'vertical';
       );
     }
 
+    // Expand from the collapsed state, restoring to the previous/expanded position.
+    // Shared by the collapse toggle, popup buttons and keyboard handlers.
+    private expandFromCollapsed() {
+      if (!this.separator) return;
+
+      const restorePosition =
+        this.previousPosition ?? this.expandedPosition ?? this.defaultPosition ?? 50;
+      const clampedRestore = this.clamp(restorePosition);
+
+      this.dispatchEvent(
+        new CustomEvent('collapsedchange', {
+          detail: { collapsed: false, previousPosition: this.currentPosition },
+          bubbles: true,
+        })
+      );
+
+      this.collapsed = false;
+      this.separator.setAttribute('aria-valuenow', String(clampedRestore));
+
+      if (this.container) {
+        this.container.style.setProperty('--splitter-position', `${clampedRestore}%`);
+      }
+
+      let sizeInPx = 0;
+      if (this.container) {
+        sizeInPx =
+          (clampedRestore / 100) *
+          (this.isHorizontal ? this.container.offsetWidth : this.container.offsetHeight);
+      }
+
+      this.updatePopupButtonStates();
+
+      this.dispatchEvent(
+        new CustomEvent('positionchange', {
+          detail: { position: clampedRestore, sizeInPx },
+          bubbles: true,
+        })
+      );
+    }
+
     private handleToggleCollapse() {
       if (!this.isCollapsible || this.isDisabled || this.isReadonly) return;
       if (!this.separator) return;
 
       if (this.collapsed) {
-        // Expand
-        const restorePosition =
-          this.previousPosition ?? this.expandedPosition ?? this.defaultPosition ?? 50;
-        const clampedRestore = this.clamp(restorePosition);
-
-        this.dispatchEvent(
-          new CustomEvent('collapsedchange', {
-            detail: { collapsed: false, previousPosition: this.currentPosition },
-            bubbles: true,
-          })
-        );
-
-        this.collapsed = false;
-        this.separator.setAttribute('aria-valuenow', String(clampedRestore));
-
-        if (this.container) {
-          this.container.style.setProperty('--splitter-position', `${clampedRestore}%`);
-        }
-
-        let sizeInPx = 0;
-        if (this.container) {
-          sizeInPx =
-            (clampedRestore / 100) *
-            (this.isHorizontal ? this.container.offsetWidth : this.container.offsetHeight);
-        }
-
-        this.updatePopupButtonStates();
-
-        this.dispatchEvent(
-          new CustomEvent('positionchange', {
-            detail: { position: clampedRestore, sizeInPx },
-            bubbles: true,
-          })
-        );
-      } else {
-        // Collapse
-        this.previousPosition = this.currentPosition;
-
-        this.dispatchEvent(
-          new CustomEvent('collapsedchange', {
-            detail: { collapsed: true, previousPosition: this.currentPosition },
-            bubbles: true,
-          })
-        );
-
-        this.collapsed = true;
-        this.separator.setAttribute('aria-valuenow', '0');
-
-        if (this.container) {
-          this.container.style.setProperty('--splitter-position', '0%');
-        }
-
-        this.updatePopupButtonStates();
-
-        this.dispatchEvent(
-          new CustomEvent('positionchange', {
-            detail: { position: 0, sizeInPx: 0 },
-            bubbles: true,
-          })
-        );
+        this.expandFromCollapsed();
+        return;
       }
+
+      // Collapse
+      this.previousPosition = this.currentPosition;
+
+      this.dispatchEvent(
+        new CustomEvent('collapsedchange', {
+          detail: { collapsed: true, previousPosition: this.currentPosition },
+          bubbles: true,
+        })
+      );
+
+      this.collapsed = true;
+      this.separator.setAttribute('aria-valuenow', '0');
+
+      if (this.container) {
+        this.container.style.setProperty('--splitter-position', '0%');
+      }
+
+      this.updatePopupButtonStates();
+
+      this.dispatchEvent(
+        new CustomEvent('positionchange', {
+          detail: { position: 0, sizeInPx: 0 },
+          bubbles: true,
+        })
+      );
     }
 
     private calcPopupPosition(clientX: number, clientY: number): { x: number; y: number } | null {
@@ -648,12 +663,17 @@ const isVertical = orientation === 'vertical';
           break;
 
         case 'Home':
-          this.updatePosition(this.min);
+          // Shrink direction is a no-op while collapsed (already at minimum).
+          if (!this.collapsed) this.updatePosition(this.min);
           handled = true;
           break;
 
         case 'End':
-          this.updatePosition(this.max);
+          if (this.collapsed) {
+            this.expandFromCollapsed();
+          } else {
+            this.updatePosition(this.max);
+          }
           handled = true;
           break;
       }
@@ -661,7 +681,12 @@ const isVertical = orientation === 'vertical';
       if (handled) {
         event.preventDefault();
         if (delta !== 0) {
-          this.updatePosition(this.currentPosition + delta);
+          if (this.collapsed) {
+            // Only the expand direction wakes a collapsed splitter; shrink is a no-op.
+            if (delta > 0) this.expandFromCollapsed();
+          } else {
+            this.updatePosition(this.currentPosition + delta);
+          }
         }
       }
     }
@@ -704,11 +729,10 @@ const isVertical = orientation === 'vertical';
 
       if (!this.container) return;
 
-      // Use demo container for stable measurement if available
-      const demoContainer = this.container.closest(
-        '.apg-window-splitter-demo-container'
-      ) as HTMLElement | null;
-      const measureElement = demoContainer || this.container.parentElement || this.container;
+      // Measure the containing layout (the consumer positions the panes there).
+      // The visual update is driven solely by the positionchange event, keeping
+      // the component agnostic of how the consumer renders its panes.
+      const measureElement = this.container.parentElement || this.container;
       const rect = measureElement.getBoundingClientRect();
 
       let percent: number;
@@ -718,14 +742,6 @@ const isVertical = orientation === 'vertical';
       } else {
         const y = event.clientY - rect.top;
         percent = (y / rect.height) * 100;
-      }
-
-      // Clamp the percent to min/max
-      const clampedPercent = this.clamp(percent);
-
-      // Update CSS variable directly for smooth dragging
-      if (demoContainer) {
-        demoContainer.style.setProperty('--splitter-position', `${clampedPercent}%`);
       }
 
       this.updatePosition(percent);
@@ -830,34 +846,8 @@ const isVertical = orientation === 'vertical';
       }
     }
 
-    private handlePopupButtonClick(event: Event) {
-      const target = (event.target as HTMLElement).closest<HTMLButtonElement>('[data-adjust]');
-      if (!target) return;
-      if (this.isDisabled || this.isReadonly) return;
-
-      const adjustType = target.dataset.adjust;
-      let delta: number;
-      switch (adjustType) {
-        case 'collapse':
-          delta = this.min - this.currentPosition;
-          break;
-        case 'decrease':
-          delta = -this.step;
-          break;
-        case 'increase':
-          delta = this.step;
-          break;
-        case 'maximize':
-          delta = this.max - this.currentPosition;
-          break;
-        default:
-          return;
-      }
-      const newPos = this.currentPosition + delta;
-
-      if (newPos < this.min || newPos > this.max) return;
-
-      this.updatePosition(newPos);
+    // Mark the popup as actively adjusting, then settle back to the showing state.
+    private markPopupActive() {
       if (this.popupState !== 'active') {
         this.popupState = 'active';
         document.addEventListener('pointerdown', this.boundHandleOutsidePointerDown);
@@ -879,6 +869,45 @@ const isVertical = orientation === 'vertical';
           this.popupState = 'showing';
         }
       }, ACTIVE_SETTLE_DELAY);
+    }
+
+    private handlePopupButtonClick(event: Event) {
+      const target = (event.target as HTMLElement).closest<HTMLButtonElement>('[data-adjust]');
+      if (!target) return;
+      if (this.isDisabled || this.isReadonly) return;
+      if (target.getAttribute('aria-disabled') === 'true') return;
+
+      const adjustType = target.dataset.adjust;
+
+      if (this.collapsed) {
+        // Shrink direction is a no-op while collapsed (already at minimum).
+        if (adjustType !== 'increase' && adjustType !== 'maximize') return;
+        this.expandFromCollapsed();
+        if (adjustType === 'maximize') this.updatePosition(this.max);
+        this.markPopupActive();
+        return;
+      }
+
+      let targetPos: number;
+      switch (adjustType) {
+        case 'collapse':
+          targetPos = this.min;
+          break;
+        case 'decrease':
+          targetPos = this.currentPosition - this.step;
+          break;
+        case 'increase':
+          targetPos = this.currentPosition + this.step;
+          break;
+        case 'maximize':
+          targetPos = this.max;
+          break;
+        default:
+          return;
+      }
+
+      this.updatePosition(targetPos);
+      this.markPopupActive();
     }
 
     // Public method to update position programmatically

--- a/src/patterns/windowsplitter/WindowSplitter.svelte
+++ b/src/patterns/windowsplitter/WindowSplitter.svelte
@@ -116,8 +116,12 @@
 
   const splitterLabel = $derived((restProps['aria-label'] as string) || '');
 
-  const isAtMin = $derived(position <= min);
-  const isAtMax = $derived(position >= max);
+  // While collapsed the splitter sits below `min`, so the shrink direction is
+  // disabled (already minimal) and the expand direction stays enabled.
+  const shrinkDisabled = $derived(collapsed || position <= min);
+  const collapseDisabled = $derived(collapsed || position <= min);
+  const expandDisabled = $derived(!collapsed && position >= max);
+  const maxDisabled = $derived(!collapsed && position >= max);
 
   const icons = $derived(
     isVertical
@@ -238,13 +242,8 @@
     }
   }
 
-  // Handle popup button click
-  function handlePopupButtonClick(delta: number) {
-    if (disabled || readonly) return;
-    const currentPos = latestPosition;
-    const newPos = currentPos + delta;
-    if (newPos < min || newPos > max) return;
-    updatePosition(newPos);
+  // Mark the popup as actively adjusting, then settle back to the showing state.
+  function markPopupActive() {
     popupState = 'active';
     if (activeSettleTimer) clearTimeout(activeSettleTimer);
     activeSettleTimer = setTimeout(() => {
@@ -261,36 +260,73 @@
     }, ACTIVE_SETTLE_DELAY);
   }
 
+  // Expand from the collapsed state, restoring to the previous/expanded position.
+  // Shared by the collapse toggle, popup buttons and keyboard handlers.
+  function expandFromCollapsed() {
+    const currentPos = latestPosition;
+    const restorePosition = previousPosition ?? expandedPosition ?? defaultPosition ?? 50;
+    const clampedRestore = clamp(restorePosition, min, max);
+
+    oncollapsedchange?.(false, currentPos);
+    collapsed = false;
+    latestPosition = clampedRestore;
+    position = clampedRestore;
+
+    const sizeInPx = containerEl
+      ? (clampedRestore / 100) * (isHorizontal ? containerEl.offsetWidth : containerEl.offsetHeight)
+      : 0;
+    onpositionchange?.(clampedRestore, sizeInPx);
+  }
+
+  // Handle popup button (collapse / shrink / expand / maximize)
+  function handlePopupAdjust(kind: 'collapse' | 'shrink' | 'expand' | 'maximize') {
+    if (disabled || readonly) return;
+
+    if (collapsed) {
+      // Shrink direction is a no-op while collapsed (already at minimum).
+      if (kind === 'collapse' || kind === 'shrink') return;
+      expandFromCollapsed();
+      if (kind === 'maximize') updatePosition(max);
+      markPopupActive();
+      return;
+    }
+
+    const currentPos = latestPosition;
+    let target = currentPos;
+    switch (kind) {
+      case 'collapse':
+        target = min;
+        break;
+      case 'shrink':
+        target = currentPos - step;
+        break;
+      case 'expand':
+        target = currentPos + step;
+        break;
+      case 'maximize':
+        target = max;
+        break;
+    }
+    updatePosition(target);
+    markPopupActive();
+  }
+
   // Handle collapse/expand
   function handleToggleCollapse() {
     if (!collapsible || disabled || readonly) return;
 
-    const currentPos = latestPosition;
-
     if (collapsed) {
-      // Expand: restore to previous or fallback
-      const restorePosition = previousPosition ?? expandedPosition ?? defaultPosition ?? 50;
-      const clampedRestore = clamp(restorePosition, min, max);
-
-      oncollapsedchange?.(false, currentPos);
-      collapsed = false;
-      latestPosition = clampedRestore;
-      position = clampedRestore;
-
-      const sizeInPx = containerEl
-        ? (clampedRestore / 100) *
-          (isHorizontal ? containerEl.offsetWidth : containerEl.offsetHeight)
-        : 0;
-      onpositionchange?.(clampedRestore, sizeInPx);
-    } else {
-      // Collapse: save current position, set to 0
-      previousPosition = currentPos;
-      oncollapsedchange?.(true, currentPos);
-      collapsed = true;
-      latestPosition = 0;
-      position = 0;
-      onpositionchange?.(0, 0);
+      expandFromCollapsed();
+      return;
     }
+    // Collapse: save current position, set to 0
+    const currentPos = latestPosition;
+    previousPosition = currentPos;
+    oncollapsedchange?.(true, currentPos);
+    collapsed = true;
+    latestPosition = 0;
+    position = 0;
+    onpositionchange?.(0, 0);
   }
 
   // Keyboard handler
@@ -344,12 +380,17 @@
         break;
 
       case 'Home':
-        updatePosition(min);
+        // Shrink direction is a no-op while collapsed (already at minimum).
+        if (!collapsed) updatePosition(min);
         handled = true;
         break;
 
       case 'End':
-        updatePosition(max);
+        if (collapsed) {
+          expandFromCollapsed();
+        } else {
+          updatePosition(max);
+        }
         handled = true;
         break;
     }
@@ -357,7 +398,12 @@
     if (handled) {
       event.preventDefault();
       if (delta !== 0) {
-        updatePosition(latestPosition + delta);
+        if (collapsed) {
+          // Only the expand direction wakes a collapsed splitter; shrink is a no-op.
+          if (delta > 0) expandFromCollapsed();
+        } else {
+          updatePosition(latestPosition + delta);
+        }
       }
     }
   }
@@ -402,10 +448,10 @@
 
     if (!containerEl) return;
 
-    // Use demo container for stable measurement if available
-    const demoContainerElement = containerEl.closest('.apg-window-splitter-demo-container');
-    const demoContainer = demoContainerElement instanceof HTMLElement ? demoContainerElement : null;
-    const measureElement = demoContainer || containerEl.parentElement || containerEl;
+    // Measure the containing layout (the consumer positions the panes there).
+    // The visual update is driven solely by onpositionchange, keeping the
+    // component agnostic of how the consumer renders its panes.
+    const measureElement = containerEl.parentElement || containerEl;
     const rect = measureElement.getBoundingClientRect();
 
     let percent: number;
@@ -415,14 +461,6 @@
     } else {
       const y = event.clientY - rect.top;
       percent = (y / rect.height) * 100;
-    }
-
-    // Clamp the percent to min/max
-    const clampedPercent = clamp(percent, min, max);
-
-    // Update CSS variable directly for smooth dragging
-    if (demoContainer) {
-      demoContainer.style.setProperty('--splitter-position', `${clampedPercent}%`);
     }
 
     updatePosition(percent);
@@ -587,8 +625,8 @@
         class="apg-window-splitter__popup-button"
         tabindex={-1}
         aria-label={`Collapse ${splitterLabel}`}
-        aria-disabled={isAtMin}
-        onclick={() => !isAtMin && handlePopupButtonClick(min - latestPosition)}
+        aria-disabled={collapseDisabled}
+        onclick={() => !collapseDisabled && handlePopupAdjust('collapse')}
       >
         <svg
           width="12"
@@ -609,8 +647,8 @@
         class="apg-window-splitter__popup-button"
         tabindex={-1}
         aria-label={`Shrink ${splitterLabel}`}
-        aria-disabled={isAtMin}
-        onclick={() => !isAtMin && handlePopupButtonClick(-step)}
+        aria-disabled={shrinkDisabled}
+        onclick={() => !shrinkDisabled && handlePopupAdjust('shrink')}
       >
         <svg
           width="12"
@@ -631,8 +669,8 @@
         class="apg-window-splitter__popup-button"
         tabindex={-1}
         aria-label={`Expand ${splitterLabel}`}
-        aria-disabled={isAtMax}
-        onclick={() => !isAtMax && handlePopupButtonClick(step)}
+        aria-disabled={expandDisabled}
+        onclick={() => !expandDisabled && handlePopupAdjust('expand')}
       >
         <svg
           width="12"
@@ -653,8 +691,8 @@
         class="apg-window-splitter__popup-button"
         tabindex={-1}
         aria-label={`Expand ${splitterLabel} to maximum`}
-        aria-disabled={isAtMax}
-        onclick={() => !isAtMax && handlePopupButtonClick(max - latestPosition)}
+        aria-disabled={maxDisabled}
+        onclick={() => !maxDisabled && handlePopupAdjust('maximize')}
       >
         <svg
           width="12"

--- a/src/patterns/windowsplitter/WindowSplitter.test.astro.ts
+++ b/src/patterns/windowsplitter/WindowSplitter.test.astro.ts
@@ -120,61 +120,67 @@ describe('WindowSplitter (Web Component)', () => {
       );
     }
 
+    private expandFromCollapsed() {
+      if (!this.separator) return;
+
+      const restorePosition =
+        this.previousPosition ?? this.expandedPosition ?? this.defaultPosition ?? 50;
+      const clampedRestore = this.clamp(restorePosition);
+
+      this.dispatchEvent(
+        new CustomEvent('collapsedchange', {
+          detail: { collapsed: false, previousPosition: this.currentPosition },
+          bubbles: true,
+        })
+      );
+
+      this.collapsed = false;
+      this.separator.setAttribute('aria-valuenow', String(clampedRestore));
+
+      if (this.containerEl) {
+        this.containerEl.style.setProperty('--splitter-position', `${clampedRestore}%`);
+      }
+
+      this.dispatchEvent(
+        new CustomEvent('positionchange', {
+          detail: { position: clampedRestore },
+          bubbles: true,
+        })
+      );
+    }
+
     private handleToggleCollapse() {
       if (!this.isCollapsible || this.isDisabled || this.isReadonly) return;
       if (!this.separator) return;
 
       if (this.collapsed) {
-        // Expand
-        const restorePosition =
-          this.previousPosition ?? this.expandedPosition ?? this.defaultPosition ?? 50;
-        const clampedRestore = this.clamp(restorePosition);
-
-        this.dispatchEvent(
-          new CustomEvent('collapsedchange', {
-            detail: { collapsed: false, previousPosition: this.currentPosition },
-            bubbles: true,
-          })
-        );
-
-        this.collapsed = false;
-        this.separator.setAttribute('aria-valuenow', String(clampedRestore));
-
-        if (this.containerEl) {
-          this.containerEl.style.setProperty('--splitter-position', `${clampedRestore}%`);
-        }
-
-        this.dispatchEvent(
-          new CustomEvent('positionchange', {
-            detail: { position: clampedRestore },
-            bubbles: true,
-          })
-        );
-      } else {
-        // Collapse
-        this.previousPosition = this.currentPosition;
-
-        this.dispatchEvent(
-          new CustomEvent('collapsedchange', {
-            detail: { collapsed: true, previousPosition: this.currentPosition },
-            bubbles: true,
-          })
-        );
-
-        this.collapsed = true;
-        this.separator.setAttribute('aria-valuenow', '0');
-
-        if (this.containerEl) {
-          this.containerEl.style.setProperty('--splitter-position', '0%');
-        }
-
-        this.dispatchEvent(
-          new CustomEvent('positionchange', {
-            detail: { position: 0, sizeInPx: 0 },
-            bubbles: true,
-          })
-        );
+        this.expandFromCollapsed();
+        return;
       }
+
+      // Collapse
+      this.previousPosition = this.currentPosition;
+
+      this.dispatchEvent(
+        new CustomEvent('collapsedchange', {
+          detail: { collapsed: true, previousPosition: this.currentPosition },
+          bubbles: true,
+        })
+      );
+
+      this.collapsed = true;
+      this.separator.setAttribute('aria-valuenow', '0');
+
+      if (this.containerEl) {
+        this.containerEl.style.setProperty('--splitter-position', '0%');
+      }
+
+      this.dispatchEvent(
+        new CustomEvent('positionchange', {
+          detail: { position: 0, sizeInPx: 0 },
+          bubbles: true,
+        })
+      );
     }
 
     private handleKeyDown(event: KeyboardEvent) {
@@ -217,12 +223,17 @@ describe('WindowSplitter (Web Component)', () => {
           break;
 
         case 'Home':
-          this.updatePosition(this.min);
+          // Shrink direction is a no-op while collapsed (already at minimum).
+          if (!this.collapsed) this.updatePosition(this.min);
           handled = true;
           break;
 
         case 'End':
-          this.updatePosition(this.max);
+          if (this.collapsed) {
+            this.expandFromCollapsed();
+          } else {
+            this.updatePosition(this.max);
+          }
           handled = true;
           break;
       }
@@ -230,7 +241,12 @@ describe('WindowSplitter (Web Component)', () => {
       if (handled) {
         event.preventDefault();
         if (delta !== 0) {
-          this.updatePosition(this.currentPosition + delta);
+          if (this.collapsed) {
+            // Only the expand direction wakes a collapsed splitter; shrink is a no-op.
+            if (delta > 0) this.expandFromCollapsed();
+          } else {
+            this.updatePosition(this.currentPosition + delta);
+          }
         }
       }
     }
@@ -597,6 +613,34 @@ describe('WindowSplitter (Web Component)', () => {
       pressKey(separator, 'Enter');
 
       expect(separator.getAttribute('aria-valuenow')).toBe('50');
+    });
+
+    it('expands to expandedPosition via an expand-direction arrow key while collapsed', async () => {
+      container.innerHTML = createSplitterHTML({ collapsed: true, expandedPosition: 50 });
+      const element = container.querySelector('apg-window-splitter') as TestApgWindowSplitter;
+      await customElements.whenDefined('apg-window-splitter');
+      element.connectedCallback();
+
+      const separator = element._separator!;
+      expect(separator.getAttribute('aria-valuenow')).toBe('0');
+
+      pressKey(separator, 'ArrowRight');
+
+      expect(separator.getAttribute('aria-valuenow')).toBe('50');
+      expect(element._collapsed).toBe(false);
+    });
+
+    it('ignores a shrink-direction arrow key while collapsed', async () => {
+      container.innerHTML = createSplitterHTML({ collapsed: true, expandedPosition: 50 });
+      const element = container.querySelector('apg-window-splitter') as TestApgWindowSplitter;
+      await customElements.whenDefined('apg-window-splitter');
+      element.connectedCallback();
+
+      const separator = element._separator!;
+      pressKey(separator, 'ArrowLeft');
+
+      expect(separator.getAttribute('aria-valuenow')).toBe('0');
+      expect(element._collapsed).toBe(true);
     });
   });
 

--- a/src/patterns/windowsplitter/WindowSplitter.test.svelte.ts
+++ b/src/patterns/windowsplitter/WindowSplitter.test.svelte.ts
@@ -476,6 +476,134 @@ describe('WindowSplitter (Svelte)', () => {
     });
   });
 
+  // 🔴 High Priority: Operating the separator while collapsed
+  describe('Operating the separator while collapsed', () => {
+    it('expands to expandedPosition via the Expand popup button and un-collapses', async () => {
+      const user = userEvent.setup();
+      let capturedCollapsed: boolean | undefined;
+      let capturedPreviousPosition: number | undefined;
+      render(WindowSplitter, {
+        props: {
+          primaryPaneId: 'primary',
+          defaultCollapsed: true,
+          expandedPosition: 50,
+          'aria-label': 'Resize panels',
+          oncollapsedchange: (collapsed: boolean, prevPos: number) => {
+            capturedCollapsed = collapsed;
+            capturedPreviousPosition = prevPos;
+          },
+        },
+      });
+      const separator = screen.getByRole('separator');
+      expect(separator).toHaveAttribute('aria-valuenow', '0');
+
+      await user.click(screen.getByRole('button', { name: 'Expand Resize panels' }));
+
+      expect(separator).toHaveAttribute('aria-valuenow', '50');
+      expect(capturedCollapsed).toBe(false);
+      expect(capturedPreviousPosition).toBe(0);
+    });
+
+    it('expands straight to max via the Maximize popup button while collapsed', async () => {
+      const user = userEvent.setup();
+      render(WindowSplitter, {
+        props: {
+          primaryPaneId: 'primary',
+          defaultCollapsed: true,
+          expandedPosition: 50,
+          max: 90,
+          'aria-label': 'Resize panels',
+        },
+      });
+      const separator = screen.getByRole('separator');
+
+      await user.click(screen.getByRole('button', { name: 'Expand Resize panels to maximum' }));
+
+      expect(separator).toHaveAttribute('aria-valuenow', '90');
+    });
+
+    it('expands via an expand-direction arrow key while collapsed', async () => {
+      const user = userEvent.setup();
+      render(WindowSplitter, {
+        props: {
+          primaryPaneId: 'primary',
+          defaultCollapsed: true,
+          expandedPosition: 50,
+          'aria-label': 'Resize panels',
+        },
+      });
+      const separator = screen.getByRole('separator');
+
+      await user.click(separator);
+      await user.keyboard('{ArrowRight}');
+
+      expect(separator).toHaveAttribute('aria-valuenow', '50');
+    });
+
+    it('ignores a shrink-direction arrow key while collapsed', async () => {
+      const user = userEvent.setup();
+      render(WindowSplitter, {
+        props: {
+          primaryPaneId: 'primary',
+          defaultCollapsed: true,
+          expandedPosition: 50,
+          'aria-label': 'Resize panels',
+        },
+      });
+      const separator = screen.getByRole('separator');
+
+      await user.click(separator);
+      await user.keyboard('{ArrowLeft}');
+
+      expect(separator).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('disables the Collapse and Shrink buttons while collapsed, keeps expand enabled', () => {
+      render(WindowSplitter, {
+        props: {
+          primaryPaneId: 'primary',
+          defaultCollapsed: true,
+          expandedPosition: 50,
+          'aria-label': 'Resize panels',
+        },
+      });
+
+      expect(screen.getByRole('button', { name: 'Collapse Resize panels' })).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
+      expect(screen.getByRole('button', { name: 'Shrink Resize panels' })).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
+      expect(screen.getByRole('button', { name: 'Expand Resize panels' })).toHaveAttribute(
+        'aria-disabled',
+        'false'
+      );
+      expect(
+        screen.getByRole('button', { name: 'Expand Resize panels to maximum' })
+      ).toHaveAttribute('aria-disabled', 'false');
+    });
+
+    it('clamps to max when an Expand step would overshoot (no silent reject)', async () => {
+      const user = userEvent.setup();
+      render(WindowSplitter, {
+        props: {
+          primaryPaneId: 'primary',
+          defaultPosition: 88,
+          step: 5,
+          max: 90,
+          'aria-label': 'Resize panels',
+        },
+      });
+      const separator = screen.getByRole('separator');
+
+      await user.click(screen.getByRole('button', { name: 'Expand Resize panels' }));
+
+      expect(separator).toHaveAttribute('aria-valuenow', '90');
+    });
+  });
+
   // 🔴 High Priority: Keyboard Interaction - Home/End
   describe('Keyboard Interaction - Home/End', () => {
     it('sets min value on Home', async () => {

--- a/src/patterns/windowsplitter/WindowSplitter.test.tsx
+++ b/src/patterns/windowsplitter/WindowSplitter.test.tsx
@@ -445,6 +445,129 @@ describe('WindowSplitter', () => {
     });
   });
 
+  // 🔴 High Priority: Operating the separator while collapsed
+  describe('Operating the separator while collapsed', () => {
+    it('expands to expandedPosition via the Expand popup button and un-collapses', async () => {
+      const user = userEvent.setup();
+      const handleCollapse = vi.fn();
+      render(
+        <WindowSplitter
+          primaryPaneId="primary"
+          defaultCollapsed
+          expandedPosition={50}
+          onCollapsedChange={handleCollapse}
+          aria-label="Resize panels"
+        />
+      );
+      const splitter = screen.getByRole('separator');
+      expect(splitter).toHaveAttribute('aria-valuenow', '0');
+
+      await user.click(screen.getByRole('button', { name: 'Expand Resize panels' }));
+
+      expect(splitter).toHaveAttribute('aria-valuenow', '50');
+      expect(handleCollapse).toHaveBeenCalledWith(false, 0);
+    });
+
+    it('expands straight to max via the Maximize popup button while collapsed', async () => {
+      const user = userEvent.setup();
+      render(
+        <WindowSplitter
+          primaryPaneId="primary"
+          defaultCollapsed
+          expandedPosition={50}
+          max={90}
+          aria-label="Resize panels"
+        />
+      );
+      const splitter = screen.getByRole('separator');
+
+      await user.click(screen.getByRole('button', { name: 'Expand Resize panels to maximum' }));
+
+      expect(splitter).toHaveAttribute('aria-valuenow', '90');
+    });
+
+    it('expands via an expand-direction arrow key while collapsed', async () => {
+      const user = userEvent.setup();
+      render(
+        <WindowSplitter
+          primaryPaneId="primary"
+          defaultCollapsed
+          expandedPosition={50}
+          aria-label="Resize panels"
+        />
+      );
+      const splitter = screen.getByRole('separator');
+
+      await user.click(splitter);
+      await user.keyboard('{ArrowRight}');
+
+      expect(splitter).toHaveAttribute('aria-valuenow', '50');
+    });
+
+    it('ignores a shrink-direction arrow key while collapsed', async () => {
+      const user = userEvent.setup();
+      render(
+        <WindowSplitter
+          primaryPaneId="primary"
+          defaultCollapsed
+          expandedPosition={50}
+          aria-label="Resize panels"
+        />
+      );
+      const splitter = screen.getByRole('separator');
+
+      await user.click(splitter);
+      await user.keyboard('{ArrowLeft}');
+
+      expect(splitter).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('disables the Collapse and Shrink buttons while collapsed, keeps expand enabled', () => {
+      render(
+        <WindowSplitter
+          primaryPaneId="primary"
+          defaultCollapsed
+          expandedPosition={50}
+          aria-label="Resize panels"
+        />
+      );
+
+      expect(screen.getByRole('button', { name: 'Collapse Resize panels' })).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
+      expect(screen.getByRole('button', { name: 'Shrink Resize panels' })).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
+      expect(screen.getByRole('button', { name: 'Expand Resize panels' })).toHaveAttribute(
+        'aria-disabled',
+        'false'
+      );
+      expect(
+        screen.getByRole('button', { name: 'Expand Resize panels to maximum' })
+      ).toHaveAttribute('aria-disabled', 'false');
+    });
+
+    it('clamps to max when an Expand step would overshoot (no silent reject)', async () => {
+      const user = userEvent.setup();
+      render(
+        <WindowSplitter
+          primaryPaneId="primary"
+          defaultPosition={88}
+          step={5}
+          max={90}
+          aria-label="Resize panels"
+        />
+      );
+      const splitter = screen.getByRole('separator');
+
+      await user.click(screen.getByRole('button', { name: 'Expand Resize panels' }));
+
+      expect(splitter).toHaveAttribute('aria-valuenow', '90');
+    });
+  });
+
   // 🔴 High Priority: Keyboard Interaction - Home/End
   describe('Keyboard Interaction - Home/End', () => {
     it('sets min value on Home', async () => {

--- a/src/patterns/windowsplitter/WindowSplitter.test.vue.ts
+++ b/src/patterns/windowsplitter/WindowSplitter.test.vue.ts
@@ -478,6 +478,101 @@ describe('WindowSplitter (Vue)', () => {
     });
   });
 
+  // 🔴 High Priority: Operating the separator while collapsed
+  describe('Operating the separator while collapsed', () => {
+    it('expands to expandedPosition via the Expand popup button and un-collapses', async () => {
+      const user = userEvent.setup();
+      const { emitted } = render(WindowSplitter, {
+        props: { primaryPaneId: 'primary', defaultCollapsed: true, expandedPosition: 50 },
+        attrs: { 'aria-label': 'Resize panels' },
+      });
+      const separator = screen.getByRole('separator');
+      expect(separator).toHaveAttribute('aria-valuenow', '0');
+
+      await user.click(screen.getByRole('button', { name: 'Expand Resize panels' }));
+
+      expect(separator).toHaveAttribute('aria-valuenow', '50');
+      expect(emitted().collapsedChange).toContainEqual([false, 0]);
+    });
+
+    it('expands straight to max via the Maximize popup button while collapsed', async () => {
+      const user = userEvent.setup();
+      render(WindowSplitter, {
+        props: { primaryPaneId: 'primary', defaultCollapsed: true, expandedPosition: 50, max: 90 },
+        attrs: { 'aria-label': 'Resize panels' },
+      });
+      const separator = screen.getByRole('separator');
+
+      await user.click(screen.getByRole('button', { name: 'Expand Resize panels to maximum' }));
+
+      expect(separator).toHaveAttribute('aria-valuenow', '90');
+    });
+
+    it('expands via an expand-direction arrow key while collapsed', async () => {
+      const user = userEvent.setup();
+      render(WindowSplitter, {
+        props: { primaryPaneId: 'primary', defaultCollapsed: true, expandedPosition: 50 },
+        attrs: { 'aria-label': 'Resize panels' },
+      });
+      const separator = screen.getByRole('separator');
+
+      await user.click(separator);
+      await user.keyboard('{ArrowRight}');
+
+      expect(separator).toHaveAttribute('aria-valuenow', '50');
+    });
+
+    it('ignores a shrink-direction arrow key while collapsed', async () => {
+      const user = userEvent.setup();
+      render(WindowSplitter, {
+        props: { primaryPaneId: 'primary', defaultCollapsed: true, expandedPosition: 50 },
+        attrs: { 'aria-label': 'Resize panels' },
+      });
+      const separator = screen.getByRole('separator');
+
+      await user.click(separator);
+      await user.keyboard('{ArrowLeft}');
+
+      expect(separator).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('disables the Collapse and Shrink buttons while collapsed, keeps expand enabled', () => {
+      render(WindowSplitter, {
+        props: { primaryPaneId: 'primary', defaultCollapsed: true, expandedPosition: 50 },
+        attrs: { 'aria-label': 'Resize panels' },
+      });
+
+      expect(screen.getByRole('button', { name: 'Collapse Resize panels' })).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
+      expect(screen.getByRole('button', { name: 'Shrink Resize panels' })).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
+      expect(screen.getByRole('button', { name: 'Expand Resize panels' })).toHaveAttribute(
+        'aria-disabled',
+        'false'
+      );
+      expect(
+        screen.getByRole('button', { name: 'Expand Resize panels to maximum' })
+      ).toHaveAttribute('aria-disabled', 'false');
+    });
+
+    it('clamps to max when an Expand step would overshoot (no silent reject)', async () => {
+      const user = userEvent.setup();
+      render(WindowSplitter, {
+        props: { primaryPaneId: 'primary', defaultPosition: 88, step: 5, max: 90 },
+        attrs: { 'aria-label': 'Resize panels' },
+      });
+      const separator = screen.getByRole('separator');
+
+      await user.click(screen.getByRole('button', { name: 'Expand Resize panels' }));
+
+      expect(separator).toHaveAttribute('aria-valuenow', '90');
+    });
+  });
+
   // 🔴 High Priority: Keyboard Interaction - Home/End
   describe('Keyboard Interaction - Home/End', () => {
     it('sets min value on Home', async () => {

--- a/src/patterns/windowsplitter/WindowSplitter.tsx
+++ b/src/patterns/windowsplitter/WindowSplitter.tsx
@@ -241,68 +241,116 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
     [min, max, isHorizontal, onPositionChange]
   );
 
-  const handlePopupButtonClick = useCallback(
-    (delta: number) => {
-      if (disabled || readonly) return;
-      const currentPos = positionRef.current;
-      const newPos = currentPos + delta;
-      if (newPos < min || newPos > max) return;
-      updatePosition(newPos);
-      setPopupState('active');
-      if (activeSettleTimerRef.current) clearTimeout(activeSettleTimerRef.current);
-      activeSettleTimerRef.current = setTimeout(() => {
-        setPopupState((prev) => {
-          if (prev === 'active') {
-            if (!isMouseOverPopupRef.current) {
-              const pos = hoverPosRef.current;
-              if (pos) {
-                const newPopupPos = calcPopupPosition(pos.x, pos.y);
-                if (newPopupPos) setPopupPos(newPopupPos);
-              }
+  const markPopupActive = useCallback(() => {
+    setPopupState('active');
+    if (activeSettleTimerRef.current) clearTimeout(activeSettleTimerRef.current);
+    activeSettleTimerRef.current = setTimeout(() => {
+      setPopupState((prev) => {
+        if (prev === 'active') {
+          if (!isMouseOverPopupRef.current) {
+            const pos = hoverPosRef.current;
+            if (pos) {
+              const newPopupPos = calcPopupPosition(pos.x, pos.y);
+              if (newPopupPos) setPopupPos(newPopupPos);
             }
-            return 'showing';
           }
-          return prev;
-        });
-      }, ACTIVE_SETTLE_DELAY);
-    },
-    [disabled, readonly, min, max, updatePosition, calcPopupPosition]
-  );
+          return 'showing';
+        }
+        return prev;
+      });
+    }, ACTIVE_SETTLE_DELAY);
+  }, [calcPopupPosition]);
 
-  const handleToggleCollapse = useCallback(() => {
-    if (!collapsible || disabled || readonly) return;
+  // Expand from the collapsed state, restoring to the previous/expanded position.
+  // Shared by the collapse toggle, popup buttons and keyboard handlers.
+  const expandFromCollapsed = useCallback(() => {
     const currentPos = positionRef.current;
-    if (collapsed) {
-      const restorePosition =
-        previousPositionRef.current ?? expandedPosition ?? defaultPosition ?? 50;
-      const clampedRestore = clamp(restorePosition, min, max);
-      onCollapsedChange?.(false, currentPos);
-      setCollapsed(false);
-      positionRef.current = clampedRestore;
-      setPosition(clampedRestore);
-      const container = containerRef.current;
-      const sizeInPx = container
-        ? (clampedRestore / 100) * (isHorizontal ? container.offsetWidth : container.offsetHeight)
-        : 0;
-      onPositionChange?.(clampedRestore, sizeInPx);
-    } else {
-      previousPositionRef.current = currentPos;
-      onCollapsedChange?.(true, currentPos);
-      setCollapsed(true);
-      positionRef.current = 0;
-      setPosition(0);
-      onPositionChange?.(0, 0);
-    }
+    const restorePosition =
+      previousPositionRef.current ?? expandedPosition ?? defaultPosition ?? 50;
+    const clampedRestore = clamp(restorePosition, min, max);
+    onCollapsedChange?.(false, currentPos);
+    setCollapsed(false);
+    positionRef.current = clampedRestore;
+    setPosition(clampedRestore);
+    const container = containerRef.current;
+    const sizeInPx = container
+      ? (clampedRestore / 100) * (isHorizontal ? container.offsetWidth : container.offsetHeight)
+      : 0;
+    onPositionChange?.(clampedRestore, sizeInPx);
   }, [
-    collapsed,
-    collapsible,
-    disabled,
-    readonly,
     expandedPosition,
     defaultPosition,
     min,
     max,
     isHorizontal,
+    onCollapsedChange,
+    onPositionChange,
+  ]);
+
+  const handlePopupAdjust = useCallback(
+    (kind: 'collapse' | 'shrink' | 'expand' | 'maximize') => {
+      if (disabled || readonly) return;
+
+      if (collapsed) {
+        // Shrink direction is a no-op while collapsed (already at minimum).
+        if (kind === 'collapse' || kind === 'shrink') return;
+        expandFromCollapsed();
+        if (kind === 'maximize') updatePosition(max);
+        markPopupActive();
+        return;
+      }
+
+      const currentPos = positionRef.current;
+      let target = currentPos;
+      switch (kind) {
+        case 'collapse':
+          target = min;
+          break;
+        case 'shrink':
+          target = currentPos - step;
+          break;
+        case 'expand':
+          target = currentPos + step;
+          break;
+        case 'maximize':
+          target = max;
+          break;
+      }
+      updatePosition(target);
+      markPopupActive();
+    },
+    [
+      disabled,
+      readonly,
+      collapsed,
+      expandFromCollapsed,
+      updatePosition,
+      markPopupActive,
+      min,
+      max,
+      step,
+    ]
+  );
+
+  const handleToggleCollapse = useCallback(() => {
+    if (!collapsible || disabled || readonly) return;
+    if (collapsed) {
+      expandFromCollapsed();
+      return;
+    }
+    const currentPos = positionRef.current;
+    previousPositionRef.current = currentPos;
+    onCollapsedChange?.(true, currentPos);
+    setCollapsed(true);
+    positionRef.current = 0;
+    setPosition(0);
+    onPositionChange?.(0, 0);
+  }, [
+    collapsed,
+    collapsible,
+    disabled,
+    readonly,
+    expandFromCollapsed,
     onCollapsedChange,
     onPositionChange,
   ]);
@@ -357,12 +405,17 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
           break;
 
         case 'Home':
-          updatePosition(min);
+          // Shrink direction is a no-op while collapsed (already at minimum).
+          if (!collapsed) updatePosition(min);
           handled = true;
           break;
 
         case 'End':
-          updatePosition(max);
+          if (collapsed) {
+            expandFromCollapsed();
+          } else {
+            updatePosition(max);
+          }
           handled = true;
           break;
       }
@@ -370,7 +423,12 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
       if (handled) {
         event.preventDefault();
         if (delta !== 0) {
-          updatePosition(positionRef.current + delta);
+          if (collapsed) {
+            // Only the expand direction wakes a collapsed splitter; shrink is a no-op.
+            if (delta > 0) expandFromCollapsed();
+          } else {
+            updatePosition(positionRef.current + delta);
+          }
         }
       }
     },
@@ -378,6 +436,8 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
       disabled,
       readonly,
       popupState,
+      collapsed,
+      expandFromCollapsed,
       isHorizontal,
       isVertical,
       isRTL,
@@ -434,10 +494,10 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
       const container = containerRef.current;
       if (!container) return;
 
-      const demoContainerElement = container.closest('.apg-window-splitter-demo-container');
-      const demoContainer =
-        demoContainerElement instanceof HTMLElement ? demoContainerElement : null;
-      const measureElement = demoContainer || container.parentElement || container;
+      // Measure the containing layout (the consumer positions the panes there).
+      // The visual update is driven solely by onPositionChange, keeping the
+      // component agnostic of how the consumer renders its panes.
+      const measureElement = container.parentElement || container;
       const rect = measureElement.getBoundingClientRect();
 
       let percent: number;
@@ -449,13 +509,9 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
         percent = (y / rect.height) * 100;
       }
 
-      const clampedPercent = clamp(percent, min, max);
-      if (demoContainer) {
-        demoContainer.style.setProperty('--splitter-position', `${clampedPercent}%`);
-      }
       updatePosition(percent);
     },
-    [isHorizontal, min, max, updatePosition, popupState, hidePopup]
+    [isHorizontal, updatePosition, popupState, hidePopup]
   );
 
   const handlePointerUp = useCallback(
@@ -569,8 +625,12 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
 
   const ariaControls = secondaryPaneId ? `${primaryPaneId} ${secondaryPaneId}` : primaryPaneId;
 
-  const isAtMin = position <= min;
-  const isAtMax = position >= max;
+  // While collapsed the splitter sits below `min`, so the shrink direction is
+  // disabled (already minimal) and the expand direction stays enabled.
+  const shrinkDisabled = collapsed || position <= min;
+  const collapseDisabled = collapsed || position <= min;
+  const expandDisabled = !collapsed && position >= max;
+  const maxDisabled = !collapsed && position >= max;
 
   return (
     <div
@@ -638,8 +698,8 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
             className="apg-window-splitter__popup-button"
             tabIndex={-1}
             aria-label={`Collapse ${splitterLabel}`}
-            aria-disabled={isAtMin}
-            onClick={() => !isAtMin && handlePopupButtonClick(min - positionRef.current)}
+            aria-disabled={collapseDisabled}
+            onClick={() => !collapseDisabled && handlePopupAdjust('collapse')}
           >
             <ChevronIcon {...icons.collapse} />
           </button>
@@ -648,8 +708,8 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
             className="apg-window-splitter__popup-button"
             tabIndex={-1}
             aria-label={`Shrink ${splitterLabel}`}
-            aria-disabled={isAtMin}
-            onClick={() => !isAtMin && handlePopupButtonClick(-step)}
+            aria-disabled={shrinkDisabled}
+            onClick={() => !shrinkDisabled && handlePopupAdjust('shrink')}
           >
             <ChevronIcon {...icons.shrink} />
           </button>
@@ -658,8 +718,8 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
             className="apg-window-splitter__popup-button"
             tabIndex={-1}
             aria-label={`Expand ${splitterLabel}`}
-            aria-disabled={isAtMax}
-            onClick={() => !isAtMax && handlePopupButtonClick(step)}
+            aria-disabled={expandDisabled}
+            onClick={() => !expandDisabled && handlePopupAdjust('expand')}
           >
             <ChevronIcon {...icons.expand} />
           </button>
@@ -668,8 +728,8 @@ export const WindowSplitter: React.FC<WindowSplitterProps> = ({
             className="apg-window-splitter__popup-button"
             tabIndex={-1}
             aria-label={`Expand ${splitterLabel} to maximum`}
-            aria-disabled={isAtMax}
-            onClick={() => !isAtMax && handlePopupButtonClick(max - positionRef.current)}
+            aria-disabled={maxDisabled}
+            onClick={() => !maxDisabled && handlePopupAdjust('maximize')}
           >
             <ChevronIcon {...icons.max} />
           </button>

--- a/src/patterns/windowsplitter/WindowSplitter.vue
+++ b/src/patterns/windowsplitter/WindowSplitter.vue
@@ -62,8 +62,8 @@
         class="apg-window-splitter__popup-button"
         :tabindex="-1"
         :aria-label="`Collapse ${splitterLabel}`"
-        :aria-disabled="isAtMin"
-        @click="!isAtMin && handlePopupButtonClick(props.min - positionLocal)"
+        :aria-disabled="collapseDisabled"
+        @click="!collapseDisabled && handlePopupAdjust('collapse')"
       >
         <svg
           width="12"
@@ -85,8 +85,8 @@
         class="apg-window-splitter__popup-button"
         :tabindex="-1"
         :aria-label="`Shrink ${splitterLabel}`"
-        :aria-disabled="isAtMin"
-        @click="!isAtMin && handlePopupButtonClick(-step)"
+        :aria-disabled="shrinkDisabled"
+        @click="!shrinkDisabled && handlePopupAdjust('shrink')"
       >
         <svg
           width="12"
@@ -108,8 +108,8 @@
         class="apg-window-splitter__popup-button"
         :tabindex="-1"
         :aria-label="`Expand ${splitterLabel}`"
-        :aria-disabled="isAtMax"
-        @click="!isAtMax && handlePopupButtonClick(step)"
+        :aria-disabled="expandDisabled"
+        @click="!expandDisabled && handlePopupAdjust('expand')"
       >
         <svg
           width="12"
@@ -131,8 +131,8 @@
         class="apg-window-splitter__popup-button"
         :tabindex="-1"
         :aria-label="`Expand ${splitterLabel} to maximum`"
-        :aria-disabled="isAtMax"
-        @click="!isAtMax && handlePopupButtonClick(props.max - positionLocal)"
+        :aria-disabled="maxDisabled"
+        @click="!maxDisabled && handlePopupAdjust('maximize')"
       >
         <svg
           width="12"
@@ -278,8 +278,12 @@ const splitterLabel = computed(() => {
   return typeof label === 'string' ? label : '';
 });
 
-const isAtMin = computed(() => position.value <= props.min);
-const isAtMax = computed(() => position.value >= props.max);
+// While collapsed the splitter sits below `min`, so the shrink direction is
+// disabled (already minimal) and the expand direction stays enabled.
+const shrinkDisabled = computed(() => collapsed.value || position.value <= props.min);
+const collapseDisabled = computed(() => collapsed.value || position.value <= props.min);
+const expandDisabled = computed(() => !collapsed.value && position.value >= props.max);
+const maxDisabled = computed(() => !collapsed.value && position.value >= props.max);
 
 const icons = computed(() =>
   isVertical.value
@@ -402,13 +406,8 @@ const updatePosition = (newPosition: number) => {
   }
 };
 
-// Popup button click handler
-const handlePopupButtonClick = (delta: number) => {
-  if (props.disabled || props.readonly) return;
-  const currentPos = positionLocal;
-  const newPos = currentPos + delta;
-  if (newPos < props.min || newPos > props.max) return;
-  updatePosition(newPos);
+// Mark the popup as actively adjusting, then settle back to the showing state.
+const markPopupActive = () => {
   popupState.value = 'active';
   if (activeSettleTimer) clearTimeout(activeSettleTimer);
   activeSettleTimer = setTimeout(() => {
@@ -425,36 +424,73 @@ const handlePopupButtonClick = (delta: number) => {
   }, ACTIVE_SETTLE_DELAY);
 };
 
+// Expand from the collapsed state, restoring to the previous/expanded position.
+// Shared by the collapse toggle, popup buttons and keyboard handlers.
+const expandFromCollapsed = () => {
+  const restorePosition =
+    previousPosition.value ?? props.expandedPosition ?? props.defaultPosition ?? 50;
+  const clampedRestore = clamp(restorePosition, props.min, props.max);
+
+  emit('collapsedChange', false, position.value);
+  collapsed.value = false;
+  positionLocal = clampedRestore;
+  position.value = clampedRestore;
+
+  const container = containerRef.value;
+  const sizeInPx = container
+    ? (clampedRestore / 100) * (isHorizontal.value ? container.offsetWidth : container.offsetHeight)
+    : 0;
+  emit('positionChange', clampedRestore, sizeInPx);
+};
+
+// Popup button handler (collapse / shrink / expand / maximize)
+const handlePopupAdjust = (kind: 'collapse' | 'shrink' | 'expand' | 'maximize') => {
+  if (props.disabled || props.readonly) return;
+
+  if (collapsed.value) {
+    // Shrink direction is a no-op while collapsed (already at minimum).
+    if (kind === 'collapse' || kind === 'shrink') return;
+    expandFromCollapsed();
+    if (kind === 'maximize') updatePosition(props.max);
+    markPopupActive();
+    return;
+  }
+
+  const currentPos = positionLocal;
+  let target = currentPos;
+  switch (kind) {
+    case 'collapse':
+      target = props.min;
+      break;
+    case 'shrink':
+      target = currentPos - props.step;
+      break;
+    case 'expand':
+      target = currentPos + props.step;
+      break;
+    case 'maximize':
+      target = props.max;
+      break;
+  }
+  updatePosition(target);
+  markPopupActive();
+};
+
 // Handle collapse/expand
 const handleToggleCollapse = () => {
   if (!props.collapsible || props.disabled || props.readonly) return;
 
   if (collapsed.value) {
-    // Expand: restore to previous or fallback
-    const restorePosition =
-      previousPosition.value ?? props.expandedPosition ?? props.defaultPosition ?? 50;
-    const clampedRestore = clamp(restorePosition, props.min, props.max);
-
-    emit('collapsedChange', false, position.value);
-    collapsed.value = false;
-    positionLocal = clampedRestore;
-    position.value = clampedRestore;
-
-    const container = containerRef.value;
-    const sizeInPx = container
-      ? (clampedRestore / 100) *
-        (isHorizontal.value ? container.offsetWidth : container.offsetHeight)
-      : 0;
-    emit('positionChange', clampedRestore, sizeInPx);
-  } else {
-    // Collapse: save current position, set to 0
-    previousPosition.value = position.value;
-    emit('collapsedChange', true, position.value);
-    collapsed.value = true;
-    positionLocal = 0;
-    position.value = 0;
-    emit('positionChange', 0, 0);
+    expandFromCollapsed();
+    return;
   }
+  // Collapse: save current position, set to 0
+  previousPosition.value = position.value;
+  emit('collapsedChange', true, position.value);
+  collapsed.value = true;
+  positionLocal = 0;
+  position.value = 0;
+  emit('positionChange', 0, 0);
 };
 
 // Keyboard handler
@@ -508,12 +544,17 @@ const handleKeyDown = (event: KeyboardEvent) => {
       break;
 
     case 'Home':
-      updatePosition(props.min);
+      // Shrink direction is a no-op while collapsed (already at minimum).
+      if (!collapsed.value) updatePosition(props.min);
       handled = true;
       break;
 
     case 'End':
-      updatePosition(props.max);
+      if (collapsed.value) {
+        expandFromCollapsed();
+      } else {
+        updatePosition(props.max);
+      }
       handled = true;
       break;
   }
@@ -521,7 +562,12 @@ const handleKeyDown = (event: KeyboardEvent) => {
   if (handled) {
     event.preventDefault();
     if (delta !== 0) {
-      updatePosition(positionLocal + delta);
+      if (collapsed.value) {
+        // Only the expand direction wakes a collapsed splitter; shrink is a no-op.
+        if (delta > 0) expandFromCollapsed();
+      } else {
+        updatePosition(positionLocal + delta);
+      }
     }
   }
 };
@@ -568,10 +614,10 @@ const handlePointerMove = (event: PointerEvent) => {
   const container = containerRef.value;
   if (!container) return;
 
-  // Use demo container for stable measurement if available
-  const demoContainerElement = container.closest('.apg-window-splitter-demo-container');
-  const demoContainer = demoContainerElement instanceof HTMLElement ? demoContainerElement : null;
-  const measureElement = demoContainer || container.parentElement || container;
+  // Measure the containing layout (the consumer positions the panes there).
+  // The visual update is driven solely by position-change, keeping the
+  // component agnostic of how the consumer renders its panes.
+  const measureElement = container.parentElement || container;
   const rect = measureElement.getBoundingClientRect();
 
   let percent: number;
@@ -582,14 +628,6 @@ const handlePointerMove = (event: PointerEvent) => {
     const y = event.clientY - rect.top;
     // For vertical, y position corresponds to primary pane height
     percent = (y / rect.height) * 100;
-  }
-
-  // Clamp the percent to min/max
-  const clampedPercent = clamp(percent, props.min, props.max);
-
-  // Update CSS variable directly for smooth dragging
-  if (demoContainer) {
-    demoContainer.style.setProperty('--splitter-position', `${clampedPercent}%`);
   }
 
   updatePosition(percent);

--- a/src/patterns/windowsplitter/WindowSplitterDemo.svelte
+++ b/src/patterns/windowsplitter/WindowSplitterDemo.svelte
@@ -5,6 +5,7 @@
   let verticalPosition = $state(50);
   let horizontalCollapsed = $state(false);
   let verticalCollapsed = $state(false);
+  let collapsedPosition = $state(0);
 </script>
 
 <div class="apg-window-splitter-demo-wrapper">
@@ -159,7 +160,7 @@
     <div
       class="apg-window-splitter-demo-container"
       data-testid="collapsed-demo"
-      style="--splitter-position: 0%"
+      style="--splitter-position: {collapsedPosition}%"
     >
       <div class="apg-window-splitter-pane" id="collapsed-primary">
         <div class="apg-window-splitter-pane-content">Primary Pane</div>
@@ -171,6 +172,7 @@
         data-testid="collapsed-splitter"
         defaultCollapsed={true}
         expandedPosition={50}
+        onpositionchange={(pos) => (collapsedPosition = pos)}
       />
       <div class="apg-window-splitter-pane" id="collapsed-secondary">
         <div class="apg-window-splitter-pane-content">Secondary Pane</div>

--- a/src/patterns/windowsplitter/WindowSplitterDemo.tsx
+++ b/src/patterns/windowsplitter/WindowSplitterDemo.tsx
@@ -52,6 +52,7 @@ export function WindowSplitterDemo() {
   const [verticalPosition, setVerticalPosition] = useState(50);
   const [horizontalCollapsed, setHorizontalCollapsed] = useState(false);
   const [verticalCollapsed, setVerticalCollapsed] = useState(false);
+  const [collapsedPosition, setCollapsedPosition] = useState(0);
 
   return (
     <div className="apg-window-splitter-demo-wrapper">
@@ -182,7 +183,7 @@ export function WindowSplitterDemo() {
         <div
           className="apg-window-splitter-demo-container"
           data-testid="collapsed-demo"
-          style={{ '--splitter-position': '0%' } satisfies SplitterStyle}
+          style={{ '--splitter-position': `${collapsedPosition}%` } satisfies SplitterStyle}
         >
           <div className="apg-window-splitter-pane" id="collapsed-primary">
             <div className="apg-window-splitter-pane-content">Primary Pane</div>
@@ -194,6 +195,7 @@ export function WindowSplitterDemo() {
             data-testid="collapsed-splitter"
             defaultCollapsed
             expandedPosition={50}
+            onPositionChange={(pos) => setCollapsedPosition(pos)}
           />
           <div className="apg-window-splitter-pane" id="collapsed-secondary">
             <div className="apg-window-splitter-pane-content">Secondary Pane</div>

--- a/src/patterns/windowsplitter/WindowSplitterDemo.vue
+++ b/src/patterns/windowsplitter/WindowSplitterDemo.vue
@@ -117,7 +117,7 @@
       <div
         class="apg-window-splitter-demo-container"
         data-testid="collapsed-demo"
-        style="--splitter-position: 0%"
+        :style="{ '--splitter-position': `${collapsedPosition}%` }"
       >
         <div class="apg-window-splitter-pane" id="collapsed-primary">
           <div class="apg-window-splitter-pane-content">Primary Pane</div>
@@ -129,6 +129,7 @@
           data-testid="collapsed-splitter"
           default-collapsed
           :expanded-position="50"
+          @position-change="(pos) => (collapsedPosition = pos)"
         />
         <div class="apg-window-splitter-pane" id="collapsed-secondary">
           <div class="apg-window-splitter-pane-content">Secondary Pane</div>
@@ -147,4 +148,5 @@ const horizontalPosition = ref(50);
 const verticalPosition = ref(50);
 const horizontalCollapsed = ref(false);
 const verticalCollapsed = ref(false);
+const collapsedPosition = ref(0);
 </script>


### PR DESCRIPTION
## 概要

WindowSplitter パターンの「Initially Collapsed」デモに関する一連のバグを修正し、設計上のデモ依存も解消した。バージョンを `0.4.3` → `0.4.4`（patch）に更新。

## 背景・問題

1. **collapsed 状態でボタン/キー操作が効かない**: `defaultCollapsed=true` のとき `position=0 < min(10)` となり、`handlePopupButtonClick` の `if (newPos < min || newPos > max) return;` reject ガードで Expand/Shrink ボタンと矢印キーが無反応（Maximize のみ偶然動作）。
2. **展開しても視覚が動かない**: collapsed から展開すると `aria-valuenow` は 0→50 になるのに、ペインの視覚幅が変わらない。原因は React/Vue/Svelte の Initially Collapsed デモが demo-container の `--splitter-position` を `0%` ハードコードし、`onPositionChange` を未配線だったため（Astro はグローバルリスナで動作）。
3. **デモ依存の結合（Codex 指摘）**: ドラッグ時にコンポーネントが `.apg-window-splitter-demo-container` を直接探索・更新していた。

## 変更内容

### コンポーネント（React/Vue/Svelte/Astro）
- `expandFromCollapsed` を導入し、collapsed からの展開方向操作（Expand/Maximize ボタン・展開矢印・End）で `restore = previousPosition ?? expandedPosition ?? defaultPosition` 位置へ展開（Enter トグルと同一）。縮小方向は no-op。
- reject ガードを廃止し `updatePosition` の clamp に依存（min/max 境界跨ぎの副次バグも解消）。
- disabled 算出を collapsed 考慮に再定義（collapsed 時は Collapse/Shrink を無効、Expand/Maximize を有効）。
- キーボード操作時に collapsed フラグを確実に解除。
- **ドラッグのデモ依存を解消**: 測定対象を `parentElement` に変更し、視覚更新は全操作で `onPositionChange`（`positionchange` イベント）経由に統一。Astro の型アサーションも除去。

### デモ（React/Vue/Svelte）
- Initially Collapsed デモに `collapsedPosition` state（初期値 0）を追加し、demo-container の `--splitter-position` をバインド、`onPositionChange` を配線。Astro は変更不要。

## 検証

- ユニット: 221件 + Astro 設定 144件 パス
- E2E: 4フレームワーク各 36件パス（collapsed 操作・ペイン幅の視覚アサーション・ドラッグを含む）
- tsc / eslint / astro check / prettier クリーン
- Playwright MCP で 4フレームワークの Initially Collapsed デモを手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)