### PR TITLE
fix(data-grid): Astro版で編集セルの値を innerHTML ではなく textContent で描画

### DIFF
--- a/e2e/data-grid.spec.ts
+++ b/e2e/data-grid.spec.ts
@@ -510,6 +510,41 @@ for (const framework of frameworks) {
         await expectCellOrChildFocused(page, editableCell);
       });
 
+      test('edited cell value is rendered as plain text, not HTML (astro regression)', async ({
+        page,
+      }) => {
+        // This test only applies to the Astro implementation, which previously used innerHTML
+        if (framework !== 'astro') return;
+
+        const grid = page.getByRole('grid');
+        const editableCells = grid.locator('[role="gridcell"][aria-readonly="false"]');
+        const count = await editableCells.count();
+
+        if (count === 0) {
+          test.skip();
+          return;
+        }
+
+        const editableCell = editableCells.first();
+        await focusCell(page, editableCell);
+        await expect(editableCell).toBeFocused();
+        await editableCell.press('Enter');
+
+        const input = editableCell.locator('input').first();
+        await expect(input).toBeFocused();
+
+        // Type markup that would be parsed as HTML if innerHTML were used
+        await input.fill('<b>x</b>');
+
+        // Commit by pressing Enter
+        await page.keyboard.press('Enter');
+
+        // The cell should contain the literal string, not a parsed <b> element
+        await expect(editableCell.locator('b')).toHaveCount(0);
+        const cellText = await editableCell.textContent();
+        expect(cellText).toContain('<b>x</b>');
+      });
+
       test('edit mode disables grid navigation', async ({ page }) => {
         const grid = page.getByRole('grid');
         const editableCells = grid.locator('[role="gridcell"][aria-readonly="false"]');

--- a/src/patterns/data-grid/DataGrid.astro
+++ b/src/patterns/data-grid/DataGrid.astro
@@ -1334,7 +1334,7 @@ const initialFocusedId = getInitialFocusedId();
       const finalValue = cancelled ? this.originalEditValue : this.editValue;
 
       // Restore cell content
-      cell.innerHTML = finalValue;
+      cell.textContent = finalValue;
       cell.classList.remove('editing');
 
       this.dispatchEvent(


### PR DESCRIPTION
## 概要

Astro（Web Component）版 DataGrid のセル編集確定処理が、ユーザー入力値を `innerHTML` で書き戻していたため、入力された文字列が HTML として解釈されていました。`textContent` に変更し、入力をリテラルテキストとして安全に描画するようにします。

## なぜ必要か

- **バグ／セキュリティ衛生**: 静的デモのため実害は self-XSS（攻撃者＝被害者）で軽微ですが、アクセシビリティ／ベストプラクティスを示す教材プロジェクトとして `innerHTML` にユーザー入力を流す実装は不適切です。
- **フレームワーク間の挙動差の解消**: React / Vue / Svelte 版は各フレームワークのエスケープされるテキストバインディングで描画しており、Astro 版だけが HTML として解釈する挙動でした。本修正で 4 実装の挙動が揃います。

## 変更内容

- `src/patterns/data-grid/DataGrid.astro` (`endEdit`): `cell.innerHTML = finalValue` → `cell.textContent = finalValue`（1 行）。
  - 編集開始時の `cell.dataset.originalContent = cell.innerHTML` / `cell.innerHTML = ''`（信頼済みマークアップの読み取り・クリア）は対象外として変更していません。
- `e2e/data-grid.spec.ts`: Astro 限定の回帰テストを追加。編集セルに `<b>x</b>` を入力・確定し、`<b>` 要素が生成されないこと（`toHaveCount(0)`）と、セルにリテラル文字列 `<b>x</b>` が含まれることを検証。
  - 既存の `for (const framework of frameworks)` ループ内 `DataGrid (astro)` describe に配置し、`if (framework !== 'astro') return;` でガード。describe プレフィックスにより CI の `grep: /\(astro\)/` でも実行されます。

## 検証

- `npm run lint:astro` / `lint:types` / `lint:eslint` / `format:prettier:check` → 全て exit 0、0 errors（eslint の 189 warnings は既存）
- `E2E_FRAMEWORK=astro` の data-grid E2E → 40 passed / 3 skipped、回帰テスト通過
- **falsifiability 確認**: 修正を `innerHTML` に戻すと回帰テストが失敗（`<b>` 要素が 1 個生成され `toHaveCount(0)` が Received:1）。修正後は通過 → テストが実際にバグを捕捉することを確認
- `npm run build` → exit 0（555 ページ）

## スコープ外（今回は対応せず）

- 4 実装のソート記号の表記揺れ（React/Vue は `' ▲'`、Svelte/Astro は `'▲'`）は別の小さな整合パスとして残置。

🤖 Generated with [Claude Code](https://claude.com/claude-code)