### PR TITLE
test: port React-only patterns' unit tests to Vue/Svelte/Astro (plan 002)

### DIFF
--- a/src/patterns/alert/Alert.test.astro.ts
+++ b/src/patterns/alert/Alert.test.astro.ts
@@ -1,0 +1,115 @@
+/**
+ * Alert Astro Component Tests using Container API
+ *
+ * Verifies the Alert.astro component's initial HTML structure and attributes.
+ * Interaction cases (dismiss click, focus) are covered by Vue/Svelte unit tests
+ * and E2E; Container API only renders initial HTML.
+ *
+ * Ported structural subset of Alert.test.tsx. Interaction-only React cases
+ * (focus management, onDismiss click, rerender id stability) are omitted here.
+ *
+ * @see https://docs.astro.build/en/reference/container-reference/
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+import Alert from './Alert.astro';
+
+describe('Alert (Astro Container API)', () => {
+  let container: AstroContainer;
+
+  beforeEach(async () => {
+    container = await AstroContainer.create();
+  });
+
+  async function renderAlert(
+    props: {
+      message?: string;
+      variant?: 'info' | 'success' | 'warning' | 'error';
+      id?: string;
+      dismissible?: boolean;
+      class?: string;
+    } = {}
+  ): Promise<Document> {
+    const html = await container.renderToString(Alert, { props });
+    const dom = new JSDOM(html);
+    return dom.window.document;
+  }
+
+  // High Priority: APG Core Compliance
+  describe('APG: ARIA Attributes', () => {
+    it('has role="alert"', async () => {
+      const doc = await renderAlert({ message: 'Test message' });
+      expect(doc.querySelector('[role="alert"]')).not.toBeNull();
+    });
+
+    it('role=alert container exists in DOM even without message', async () => {
+      const doc = await renderAlert();
+      expect(doc.querySelector('[role="alert"]')).not.toBeNull();
+    });
+  });
+
+  describe('APG: Focus Management', () => {
+    it('alert itself does not receive focus (no tabindex)', async () => {
+      const doc = await renderAlert({ message: 'Test message' });
+      const alert = doc.querySelector('[role="alert"]');
+      expect(alert?.hasAttribute('tabindex')).toBe(false);
+    });
+  });
+
+  describe('Dismiss Feature', () => {
+    it('shows dismiss button when dismissible=true', async () => {
+      const doc = await renderAlert({ message: 'Test message', dismissible: true });
+      expect(doc.querySelector('.apg-alert-dismiss')).not.toBeNull();
+    });
+
+    it('does not show dismiss button when dismissible=false (default)', async () => {
+      const doc = await renderAlert({ message: 'Test message' });
+      expect(doc.querySelector('.apg-alert-dismiss')).toBeNull();
+    });
+
+    it('dismiss button has type=button', async () => {
+      const doc = await renderAlert({ message: 'Test message', dismissible: true });
+      const button = doc.querySelector('.apg-alert-dismiss');
+      expect(button?.getAttribute('type')).toBe('button');
+    });
+
+    it('dismiss button has aria-label', async () => {
+      const doc = await renderAlert({ message: 'Test message', dismissible: true });
+      const button = doc.querySelector('.apg-alert-dismiss');
+      expect(button?.getAttribute('aria-label')).toBe('Dismiss alert');
+    });
+  });
+
+  describe('Variant Styles', () => {
+    it.each(['info', 'success', 'warning', 'error'] as const)(
+      'applies appropriate style class for variant=%s',
+      async (variant) => {
+        const doc = await renderAlert({ message: 'Test message', variant });
+        const wrapper = doc.querySelector('apg-alert');
+        expect(wrapper?.classList.contains('apg-alert')).toBe(true);
+      }
+    );
+
+    it('default variant is info', async () => {
+      const doc = await renderAlert({ message: 'Test message' });
+      const wrapper = doc.querySelector('apg-alert');
+      expect(wrapper?.classList.contains('bg-blue-50')).toBe(true);
+    });
+  });
+
+  describe('Props', () => {
+    it('can set custom ID with id prop', async () => {
+      const doc = await renderAlert({ message: 'Test message', id: 'custom-alert-id' });
+      const alert = doc.querySelector('[role="alert"]');
+      expect(alert?.getAttribute('id')).toBe('custom-alert-id');
+    });
+
+    it('merges className correctly', async () => {
+      const doc = await renderAlert({ message: 'Test message', class: 'custom-class' });
+      const wrapper = doc.querySelector('apg-alert');
+      expect(wrapper?.classList.contains('apg-alert')).toBe(true);
+      expect(wrapper?.classList.contains('custom-class')).toBe(true);
+    });
+  });
+});

--- a/src/patterns/alert/Alert.test.svelte.ts
+++ b/src/patterns/alert/Alert.test.svelte.ts
@@ -1,0 +1,137 @@
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+import Alert from './Alert.svelte';
+
+// Excluded React-specific cases (no faithful Svelte analogue):
+// - 'container remains the same element when message changes' (React rerender of internal id stability)
+// - 'container remains when message is cleared' (React rerender semantics)
+// - 'can pass complex content via children' (Svelte children use Snippet; cannot construct ad-hoc markup snippets in this harness)
+// - 'message takes priority when both message and children are provided' (same Snippet limitation)
+// - 'can pass additional HTML attributes' (Svelte Alert declares explicit props and does NOT
+//   spread rest props onto the element, so arbitrary HTML attributes are not forwarded — an
+//   intentional framework-implementation difference, not a bug)
+// React used `className` prop; Svelte uses `class`. React used `onDismiss` callback prop;
+// Svelte also accepts an `onDismiss` callback prop.
+
+describe('Alert (Svelte)', () => {
+  // High Priority: APG Core Compliance
+  describe('APG: ARIA Attributes', () => {
+    it('has role="alert"', () => {
+      render(Alert, { props: { message: 'Test message' } });
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    it('role=alert container exists in DOM even without message', () => {
+      render(Alert);
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+  });
+
+  describe('APG: Focus Management', () => {
+    it('alert itself does not receive focus (no tabindex)', () => {
+      render(Alert, { props: { message: 'Test message' } });
+      expect(screen.getByRole('alert')).not.toHaveAttribute('tabindex');
+    });
+  });
+
+  describe('Dismiss Feature', () => {
+    it('shows dismiss button when dismissible=true', () => {
+      render(Alert, { props: { message: 'Test message', dismissible: true } });
+      expect(screen.getByRole('button', { name: 'Dismiss alert' })).toBeInTheDocument();
+    });
+
+    it('does not show dismiss button when dismissible=false (default)', () => {
+      render(Alert, { props: { message: 'Test message' } });
+      expect(screen.queryByRole('button', { name: 'Dismiss alert' })).not.toBeInTheDocument();
+    });
+
+    it('calls onDismiss when dismiss button is clicked', async () => {
+      const handleDismiss = vi.fn();
+      const user = userEvent.setup();
+      render(Alert, {
+        props: { message: 'Test message', dismissible: true, onDismiss: handleDismiss },
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Dismiss alert' }));
+      expect(handleDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it('dismiss button has type=button', () => {
+      render(Alert, { props: { message: 'Test message', dismissible: true } });
+      expect(screen.getByRole('button', { name: 'Dismiss alert' })).toHaveAttribute(
+        'type',
+        'button'
+      );
+    });
+
+    it('dismiss button has aria-label', () => {
+      render(Alert, { props: { message: 'Test message', dismissible: true } });
+      expect(screen.getByRole('button', { name: 'Dismiss alert' })).toHaveAccessibleName(
+        'Dismiss alert'
+      );
+    });
+  });
+
+  // Medium Priority: Accessibility Validation
+  describe('Accessibility', () => {
+    it('has no WCAG 2.1 AA violations (with message)', async () => {
+      const { container } = render(Alert, { props: { message: 'Test message' } });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no WCAG 2.1 AA violations (without message)', async () => {
+      const { container } = render(Alert);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no WCAG 2.1 AA violations (dismissible)', async () => {
+      const { container } = render(Alert, {
+        props: { message: 'Test message', dismissible: true, onDismiss: () => {} },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  describe('Variant Styles', () => {
+    it.each(['info', 'success', 'warning', 'error'] as const)(
+      'applies appropriate style class for variant=%s',
+      (variant) => {
+        render(Alert, { props: { message: 'Test message', variant } });
+        const alert = screen.getByRole('alert');
+        // apg-alert class is on the parent wrapper, not on role="alert"
+        const wrapper = alert.parentElement;
+        expect(wrapper).toHaveClass('apg-alert');
+      }
+    );
+
+    it('default variant is info', () => {
+      render(Alert, { props: { message: 'Test message' } });
+      const alert = screen.getByRole('alert');
+      // info variant style is applied to the parent wrapper
+      const wrapper = alert.parentElement;
+      expect(wrapper).toHaveClass('bg-blue-50');
+    });
+  });
+
+  // Low Priority: Props & Extensibility
+  describe('Props', () => {
+    it('can set custom ID with id prop', () => {
+      render(Alert, { props: { message: 'Test message', id: 'custom-alert-id' } });
+      expect(screen.getByRole('alert')).toHaveAttribute('id', 'custom-alert-id');
+    });
+
+    it('merges className correctly', () => {
+      render(Alert, { props: { message: 'Test message', class: 'custom-class' } });
+      const alert = screen.getByRole('alert');
+      // class is applied to the parent wrapper
+      const wrapper = alert.parentElement;
+      expect(wrapper).toHaveClass('apg-alert');
+      expect(wrapper).toHaveClass('custom-class');
+    });
+  });
+});

--- a/src/patterns/alert/Alert.test.vue.ts
+++ b/src/patterns/alert/Alert.test.vue.ts
@@ -1,0 +1,173 @@
+import { render, screen } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+import { h } from 'vue';
+import Alert from './Alert.vue';
+
+// Excluded React-specific cases (no faithful Vue analogue):
+// - 'container remains the same element when message changes' (React rerender of internal id stability)
+// - 'container remains when message is cleared' (React rerender semantics)
+// React used `className` prop; Vue uses `class`. React used `onDismiss` callback prop;
+// Vue emits a `dismiss` event (assert via onDismiss listener / vi.fn()).
+
+describe('Alert (Vue)', () => {
+  // High Priority: APG Core Compliance
+  describe('APG: ARIA Attributes', () => {
+    it('has role="alert"', () => {
+      render(Alert, { props: { message: 'Test message' } });
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    it('role=alert container exists in DOM even without message', () => {
+      render(Alert);
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+  });
+
+  describe('APG: Focus Management', () => {
+    it('does not move focus when alert is displayed', async () => {
+      const user = userEvent.setup();
+      render({
+        components: { Alert },
+        template: '<div><button>Other button</button><Alert message="Test message" /></div>',
+      });
+
+      const button = screen.getByRole('button', { name: 'Other button' });
+      await user.click(button);
+      expect(button).toHaveFocus();
+
+      // Focus should not move when alert is displayed
+      expect(button).toHaveFocus();
+    });
+
+    it('alert itself does not receive focus (no tabindex)', () => {
+      render(Alert, { props: { message: 'Test message' } });
+      expect(screen.getByRole('alert')).not.toHaveAttribute('tabindex');
+    });
+  });
+
+  describe('Dismiss Feature', () => {
+    it('shows dismiss button when dismissible=true', () => {
+      render(Alert, { props: { message: 'Test message', dismissible: true } });
+      expect(screen.getByRole('button', { name: 'Dismiss alert' })).toBeInTheDocument();
+    });
+
+    it('does not show dismiss button when dismissible=false (default)', () => {
+      render(Alert, { props: { message: 'Test message' } });
+      expect(screen.queryByRole('button', { name: 'Dismiss alert' })).not.toBeInTheDocument();
+    });
+
+    it('calls onDismiss when dismiss button is clicked', async () => {
+      const handleDismiss = vi.fn();
+      const user = userEvent.setup();
+      render(Alert, {
+        props: { message: 'Test message', dismissible: true, onDismiss: handleDismiss },
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Dismiss alert' }));
+      expect(handleDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it('dismiss button has type=button', () => {
+      render(Alert, { props: { message: 'Test message', dismissible: true } });
+      expect(screen.getByRole('button', { name: 'Dismiss alert' })).toHaveAttribute(
+        'type',
+        'button'
+      );
+    });
+
+    it('dismiss button has aria-label', () => {
+      render(Alert, { props: { message: 'Test message', dismissible: true } });
+      expect(screen.getByRole('button', { name: 'Dismiss alert' })).toHaveAccessibleName(
+        'Dismiss alert'
+      );
+    });
+  });
+
+  // Medium Priority: Accessibility Validation
+  describe('Accessibility', () => {
+    it('has no WCAG 2.1 AA violations (with message)', async () => {
+      const { container } = render(Alert, { props: { message: 'Test message' } });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no WCAG 2.1 AA violations (without message)', async () => {
+      const { container } = render(Alert);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no WCAG 2.1 AA violations (dismissible)', async () => {
+      const { container } = render(Alert, {
+        props: { message: 'Test message', dismissible: true, onDismiss: () => {} },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  describe('Variant Styles', () => {
+    it.each(['info', 'success', 'warning', 'error'] as const)(
+      'applies appropriate style class for variant=%s',
+      (variant) => {
+        render(Alert, { props: { message: 'Test message', variant } });
+        const alert = screen.getByRole('alert');
+        // apg-alert class is on the parent wrapper, not on role="alert"
+        const wrapper = alert.parentElement;
+        expect(wrapper).toHaveClass('apg-alert');
+      }
+    );
+
+    it('default variant is info', () => {
+      render(Alert, { props: { message: 'Test message' } });
+      const alert = screen.getByRole('alert');
+      // info variant style is applied to the parent wrapper
+      const wrapper = alert.parentElement;
+      expect(wrapper).toHaveClass('bg-blue-50');
+    });
+  });
+
+  // Low Priority: Props & Extensibility
+  describe('Props', () => {
+    it('can set custom ID with id prop', () => {
+      render(Alert, { props: { message: 'Test message', id: 'custom-alert-id' } });
+      expect(screen.getByRole('alert')).toHaveAttribute('id', 'custom-alert-id');
+    });
+
+    it('merges className correctly', () => {
+      render(Alert, { props: { message: 'Test message', class: 'custom-class' } });
+      const alert = screen.getByRole('alert');
+      // class is applied to the parent wrapper
+      const wrapper = alert.parentElement;
+      expect(wrapper).toHaveClass('apg-alert');
+      expect(wrapper).toHaveClass('custom-class');
+    });
+
+    it('can pass complex content via children', () => {
+      render(Alert, {
+        slots: {
+          default: () => [h('strong', 'Important:'), ' This is a message'],
+        },
+      });
+      expect(screen.getByRole('alert')).toHaveTextContent('Important: This is a message');
+    });
+
+    it('message takes priority when both message and children are provided', () => {
+      render(Alert, {
+        props: { message: 'Message prop' },
+        slots: { default: () => h('span', 'Children content') },
+      });
+      expect(screen.getByRole('alert')).toHaveTextContent('Message prop');
+      expect(screen.getByRole('alert')).not.toHaveTextContent('Children content');
+    });
+  });
+
+  describe('HTML Attribute Inheritance', () => {
+    it('can pass additional HTML attributes', () => {
+      render(Alert, { props: { message: 'Test', 'data-testid': 'custom-alert' } });
+      expect(screen.getByTestId('custom-alert')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/patterns/data-grid/DataGrid.test.astro.ts
+++ b/src/patterns/data-grid/DataGrid.test.astro.ts
@@ -1,0 +1,501 @@
+/**
+ * DataGrid Astro Component Tests using Container API
+ *
+ * Verifies the DataGrid.astro initial HTML structure and ARIA attributes.
+ * Interaction cases (keyboard navigation, sorting actions, range/row selection,
+ * cell editing, focus movement) are covered by the Vue/Svelte unit tests and
+ * E2E; the Container API only renders initial HTML.
+ *
+ * Ported structural/initial-state subset of DataGrid.test.tsx. Interaction-only
+ * React cases are omitted here. The aria-rowindex case is it.skip — the Astro
+ * DataGrid uses `startRowIndex + rowIndex + 1` (vs React's `startRowIndex + rowIndex`),
+ * the same off-by-one divergence documented in the Vue/Svelte ports.
+ *
+ * @see https://docs.astro.build/en/reference/container-reference/
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+import DataGrid from './DataGrid.astro';
+
+const createSortableColumns = () => [
+  { id: 'name', header: 'Name', sortable: true, sortDirection: 'none' },
+  { id: 'email', header: 'Email', sortable: true, sortDirection: 'none' },
+  { id: 'role', header: 'Role', sortable: false },
+];
+
+const createBasicColumns = () => [
+  { id: 'name', header: 'Name' },
+  { id: 'email', header: 'Email' },
+  { id: 'role', header: 'Role' },
+];
+
+const createBasicRows = () => [
+  {
+    id: 'row1',
+    cells: [
+      { id: 'row1-0', value: 'Alice' },
+      { id: 'row1-1', value: 'alice@example.com' },
+      { id: 'row1-2', value: 'Admin' },
+    ],
+  },
+  {
+    id: 'row2',
+    cells: [
+      { id: 'row2-0', value: 'Bob' },
+      { id: 'row2-1', value: 'bob@example.com' },
+      { id: 'row2-2', value: 'User' },
+    ],
+  },
+  {
+    id: 'row3',
+    cells: [
+      { id: 'row3-0', value: 'Charlie' },
+      { id: 'row3-1', value: 'charlie@example.com' },
+      { id: 'row3-2', value: 'User' },
+    ],
+  },
+];
+
+const createEditableRows = () => [
+  {
+    id: 'row1',
+    cells: [
+      { id: 'row1-0', value: 'Alice', editable: true },
+      { id: 'row1-1', value: 'alice@example.com', editable: true },
+      { id: 'row1-2', value: 'Admin', readonly: true },
+    ],
+  },
+];
+
+const createRowsWithDisabled = () => [
+  {
+    id: 'row1',
+    cells: [
+      { id: 'row1-0', value: 'Alice' },
+      { id: 'row1-1', value: 'alice@example.com', disabled: true },
+      { id: 'row1-2', value: 'Admin' },
+    ],
+  },
+  {
+    id: 'row2',
+    disabled: true,
+    cells: [
+      { id: 'row2-0', value: 'Bob' },
+      { id: 'row2-1', value: 'bob@example.com' },
+      { id: 'row2-2', value: 'User' },
+    ],
+  },
+];
+
+const createRowsWithRowHeader = () => [
+  {
+    id: 'row1',
+    hasRowHeader: true,
+    cells: [
+      { id: 'row1-0', value: '1' },
+      { id: 'row1-1', value: 'Alice' },
+      { id: 'row1-2', value: 'Admin' },
+    ],
+  },
+  {
+    id: 'row2',
+    hasRowHeader: true,
+    cells: [
+      { id: 'row2-0', value: '2' },
+      { id: 'row2-1', value: 'Bob' },
+      { id: 'row2-2', value: 'User' },
+    ],
+  },
+];
+
+const createColumnsWithSpan = () => [
+  { id: 'info', header: 'Info', colspan: 2 },
+  { id: 'role', header: 'Role' },
+];
+
+const createRowsWithSpan = () => [
+  {
+    id: 'row1',
+    cells: [
+      { id: 'row1-0', value: 'Merged', colspan: 2 },
+      { id: 'row1-2', value: 'Normal' },
+    ],
+  },
+  {
+    id: 'row2',
+    hasRowHeader: true,
+    cells: [
+      { id: 'row2-0', value: 'Header', rowspan: 2 },
+      { id: 'row2-1', value: 'A' },
+      { id: 'row2-2', value: 'B' },
+    ],
+  },
+];
+
+describe('DataGrid (Astro Container API)', () => {
+  let container: AstroContainer;
+
+  beforeEach(async () => {
+    container = await AstroContainer.create();
+  });
+
+  async function renderGrid(props: Record<string, unknown>): Promise<Document> {
+    const html = await container.renderToString(DataGrid, { props });
+    const dom = new JSDOM(html);
+    return dom.window.document;
+  }
+
+  function cellByText(doc: Document, text: string): Element | undefined {
+    return Array.from(doc.querySelectorAll('[role="gridcell"]')).find(
+      (c) => c.textContent?.trim() === text
+    );
+  }
+
+  function headerByText(doc: Document, text: string): Element | undefined {
+    return Array.from(doc.querySelectorAll('[role="columnheader"]')).find((h) =>
+      h.textContent?.includes(text)
+    );
+  }
+
+  describe('ARIA Attributes', () => {
+    it('has role="grid" on container', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createBasicRows(),
+        ariaLabel: 'Users',
+      });
+      expect(doc.querySelector('[role="grid"]')).not.toBeNull();
+    });
+
+    it('has role="row" on all rows', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createBasicRows(),
+        ariaLabel: 'Users',
+      });
+      expect(doc.querySelectorAll('[role="row"]')).toHaveLength(4);
+    });
+
+    it('has role="gridcell" on data cells', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createBasicRows(),
+        ariaLabel: 'Users',
+      });
+      expect(doc.querySelectorAll('[role="gridcell"]')).toHaveLength(9);
+    });
+
+    it('has role="columnheader" on header cells', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createBasicRows(),
+        ariaLabel: 'Users',
+      });
+      expect(doc.querySelectorAll('[role="columnheader"]')).toHaveLength(3);
+    });
+
+    it('has role="rowheader" when hasRowHeader is true', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createRowsWithRowHeader(),
+        ariaLabel: 'Users',
+      });
+      expect(doc.querySelectorAll('[role="rowheader"]')).toHaveLength(2);
+    });
+
+    it('sortable columnheader has aria-sort', async () => {
+      const doc = await renderGrid({
+        columns: createSortableColumns(),
+        rows: createBasicRows(),
+        ariaLabel: 'Users',
+      });
+      expect(headerByText(doc, 'Name')?.getAttribute('aria-sort')).toBe('none');
+    });
+
+    it('non-sortable columnheader does NOT have aria-sort', async () => {
+      const doc = await renderGrid({
+        columns: createSortableColumns(),
+        rows: createBasicRows(),
+        ariaLabel: 'Users',
+      });
+      expect(headerByText(doc, 'Role')?.hasAttribute('aria-sort')).toBe(false);
+    });
+
+    it('row has aria-selected when rowSelectable', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createBasicRows(),
+        ariaLabel: 'Users',
+        rowSelectable: true,
+      });
+      const rows = Array.from(doc.querySelectorAll('[role="row"]'));
+      expect(rows[1].getAttribute('aria-selected')).toBe('false');
+      expect(rows[2].getAttribute('aria-selected')).toBe('false');
+    });
+
+    it('has accessible name via aria-label', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createBasicRows(),
+        ariaLabel: 'Users',
+      });
+      expect(doc.querySelector('[role="grid"]')?.getAttribute('aria-label')).toBe('Users');
+    });
+
+    it('has accessible name via aria-labelledby', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createBasicRows(),
+        ariaLabelledby: 'grid-title',
+      });
+      expect(doc.querySelector('[role="grid"]')?.getAttribute('aria-labelledby')).toBe(
+        'grid-title'
+      );
+    });
+
+    it('has aria-multiselectable="true" when rowMultiselectable', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createBasicRows(),
+        ariaLabel: 'Users',
+        rowSelectable: true,
+        rowMultiselectable: true,
+      });
+      expect(doc.querySelector('[role="grid"]')?.getAttribute('aria-multiselectable')).toBe('true');
+    });
+
+    it('has aria-multiselectable="true" when cell multiselectable', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createBasicRows(),
+        ariaLabel: 'Users',
+        selectable: true,
+        multiselectable: true,
+      });
+      expect(doc.querySelector('[role="grid"]')?.getAttribute('aria-multiselectable')).toBe('true');
+    });
+
+    it('has aria-readonly="true" when readonly prop is true', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createBasicRows(),
+        ariaLabel: 'Users',
+        editable: true,
+        readonly: true,
+      });
+      expect(doc.querySelector('[role="grid"]')?.getAttribute('aria-readonly')).toBe('true');
+    });
+
+    it('editable cells have aria-readonly="false" or omitted', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createEditableRows(),
+        ariaLabel: 'Users',
+        editable: true,
+      });
+      const ariaReadonly = cellByText(doc, 'Alice')?.getAttribute('aria-readonly');
+      expect(ariaReadonly === null || ariaReadonly === 'false').toBe(true);
+    });
+
+    it('readonly cells have aria-readonly="true"', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createEditableRows(),
+        ariaLabel: 'Users',
+        editable: true,
+      });
+      expect(cellByText(doc, 'Admin')?.getAttribute('aria-readonly')).toBe('true');
+    });
+
+    it('has aria-rowcount/aria-colcount when virtualizing', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createBasicRows(),
+        ariaLabel: 'Users',
+        totalRows: 100,
+        totalColumns: 10,
+      });
+      const grid = doc.querySelector('[role="grid"]');
+      expect(grid?.getAttribute('aria-rowcount')).toBe('100');
+      expect(grid?.getAttribute('aria-colcount')).toBe('10');
+    });
+
+    // SKIPPED — real off-by-one divergence (do not "fix" by weakening the assertion).
+    // The Astro DataGrid template uses `startRowIndex + rowIndex + 1` (DataGrid.astro) so the
+    // first data row is 11 for startRowIndex=10, whereas React uses `startRowIndex + rowIndex`
+    // (10). Same divergence documented in the Vue/Svelte ports. Component unmodified.
+    it.skip('has aria-rowindex on rows when virtualizing (1-based, header row = 1)', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createBasicRows(),
+        ariaLabel: 'Users',
+        totalRows: 100,
+        startRowIndex: 10,
+      });
+      const rows = Array.from(doc.querySelectorAll('[role="row"]'));
+      expect(rows[0].getAttribute('aria-rowindex')).toBe('1');
+      expect(rows[1].getAttribute('aria-rowindex')).toBe('10');
+      expect(rows[2].getAttribute('aria-rowindex')).toBe('11');
+    });
+
+    it('has aria-colindex on cells/headers when virtualizing', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createBasicRows(),
+        ariaLabel: 'Users',
+        totalColumns: 10,
+        startColIndex: 5,
+      });
+      const headers = Array.from(doc.querySelectorAll('[role="columnheader"]'));
+      expect(headers[0].getAttribute('aria-colindex')).toBe('5');
+      expect(headers[1].getAttribute('aria-colindex')).toBe('6');
+      const cells = Array.from(doc.querySelectorAll('[role="gridcell"]')).slice(0, 3);
+      expect(cells[0].getAttribute('aria-colindex')).toBe('5');
+      expect(cells[1].getAttribute('aria-colindex')).toBe('6');
+    });
+
+    it('has aria-disabled="true" on disabled rows/cells', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createRowsWithDisabled(),
+        ariaLabel: 'Users',
+      });
+      expect(cellByText(doc, 'alice@example.com')?.getAttribute('aria-disabled')).toBe('true');
+      const disabledRow = Array.from(doc.querySelectorAll('[role="row"]'))[2];
+      expect(disabledRow.getAttribute('aria-disabled')).toBe('true');
+    });
+
+    it('has aria-colspan on gridcells with colspan > 1', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createRowsWithSpan(),
+        ariaLabel: 'Users',
+      });
+      expect(cellByText(doc, 'Merged')?.getAttribute('aria-colspan')).toBe('2');
+    });
+
+    it('has aria-colspan on columnheaders with colspan > 1', async () => {
+      const doc = await renderGrid({
+        columns: createColumnsWithSpan(),
+        rows: createBasicRows(),
+        ariaLabel: 'Users',
+      });
+      expect(headerByText(doc, 'Info')?.getAttribute('aria-colspan')).toBe('2');
+    });
+
+    it('has aria-rowspan on gridcells/rowheaders with rowspan > 1', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createRowsWithSpan(),
+        ariaLabel: 'Users',
+      });
+      const spanned = Array.from(doc.querySelectorAll('[role="rowheader"]')).find((r) =>
+        r.textContent?.includes('Header')
+      );
+      expect(spanned?.getAttribute('aria-rowspan')).toBe('2');
+    });
+  });
+
+  describe('Selection Model Exclusivity', () => {
+    it('when rowSelectable: aria-selected on rows only', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createBasicRows(),
+        ariaLabel: 'Users',
+        rowSelectable: true,
+      });
+      expect(
+        Array.from(doc.querySelectorAll('[role="row"]'))[1].hasAttribute('aria-selected')
+      ).toBe(true);
+      doc.querySelectorAll('[role="gridcell"]').forEach((cell) => {
+        expect(cell.hasAttribute('aria-selected')).toBe(false);
+      });
+    });
+
+    it('when selectable (cell): aria-selected on gridcells only', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createBasicRows(),
+        ariaLabel: 'Users',
+        selectable: true,
+      });
+      doc.querySelectorAll('[role="gridcell"]').forEach((cell) => {
+        expect(cell.hasAttribute('aria-selected')).toBe(true);
+      });
+      expect(
+        Array.from(doc.querySelectorAll('[role="row"]'))[1].hasAttribute('aria-selected')
+      ).toBe(false);
+    });
+
+    it('aria-multiselectable on grid (not on individual elements)', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createBasicRows(),
+        ariaLabel: 'Users',
+        rowSelectable: true,
+        rowMultiselectable: true,
+      });
+      expect(doc.querySelector('[role="grid"]')?.getAttribute('aria-multiselectable')).toBe('true');
+      doc.querySelectorAll('[role="row"]').forEach((row) => {
+        expect(row.hasAttribute('aria-multiselectable')).toBe(false);
+      });
+    });
+  });
+
+  describe('Focus Management', () => {
+    it('sortable columnheaders are focusable (tabindex)', async () => {
+      const doc = await renderGrid({
+        columns: createSortableColumns(),
+        rows: createBasicRows(),
+        ariaLabel: 'Users',
+      });
+      expect(headerByText(doc, 'Name')?.hasAttribute('tabindex')).toBe(true);
+    });
+
+    it('non-sortable columnheaders are NOT focusable', async () => {
+      const doc = await renderGrid({
+        columns: createSortableColumns(),
+        rows: createBasicRows(),
+        ariaLabel: 'Users',
+      });
+      expect(headerByText(doc, 'Role')?.hasAttribute('tabindex')).toBe(false);
+    });
+
+    it('first focusable cell has tabindex="0"', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createBasicRows(),
+        ariaLabel: 'Users',
+      });
+      expect(
+        Array.from(doc.querySelectorAll('[role="gridcell"]'))[0].getAttribute('tabindex')
+      ).toBe('0');
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('sort indicators have accessible names', async () => {
+      const doc = await renderGrid({
+        columns: [{ id: 'name', header: 'Name', sortable: true, sortDirection: 'ascending' }],
+        rows: createBasicRows(),
+        ariaLabel: 'Users',
+      });
+      expect(headerByText(doc, 'Name')?.getAttribute('aria-sort')).toBe('ascending');
+    });
+
+    it('checkboxes have accessible labels', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        rows: createBasicRows(),
+        ariaLabel: 'Users',
+        rowSelectable: true,
+      });
+      doc.querySelectorAll('input[type="checkbox"]').forEach((checkbox) => {
+        const label =
+          checkbox.getAttribute('aria-label') || checkbox.getAttribute('aria-labelledby');
+        expect(label).toBeTruthy();
+      });
+    });
+  });
+});

--- a/src/patterns/data-grid/DataGrid.test.svelte.ts
+++ b/src/patterns/data-grid/DataGrid.test.svelte.ts
@@ -1,0 +1,1204 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+import { tick } from 'svelte';
+import DataGrid from './DataGrid.svelte';
+import type { DataGridColumnDef, DataGridRowData, SortDirection } from './DataGrid.svelte';
+
+// Prop/event mapping vs React:
+// - React `ariaLabel` / `ariaLabelledby` -> Vue `ariaLabel` / `ariaLabelledby` (same names).
+// - React callback props `onSort` / `onRangeSelect` / `onRowSelectionChange` / `onEditStart` /
+//   `onEditEnd` -> Svelte same-named callback props.
+// - External label element (aria-labelledby) and sibling buttons (Tab/Shift+Tab tests) are
+//   inserted into the document directly, mirroring the React JSX setup.
+// - The Svelte DataGrid adjusts inner focusable-element tabindex via an $effect, so `renderTree`
+//   awaits a tick after mounting (mirrors React's synchronous render) before assertions.
+// All titles are ported 1:1. One case ('has aria-rowindex on rows when virtualizing ...') is
+// it.skip (NOT React-specific): it exposes a real off-by-one divergence — the Vue DataGrid
+// computes data-row aria-rowindex as `startRowIndex + rowIndex + 1` vs React's
+// `startRowIndex + rowIndex` (same divergence as the Vue port). See the inline note. Reported for the reviewer.
+const renderTree = async (
+  ...args: Parameters<typeof render>
+): Promise<ReturnType<typeof render>> => {
+  const result = render(...args);
+  await tick();
+  return result;
+};
+
+const createSortableColumns = (): DataGridColumnDef[] => [
+  { id: 'name', header: 'Name', sortable: true, sortDirection: 'none' },
+  { id: 'email', header: 'Email', sortable: true, sortDirection: 'none' },
+  { id: 'role', header: 'Role', sortable: false },
+];
+
+const createBasicColumns = (): DataGridColumnDef[] => [
+  { id: 'name', header: 'Name' },
+  { id: 'email', header: 'Email' },
+  { id: 'role', header: 'Role' },
+];
+
+const createBasicRows = (): DataGridRowData[] => [
+  {
+    id: 'row1',
+    cells: [
+      { id: 'row1-0', value: 'Alice' },
+      { id: 'row1-1', value: 'alice@example.com' },
+      { id: 'row1-2', value: 'Admin' },
+    ],
+  },
+  {
+    id: 'row2',
+    cells: [
+      { id: 'row2-0', value: 'Bob' },
+      { id: 'row2-1', value: 'bob@example.com' },
+      { id: 'row2-2', value: 'User' },
+    ],
+  },
+  {
+    id: 'row3',
+    cells: [
+      { id: 'row3-0', value: 'Charlie' },
+      { id: 'row3-1', value: 'charlie@example.com' },
+      { id: 'row3-2', value: 'User' },
+    ],
+  },
+];
+
+const createEditableRows = (): DataGridRowData[] => [
+  {
+    id: 'row1',
+    cells: [
+      { id: 'row1-0', value: 'Alice', editable: true },
+      { id: 'row1-1', value: 'alice@example.com', editable: true },
+      { id: 'row1-2', value: 'Admin', readonly: true },
+    ],
+  },
+  {
+    id: 'row2',
+    cells: [
+      { id: 'row2-0', value: 'Bob', editable: true },
+      { id: 'row2-1', value: 'bob@example.com', editable: true },
+      { id: 'row2-2', value: 'User' },
+    ],
+  },
+];
+
+const createRowsWithDisabled = (): DataGridRowData[] => [
+  {
+    id: 'row1',
+    cells: [
+      { id: 'row1-0', value: 'Alice' },
+      { id: 'row1-1', value: 'alice@example.com', disabled: true },
+      { id: 'row1-2', value: 'Admin' },
+    ],
+  },
+  {
+    id: 'row2',
+    disabled: true,
+    cells: [
+      { id: 'row2-0', value: 'Bob' },
+      { id: 'row2-1', value: 'bob@example.com' },
+      { id: 'row2-2', value: 'User' },
+    ],
+  },
+];
+
+const createRowsWithRowHeader = (): DataGridRowData[] => [
+  {
+    id: 'row1',
+    hasRowHeader: true,
+    cells: [
+      { id: 'row1-0', value: '1' },
+      { id: 'row1-1', value: 'Alice' },
+      { id: 'row1-2', value: 'Admin' },
+    ],
+  },
+  {
+    id: 'row2',
+    hasRowHeader: true,
+    cells: [
+      { id: 'row2-0', value: '2' },
+      { id: 'row2-1', value: 'Bob' },
+      { id: 'row2-2', value: 'User' },
+    ],
+  },
+];
+
+const createColumnsWithSpan = (): DataGridColumnDef[] => [
+  { id: 'info', header: 'Info', colspan: 2 },
+  { id: 'role', header: 'Role' },
+];
+
+const createRowsWithSpan = (): DataGridRowData[] => [
+  {
+    id: 'row1',
+    cells: [
+      { id: 'row1-0', value: 'Merged', colspan: 2 },
+      { id: 'row1-2', value: 'Normal' },
+    ],
+  },
+  {
+    id: 'row2',
+    hasRowHeader: true,
+    cells: [
+      { id: 'row2-0', value: 'Header', rowspan: 2 },
+      { id: 'row2-1', value: 'A' },
+      { id: 'row2-2', value: 'B' },
+    ],
+  },
+];
+
+describe('DataGrid (Svelte)', () => {
+  describe('ARIA Attributes', () => {
+    it('has role="grid" on container', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      expect(screen.getByRole('grid')).toBeInTheDocument();
+    });
+
+    it('has role="row" on all rows', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      expect(screen.getAllByRole('row')).toHaveLength(4);
+    });
+
+    it('has role="gridcell" on data cells', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      expect(screen.getAllByRole('gridcell')).toHaveLength(9);
+    });
+
+    it('has role="columnheader" on header cells', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      expect(screen.getAllByRole('columnheader')).toHaveLength(3);
+    });
+
+    it('has role="rowheader" when hasRowHeader is true', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createRowsWithRowHeader(),
+          ariaLabel: 'Users',
+        },
+      });
+      expect(screen.getAllByRole('rowheader')).toHaveLength(2);
+    });
+
+    it('sortable columnheader has aria-sort', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createSortableColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      expect(screen.getByRole('columnheader', { name: 'Name' })).toHaveAttribute(
+        'aria-sort',
+        'none'
+      );
+    });
+
+    it('non-sortable columnheader does NOT have aria-sort', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createSortableColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      expect(screen.getByRole('columnheader', { name: 'Role' })).not.toHaveAttribute('aria-sort');
+    });
+
+    it('aria-sort updates on sort action', async () => {
+      // Svelte prop reactivity keys off object identity, so the rerender passes a freshly
+      // built columns array reflecting the new sortDirection (React mutated in place + rerendered).
+      let columns: DataGridColumnDef[] = [
+        { id: 'name', header: 'Name', sortable: true, sortDirection: 'none' },
+      ];
+      const onSort = vi.fn((_columnId: string, direction: SortDirection) => {
+        columns = [{ ...columns[0], sortDirection: direction }];
+      });
+      const { rerender } = await renderTree(DataGrid, {
+        props: { columns, rows: createBasicRows(), ariaLabel: 'Users', onSort },
+      });
+      const header = screen.getByRole('columnheader', { name: 'Name' });
+      header.focus();
+      await userEvent.setup().keyboard('{Enter}');
+      await rerender({ columns, rows: createBasicRows(), ariaLabel: 'Users', onSort });
+      expect(header).toHaveAttribute('aria-sort', 'ascending');
+    });
+
+    it('row has aria-selected when rowSelectable', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          rowSelectable: true,
+        },
+      });
+      const rows = screen.getAllByRole('row');
+      expect(rows[1]).toHaveAttribute('aria-selected', 'false');
+      expect(rows[2]).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('has accessible name via aria-label', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      expect(screen.getByRole('grid', { name: 'Users' })).toBeInTheDocument();
+    });
+
+    it('has accessible name via aria-labelledby', async () => {
+      const heading = document.createElement('h2');
+      heading.id = 'grid-title';
+      heading.textContent = 'User List';
+      document.body.appendChild(heading);
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabelledby: 'grid-title',
+        },
+      });
+      expect(screen.getByRole('grid')).toHaveAttribute('aria-labelledby', 'grid-title');
+    });
+
+    it('has aria-multiselectable="true" when rowMultiselectable', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          rowSelectable: true,
+          rowMultiselectable: true,
+        },
+      });
+      expect(screen.getByRole('grid')).toHaveAttribute('aria-multiselectable', 'true');
+    });
+
+    it('has aria-multiselectable="true" when cell multiselectable', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          selectable: true,
+          multiselectable: true,
+        },
+      });
+      expect(screen.getByRole('grid')).toHaveAttribute('aria-multiselectable', 'true');
+    });
+
+    it('has aria-readonly="true" when readonly prop is true', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          editable: true,
+          readonly: true,
+        },
+      });
+      expect(screen.getByRole('grid')).toHaveAttribute('aria-readonly', 'true');
+    });
+
+    it('editable cells have aria-readonly="false" or omitted', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createEditableRows(),
+          ariaLabel: 'Users',
+          editable: true,
+        },
+      });
+      const editableCell = screen.getByRole('gridcell', { name: 'Alice' });
+      const ariaReadonly = editableCell.getAttribute('aria-readonly');
+      expect(ariaReadonly === null || ariaReadonly === 'false').toBe(true);
+    });
+
+    it('readonly cells have aria-readonly="true"', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createEditableRows(),
+          ariaLabel: 'Users',
+          editable: true,
+        },
+      });
+      expect(screen.getByRole('gridcell', { name: 'Admin' })).toHaveAttribute(
+        'aria-readonly',
+        'true'
+      );
+    });
+
+    it('has aria-rowcount/aria-colcount when virtualizing', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          totalRows: 100,
+          totalColumns: 10,
+        },
+      });
+      const grid = screen.getByRole('grid');
+      expect(grid).toHaveAttribute('aria-rowcount', '100');
+      expect(grid).toHaveAttribute('aria-colcount', '10');
+    });
+
+    // SKIPPED — real Vue-only divergence (do not "fix" by weakening the assertion).
+    // The React DataGrid sets data-row aria-rowindex = `startRowIndex + rowIndex`, so with
+    // startRowIndex=10 the first data row is 10. The Svelte DataGrid template uses
+    // `startRowIndex + rowIndex + 1` (DataGrid.svelte), producing 11 for the same input — an
+    // off-by-one divergence. Component left unmodified; reported for the reviewer.
+    it.skip('has aria-rowindex on rows when virtualizing (1-based, header row = 1)', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          totalRows: 100,
+          startRowIndex: 10,
+        },
+      });
+      const rows = screen.getAllByRole('row');
+      expect(rows[0]).toHaveAttribute('aria-rowindex', '1');
+      expect(rows[1]).toHaveAttribute('aria-rowindex', '10');
+      expect(rows[2]).toHaveAttribute('aria-rowindex', '11');
+    });
+
+    it('has aria-colindex on cells/headers when virtualizing', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          totalColumns: 10,
+          startColIndex: 5,
+        },
+      });
+      const headers = screen.getAllByRole('columnheader');
+      expect(headers[0]).toHaveAttribute('aria-colindex', '5');
+      expect(headers[1]).toHaveAttribute('aria-colindex', '6');
+      const cells = screen.getAllByRole('gridcell').slice(0, 3);
+      expect(cells[0]).toHaveAttribute('aria-colindex', '5');
+      expect(cells[1]).toHaveAttribute('aria-colindex', '6');
+    });
+
+    it('has aria-disabled="true" on disabled rows/cells', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createRowsWithDisabled(),
+          ariaLabel: 'Users',
+        },
+      });
+      expect(screen.getByRole('gridcell', { name: 'alice@example.com' })).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
+      const disabledRow = screen.getAllByRole('row')[2];
+      expect(disabledRow).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('has aria-colspan on gridcells with colspan > 1', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createRowsWithSpan(), ariaLabel: 'Users' },
+      });
+      expect(screen.getByRole('gridcell', { name: 'Merged' })).toHaveAttribute('aria-colspan', '2');
+    });
+
+    it('has aria-colspan on columnheaders with colspan > 1', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createColumnsWithSpan(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      expect(screen.getByRole('columnheader', { name: 'Info' })).toHaveAttribute(
+        'aria-colspan',
+        '2'
+      );
+    });
+
+    it('has aria-rowspan on gridcells/rowheaders with rowspan > 1', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createRowsWithSpan(), ariaLabel: 'Users' },
+      });
+      expect(screen.getByRole('rowheader', { name: 'Header' })).toHaveAttribute(
+        'aria-rowspan',
+        '2'
+      );
+    });
+  });
+
+  describe('Keyboard - Base Navigation', () => {
+    it('ArrowRight moves focus one cell right', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getAllByRole('gridcell')[1]).toHaveFocus();
+    });
+
+    it('ArrowLeft moves focus one cell left', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      screen.getAllByRole('gridcell')[1].focus();
+      await user.keyboard('{ArrowLeft}');
+      expect(screen.getAllByRole('gridcell')[0]).toHaveFocus();
+    });
+
+    it('ArrowDown moves focus one row down', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getAllByRole('gridcell')[3]).toHaveFocus();
+    });
+
+    it('ArrowUp moves focus one row up', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      screen.getAllByRole('gridcell')[3].focus();
+      await user.keyboard('{ArrowUp}');
+      expect(screen.getAllByRole('gridcell')[0]).toHaveFocus();
+    });
+
+    it('ArrowRight stops at row end (no wrap by default)', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      const lastCellInRow = screen.getAllByRole('gridcell')[2];
+      lastCellInRow.focus();
+      await user.keyboard('{ArrowRight}');
+      expect(lastCellInRow).toHaveFocus();
+    });
+
+    it('ArrowUp from first data row enters sortable header', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createSortableColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.keyboard('{ArrowUp}');
+      expect(screen.getByRole('columnheader', { name: 'Name' })).toHaveFocus();
+    });
+
+    it('ArrowDown from header enters first data row', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createSortableColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      screen.getByRole('columnheader', { name: 'Name' }).focus();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getAllByRole('gridcell')[0]).toHaveFocus();
+    });
+
+    it('Home moves to first cell in row', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      screen.getAllByRole('gridcell')[2].focus();
+      await user.keyboard('{Home}');
+      expect(screen.getAllByRole('gridcell')[0]).toHaveFocus();
+    });
+
+    it('End moves to last cell in row', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.keyboard('{End}');
+      expect(screen.getAllByRole('gridcell')[2]).toHaveFocus();
+    });
+
+    it('Ctrl+Home moves to first cell in grid', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      screen.getAllByRole('gridcell')[8].focus();
+      await user.keyboard('{Control>}{Home}{/Control}');
+      expect(screen.getAllByRole('gridcell')[0]).toHaveFocus();
+    });
+
+    it('Ctrl+End moves to last cell in grid', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.keyboard('{Control>}{End}{/Control}');
+      expect(screen.getAllByRole('gridcell')[8]).toHaveFocus();
+    });
+
+    it('PageDown moves down by pageSize (when enabled)', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          enablePageNavigation: true,
+          pageSize: 2,
+        },
+      });
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.keyboard('{PageDown}');
+      expect(screen.getAllByRole('gridcell')[6]).toHaveFocus();
+    });
+
+    it('PageUp moves up by pageSize (when enabled)', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          enablePageNavigation: true,
+          pageSize: 2,
+        },
+      });
+      screen.getAllByRole('gridcell')[6].focus();
+      await user.keyboard('{PageUp}');
+      expect(screen.getAllByRole('gridcell')[0]).toHaveFocus();
+    });
+
+    it('Tab exits grid to next focusable element', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      const grid = screen.getByRole('grid');
+      const after = document.createElement('button');
+      after.textContent = 'After';
+      grid.parentElement!.appendChild(after);
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.tab();
+      expect(screen.getByRole('button', { name: 'After' })).toHaveFocus();
+    });
+
+    it('Shift+Tab exits grid to previous focusable element', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      const grid = screen.getByRole('grid');
+      const before = document.createElement('button');
+      before.textContent = 'Before';
+      grid.parentElement!.insertBefore(before, grid);
+      const firstCell = screen.getAllByRole('gridcell')[0];
+      firstCell.focus();
+      fireEvent.keyDown(firstCell, { key: 'Tab', shiftKey: true });
+      // Note: actual focus behavior depends on browser
+    });
+
+    it('navigation skips disabled cells', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createRowsWithDisabled(),
+          ariaLabel: 'Users',
+        },
+      });
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('gridcell', { name: 'Admin' })).toHaveFocus();
+    });
+  });
+
+  describe('Keyboard - Sorting', () => {
+    it('Enter on sortable header triggers sort', async () => {
+      const onSort = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createSortableColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          onSort,
+        },
+      });
+      screen.getByRole('columnheader', { name: 'Name' }).focus();
+      await user.keyboard('{Enter}');
+      expect(onSort).toHaveBeenCalledWith('name', 'ascending');
+    });
+
+    it('Space on sortable header triggers sort', async () => {
+      const onSort = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createSortableColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          onSort,
+        },
+      });
+      screen.getByRole('columnheader', { name: 'Name' }).focus();
+      await user.keyboard(' ');
+      expect(onSort).toHaveBeenCalledWith('name', 'ascending');
+    });
+
+    it('sort cycles: none -> ascending -> descending -> ascending', async () => {
+      const onSort = vi.fn();
+      const user = userEvent.setup();
+      const columns: DataGridColumnDef[] = [
+        { id: 'name', header: 'Name', sortable: true, sortDirection: 'none' },
+      ];
+      const { rerender } = await renderTree(DataGrid, {
+        props: { columns, rows: createBasicRows(), ariaLabel: 'Users', onSort },
+      });
+      const header = screen.getByRole('columnheader', { name: 'Name' });
+      header.focus();
+      await user.keyboard('{Enter}');
+      expect(onSort).toHaveBeenLastCalledWith('name', 'ascending');
+      columns[0].sortDirection = 'ascending';
+      await rerender({ columns, rows: createBasicRows(), ariaLabel: 'Users', onSort });
+      await user.keyboard('{Enter}');
+      expect(onSort).toHaveBeenLastCalledWith('name', 'descending');
+      columns[0].sortDirection = 'descending';
+      await rerender({ columns, rows: createBasicRows(), ariaLabel: 'Users', onSort });
+      await user.keyboard('{Enter}');
+      expect(onSort).toHaveBeenLastCalledWith('name', 'ascending');
+    });
+
+    it('non-sortable headers do not respond to Enter/Space', async () => {
+      const onSort = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createSortableColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          onSort,
+        },
+      });
+      const roleHeader = screen.getByRole('columnheader', { name: 'Role' });
+      roleHeader.focus();
+      await user.keyboard('{Enter}');
+      await user.keyboard(' ');
+      expect(onSort).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Keyboard - Range Selection', () => {
+    it('Shift+ArrowDown extends selection downward', async () => {
+      const onRangeSelect = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          enableRangeSelection: true,
+          onRangeSelect,
+        },
+      });
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.keyboard('{Shift>}{ArrowDown}{/Shift}');
+      expect(onRangeSelect).toHaveBeenCalled();
+      const selectedIds = onRangeSelect.mock.calls[0][0];
+      expect(selectedIds).toContain('row1-0');
+      expect(selectedIds).toContain('row2-0');
+    });
+
+    it('Shift+ArrowUp extends selection upward', async () => {
+      const onRangeSelect = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          enableRangeSelection: true,
+          onRangeSelect,
+        },
+      });
+      screen.getAllByRole('gridcell')[3].focus();
+      await user.keyboard('{Shift>}{ArrowUp}{/Shift}');
+      expect(onRangeSelect).toHaveBeenCalled();
+      const selectedIds = onRangeSelect.mock.calls[0][0];
+      expect(selectedIds).toContain('row1-0');
+      expect(selectedIds).toContain('row2-0');
+    });
+
+    it('Shift+Home extends selection to row start', async () => {
+      const onRangeSelect = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          enableRangeSelection: true,
+          onRangeSelect,
+        },
+      });
+      screen.getAllByRole('gridcell')[2].focus();
+      await user.keyboard('{Shift>}{Home}{/Shift}');
+      expect(onRangeSelect).toHaveBeenCalled();
+      const selectedIds = onRangeSelect.mock.calls[0][0];
+      expect(selectedIds).toContain('row1-0');
+      expect(selectedIds).toContain('row1-1');
+      expect(selectedIds).toContain('row1-2');
+    });
+
+    it('Shift+End extends selection to row end', async () => {
+      const onRangeSelect = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          enableRangeSelection: true,
+          onRangeSelect,
+        },
+      });
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.keyboard('{Shift>}{End}{/Shift}');
+      expect(onRangeSelect).toHaveBeenCalled();
+      const selectedIds = onRangeSelect.mock.calls[0][0];
+      expect(selectedIds).toContain('row1-0');
+      expect(selectedIds).toContain('row1-1');
+      expect(selectedIds).toContain('row1-2');
+    });
+
+    it('Ctrl+Shift+Home extends selection to grid start', async () => {
+      const onRangeSelect = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          enableRangeSelection: true,
+          onRangeSelect,
+        },
+      });
+      screen.getAllByRole('gridcell')[8].focus();
+      await user.keyboard('{Control>}{Shift>}{Home}{/Shift}{/Control}');
+      expect(onRangeSelect).toHaveBeenCalled();
+    });
+
+    it('Ctrl+Shift+End extends selection to grid end', async () => {
+      const onRangeSelect = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          enableRangeSelection: true,
+          onRangeSelect,
+        },
+      });
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.keyboard('{Control>}{Shift>}{End}{/Shift}{/Control}');
+      expect(onRangeSelect).toHaveBeenCalled();
+    });
+
+    it('selection anchor is set on first selection', async () => {
+      const onRangeSelect = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          enableRangeSelection: true,
+          onRangeSelect,
+        },
+      });
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.keyboard('{Shift>}{ArrowDown}{/Shift}');
+      const firstCall = onRangeSelect.mock.calls[0][0];
+      await user.keyboard('{Shift>}{ArrowDown}{/Shift}');
+      const secondCall = onRangeSelect.mock.calls[1][0];
+      expect(secondCall.length).toBeGreaterThan(firstCall.length);
+    });
+  });
+
+  describe('Row Selection', () => {
+    it('checkbox click toggles row selection', async () => {
+      const onRowSelectionChange = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          rowSelectable: true,
+          onRowSelectionChange,
+        },
+      });
+      await user.click(screen.getAllByRole('checkbox')[0]);
+      expect(onRowSelectionChange).toHaveBeenCalledWith(['row1']);
+    });
+
+    it('Space on checkbox cell toggles row selection', async () => {
+      const onRowSelectionChange = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          rowSelectable: true,
+          onRowSelectionChange,
+        },
+      });
+      const checkbox = screen.getAllByRole('checkbox')[0];
+      checkbox.focus();
+      await user.keyboard(' ');
+      expect(onRowSelectionChange).toHaveBeenCalledWith(['row1']);
+    });
+
+    it('aria-selected updates on row element', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          rowSelectable: true,
+        },
+      });
+      const dataRow = screen.getAllByRole('row')[1];
+      expect(dataRow).toHaveAttribute('aria-selected', 'false');
+      await user.click(screen.getAllByRole('checkbox')[0]);
+      expect(dataRow).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('onRowSelectionChange callback fires', async () => {
+      const onRowSelectionChange = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          rowSelectable: true,
+          onRowSelectionChange,
+        },
+      });
+      await user.click(screen.getAllByRole('checkbox')[0]);
+      expect(onRowSelectionChange).toHaveBeenCalledTimes(1);
+      expect(onRowSelectionChange).toHaveBeenCalledWith(['row1']);
+    });
+  });
+
+  describe('Selection Model Exclusivity', () => {
+    it('when rowSelectable: aria-selected on rows only', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          rowSelectable: true,
+        },
+      });
+      expect(screen.getAllByRole('row')[1]).toHaveAttribute('aria-selected');
+      screen.getAllByRole('gridcell').forEach((cell) => {
+        expect(cell).not.toHaveAttribute('aria-selected');
+      });
+    });
+
+    it('when selectable (cell): aria-selected on gridcells only', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          selectable: true,
+        },
+      });
+      screen.getAllByRole('gridcell').forEach((cell) => {
+        expect(cell).toHaveAttribute('aria-selected');
+      });
+      expect(screen.getAllByRole('row')[1]).not.toHaveAttribute('aria-selected');
+    });
+
+    it('aria-multiselectable on grid (not on individual elements)', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          rowSelectable: true,
+          rowMultiselectable: true,
+        },
+      });
+      expect(screen.getByRole('grid')).toHaveAttribute('aria-multiselectable', 'true');
+      screen.getAllByRole('row').forEach((row) => {
+        expect(row).not.toHaveAttribute('aria-multiselectable');
+      });
+    });
+  });
+
+  describe('Focus Management', () => {
+    it('sortable columnheaders are focusable (tabindex)', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createSortableColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      expect(screen.getByRole('columnheader', { name: 'Name' })).toHaveAttribute('tabindex');
+    });
+
+    it('non-sortable columnheaders are NOT focusable', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createSortableColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      expect(screen.getByRole('columnheader', { name: 'Role' })).not.toHaveAttribute('tabindex');
+    });
+
+    it('first focusable cell has tabindex="0"', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      expect(screen.getAllByRole('gridcell')[0]).toHaveAttribute('tabindex', '0');
+    });
+
+    it('roving tabindex updates correctly', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      const cells = screen.getAllByRole('gridcell');
+      cells[0].focus();
+      await user.keyboard('{ArrowRight}');
+      expect(cells[0]).toHaveAttribute('tabindex', '-1');
+      expect(cells[1]).toHaveAttribute('tabindex', '0');
+    });
+  });
+
+  describe('Cell Editing', () => {
+    it('Enter on editable cell enters edit mode', async () => {
+      const onEditStart = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createEditableRows(),
+          ariaLabel: 'Users',
+          editable: true,
+          onEditStart,
+        },
+      });
+      screen.getByRole('gridcell', { name: 'Alice' }).focus();
+      await user.keyboard('{Enter}');
+      expect(onEditStart).toHaveBeenCalledWith('row1-0', 'row1', 'name');
+    });
+
+    it('F2 on editable cell enters edit mode', async () => {
+      const onEditStart = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createEditableRows(),
+          ariaLabel: 'Users',
+          editable: true,
+          onEditStart,
+        },
+      });
+      screen.getByRole('gridcell', { name: 'Alice' }).focus();
+      await user.keyboard('{F2}');
+      expect(onEditStart).toHaveBeenCalledWith('row1-0', 'row1', 'name');
+    });
+
+    it('Escape in edit mode cancels and restores grid navigation', async () => {
+      const onEditEnd = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createEditableRows(),
+          ariaLabel: 'Users',
+          editable: true,
+          onEditEnd,
+        },
+      });
+      screen.getByRole('gridcell', { name: 'Alice' }).focus();
+      await user.keyboard('{Enter}');
+      await user.keyboard('New Value');
+      await user.keyboard('{Escape}');
+      expect(onEditEnd).toHaveBeenCalledWith('row1-0', expect.any(String), true);
+    });
+
+    it('edit mode disables grid keyboard navigation', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createEditableRows(),
+          ariaLabel: 'Users',
+          editable: true,
+        },
+      });
+      screen.getByRole('gridcell', { name: 'Alice' }).focus();
+      await user.keyboard('{Enter}');
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+    });
+
+    it('focus moves to input field on edit start', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createEditableRows(),
+          ariaLabel: 'Users',
+          editable: true,
+        },
+      });
+      screen.getByRole('gridcell', { name: 'Alice' }).focus();
+      await user.keyboard('{Enter}');
+      expect(screen.getByRole('textbox')).toHaveFocus();
+    });
+
+    it('focus returns to cell on edit end', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createEditableRows(),
+          ariaLabel: 'Users',
+          editable: true,
+        },
+      });
+      const editableCell = screen.getByRole('gridcell', { name: 'Alice' });
+      editableCell.focus();
+      await user.keyboard('{Enter}');
+      await waitFor(() => {
+        expect(screen.getByRole('textbox')).toBeInTheDocument();
+      });
+      await user.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(editableCell).toHaveFocus();
+      });
+    });
+
+    it('onEditStart callback fires when entering edit mode', async () => {
+      const onEditStart = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createEditableRows(),
+          ariaLabel: 'Users',
+          editable: true,
+          onEditStart,
+        },
+      });
+      screen.getByRole('gridcell', { name: 'Alice' }).focus();
+      await user.keyboard('{Enter}');
+      expect(onEditStart).toHaveBeenCalledTimes(1);
+    });
+
+    it('onEditEnd callback fires when exiting edit mode', async () => {
+      const onEditEnd = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createEditableRows(),
+          ariaLabel: 'Users',
+          editable: true,
+          onEditEnd,
+        },
+      });
+      screen.getByRole('gridcell', { name: 'Alice' }).focus();
+      await user.keyboard('{Enter}');
+      await user.keyboard('{Escape}');
+      expect(onEditEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it('non-editable cell does not enter edit mode on Enter/F2', async () => {
+      const onEditStart = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createEditableRows(),
+          ariaLabel: 'Users',
+          editable: true,
+          onEditStart,
+        },
+      });
+      const readonlyCell = screen.getByRole('gridcell', { name: 'Admin' });
+      readonlyCell.focus();
+      await user.keyboard('{Enter}');
+      await user.keyboard('{F2}');
+      expect(onEditStart).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('has no axe violations (WCAG 2.1 AA)', async () => {
+      const { container } = await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with row selection enabled', async () => {
+      const { container } = await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          rowSelectable: true,
+          rowMultiselectable: true,
+        },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with sorting enabled', async () => {
+      const { container } = await renderTree(DataGrid, {
+        props: { columns: createSortableColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('sort indicators have accessible names', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: [{ id: 'name', header: 'Name', sortable: true, sortDirection: 'ascending' }],
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+        },
+      });
+      const header = screen.getByRole('columnheader', { name: /Name/ });
+      expect(header).toHaveAttribute('aria-sort', 'ascending');
+    });
+
+    it('checkboxes have accessible labels', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          rowSelectable: true,
+        },
+      });
+      screen.getAllByRole('checkbox').forEach((checkbox) => {
+        const label =
+          checkbox.getAttribute('aria-label') || checkbox.getAttribute('aria-labelledby');
+        expect(label).toBeTruthy();
+      });
+    });
+  });
+});

--- a/src/patterns/data-grid/DataGrid.test.vue.ts
+++ b/src/patterns/data-grid/DataGrid.test.vue.ts
@@ -1,0 +1,1218 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+import { h, nextTick } from 'vue';
+import DataGrid from './DataGrid.vue';
+import type { DataGridColumnDef, DataGridRowData, SortDirection } from './DataGrid.vue';
+
+// Prop/event mapping vs React:
+// - React `ariaLabel` / `ariaLabelledby` -> Vue `ariaLabel` / `ariaLabelledby` (same names).
+// - React callback props `onSort` / `onRangeSelect` / `onRowSelectionChange` / `onEditStart` /
+//   `onEditEnd` -> Vue `sort` / `rangeSelect` / `rowSelectionChange` / `editStart` / `editEnd`
+//   emits (asserted via on* listeners).
+// - The Vue DataGrid adjusts inner focusable-element tabindex in onMounted, so `renderTree`
+//   awaits a tick after mounting (mirrors React's synchronous render) before assertions.
+// All titles are ported 1:1. One case ('has aria-rowindex on rows when virtualizing ...') is
+// it.skip (NOT React-specific): it exposes a real off-by-one divergence — the Vue DataGrid
+// computes data-row aria-rowindex as `startRowIndex + rowIndex + 1` vs React's
+// `startRowIndex + rowIndex`. See the inline note. Reported for the reviewer.
+const renderTree = async (
+  ...args: Parameters<typeof render>
+): Promise<ReturnType<typeof render>> => {
+  const result = render(...args);
+  await nextTick();
+  return result;
+};
+
+const createSortableColumns = (): DataGridColumnDef[] => [
+  { id: 'name', header: 'Name', sortable: true, sortDirection: 'none' },
+  { id: 'email', header: 'Email', sortable: true, sortDirection: 'none' },
+  { id: 'role', header: 'Role', sortable: false },
+];
+
+const createBasicColumns = (): DataGridColumnDef[] => [
+  { id: 'name', header: 'Name' },
+  { id: 'email', header: 'Email' },
+  { id: 'role', header: 'Role' },
+];
+
+const createBasicRows = (): DataGridRowData[] => [
+  {
+    id: 'row1',
+    cells: [
+      { id: 'row1-0', value: 'Alice' },
+      { id: 'row1-1', value: 'alice@example.com' },
+      { id: 'row1-2', value: 'Admin' },
+    ],
+  },
+  {
+    id: 'row2',
+    cells: [
+      { id: 'row2-0', value: 'Bob' },
+      { id: 'row2-1', value: 'bob@example.com' },
+      { id: 'row2-2', value: 'User' },
+    ],
+  },
+  {
+    id: 'row3',
+    cells: [
+      { id: 'row3-0', value: 'Charlie' },
+      { id: 'row3-1', value: 'charlie@example.com' },
+      { id: 'row3-2', value: 'User' },
+    ],
+  },
+];
+
+const createEditableRows = (): DataGridRowData[] => [
+  {
+    id: 'row1',
+    cells: [
+      { id: 'row1-0', value: 'Alice', editable: true },
+      { id: 'row1-1', value: 'alice@example.com', editable: true },
+      { id: 'row1-2', value: 'Admin', readonly: true },
+    ],
+  },
+  {
+    id: 'row2',
+    cells: [
+      { id: 'row2-0', value: 'Bob', editable: true },
+      { id: 'row2-1', value: 'bob@example.com', editable: true },
+      { id: 'row2-2', value: 'User' },
+    ],
+  },
+];
+
+const createRowsWithDisabled = (): DataGridRowData[] => [
+  {
+    id: 'row1',
+    cells: [
+      { id: 'row1-0', value: 'Alice' },
+      { id: 'row1-1', value: 'alice@example.com', disabled: true },
+      { id: 'row1-2', value: 'Admin' },
+    ],
+  },
+  {
+    id: 'row2',
+    disabled: true,
+    cells: [
+      { id: 'row2-0', value: 'Bob' },
+      { id: 'row2-1', value: 'bob@example.com' },
+      { id: 'row2-2', value: 'User' },
+    ],
+  },
+];
+
+const createRowsWithRowHeader = (): DataGridRowData[] => [
+  {
+    id: 'row1',
+    hasRowHeader: true,
+    cells: [
+      { id: 'row1-0', value: '1' },
+      { id: 'row1-1', value: 'Alice' },
+      { id: 'row1-2', value: 'Admin' },
+    ],
+  },
+  {
+    id: 'row2',
+    hasRowHeader: true,
+    cells: [
+      { id: 'row2-0', value: '2' },
+      { id: 'row2-1', value: 'Bob' },
+      { id: 'row2-2', value: 'User' },
+    ],
+  },
+];
+
+const createColumnsWithSpan = (): DataGridColumnDef[] => [
+  { id: 'info', header: 'Info', colspan: 2 },
+  { id: 'role', header: 'Role' },
+];
+
+const createRowsWithSpan = (): DataGridRowData[] => [
+  {
+    id: 'row1',
+    cells: [
+      { id: 'row1-0', value: 'Merged', colspan: 2 },
+      { id: 'row1-2', value: 'Normal' },
+    ],
+  },
+  {
+    id: 'row2',
+    hasRowHeader: true,
+    cells: [
+      { id: 'row2-0', value: 'Header', rowspan: 2 },
+      { id: 'row2-1', value: 'A' },
+      { id: 'row2-2', value: 'B' },
+    ],
+  },
+];
+
+describe('DataGrid (Vue)', () => {
+  describe('ARIA Attributes', () => {
+    it('has role="grid" on container', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      expect(screen.getByRole('grid')).toBeInTheDocument();
+    });
+
+    it('has role="row" on all rows', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      expect(screen.getAllByRole('row')).toHaveLength(4);
+    });
+
+    it('has role="gridcell" on data cells', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      expect(screen.getAllByRole('gridcell')).toHaveLength(9);
+    });
+
+    it('has role="columnheader" on header cells', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      expect(screen.getAllByRole('columnheader')).toHaveLength(3);
+    });
+
+    it('has role="rowheader" when hasRowHeader is true', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createRowsWithRowHeader(),
+          ariaLabel: 'Users',
+        },
+      });
+      expect(screen.getAllByRole('rowheader')).toHaveLength(2);
+    });
+
+    it('sortable columnheader has aria-sort', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createSortableColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      expect(screen.getByRole('columnheader', { name: 'Name' })).toHaveAttribute(
+        'aria-sort',
+        'none'
+      );
+    });
+
+    it('non-sortable columnheader does NOT have aria-sort', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createSortableColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      expect(screen.getByRole('columnheader', { name: 'Role' })).not.toHaveAttribute('aria-sort');
+    });
+
+    it('aria-sort updates on sort action', async () => {
+      const columns: DataGridColumnDef[] = [
+        { id: 'name', header: 'Name', sortable: true, sortDirection: 'none' },
+      ];
+      const onSort = vi.fn((_columnId: string, direction: SortDirection) => {
+        columns[0].sortDirection = direction;
+      });
+      const { rerender } = await renderTree(DataGrid, {
+        props: { columns, rows: createBasicRows(), ariaLabel: 'Users', onSort },
+      });
+      const header = screen.getByRole('columnheader', { name: 'Name' });
+      header.focus();
+      await userEvent.setup().keyboard('{Enter}');
+      await rerender({ columns, rows: createBasicRows(), ariaLabel: 'Users', onSort });
+      expect(header).toHaveAttribute('aria-sort', 'ascending');
+    });
+
+    it('row has aria-selected when rowSelectable', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          rowSelectable: true,
+        },
+      });
+      const rows = screen.getAllByRole('row');
+      expect(rows[1]).toHaveAttribute('aria-selected', 'false');
+      expect(rows[2]).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('has accessible name via aria-label', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      expect(screen.getByRole('grid', { name: 'Users' })).toBeInTheDocument();
+    });
+
+    it('has accessible name via aria-labelledby', async () => {
+      await renderTree({
+        components: { DataGrid },
+        setup() {
+          return () =>
+            h('div', [
+              h('h2', { id: 'grid-title' }, 'User List'),
+              h(DataGrid, {
+                columns: createBasicColumns(),
+                rows: createBasicRows(),
+                ariaLabelledby: 'grid-title',
+              }),
+            ]);
+        },
+      });
+      expect(screen.getByRole('grid')).toHaveAttribute('aria-labelledby', 'grid-title');
+    });
+
+    it('has aria-multiselectable="true" when rowMultiselectable', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          rowSelectable: true,
+          rowMultiselectable: true,
+        },
+      });
+      expect(screen.getByRole('grid')).toHaveAttribute('aria-multiselectable', 'true');
+    });
+
+    it('has aria-multiselectable="true" when cell multiselectable', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          selectable: true,
+          multiselectable: true,
+        },
+      });
+      expect(screen.getByRole('grid')).toHaveAttribute('aria-multiselectable', 'true');
+    });
+
+    it('has aria-readonly="true" when readonly prop is true', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          editable: true,
+          readonly: true,
+        },
+      });
+      expect(screen.getByRole('grid')).toHaveAttribute('aria-readonly', 'true');
+    });
+
+    it('editable cells have aria-readonly="false" or omitted', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createEditableRows(),
+          ariaLabel: 'Users',
+          editable: true,
+        },
+      });
+      const editableCell = screen.getByRole('gridcell', { name: 'Alice' });
+      const ariaReadonly = editableCell.getAttribute('aria-readonly');
+      expect(ariaReadonly === null || ariaReadonly === 'false').toBe(true);
+    });
+
+    it('readonly cells have aria-readonly="true"', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createEditableRows(),
+          ariaLabel: 'Users',
+          editable: true,
+        },
+      });
+      expect(screen.getByRole('gridcell', { name: 'Admin' })).toHaveAttribute(
+        'aria-readonly',
+        'true'
+      );
+    });
+
+    it('has aria-rowcount/aria-colcount when virtualizing', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          totalRows: 100,
+          totalColumns: 10,
+        },
+      });
+      const grid = screen.getByRole('grid');
+      expect(grid).toHaveAttribute('aria-rowcount', '100');
+      expect(grid).toHaveAttribute('aria-colcount', '10');
+    });
+
+    // SKIPPED — real Vue-only divergence (do not "fix" by weakening the assertion).
+    // The React DataGrid sets data-row aria-rowindex = `startRowIndex + rowIndex`, so with
+    // startRowIndex=10 the first data row is 10. The Vue DataGrid template uses
+    // `startRowIndex + rowIndex + 1` (DataGrid.vue), producing 11 for the same input — an
+    // off-by-one divergence. Component left unmodified; reported for the reviewer.
+    it.skip('has aria-rowindex on rows when virtualizing (1-based, header row = 1)', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          totalRows: 100,
+          startRowIndex: 10,
+        },
+      });
+      const rows = screen.getAllByRole('row');
+      expect(rows[0]).toHaveAttribute('aria-rowindex', '1');
+      expect(rows[1]).toHaveAttribute('aria-rowindex', '10');
+      expect(rows[2]).toHaveAttribute('aria-rowindex', '11');
+    });
+
+    it('has aria-colindex on cells/headers when virtualizing', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          totalColumns: 10,
+          startColIndex: 5,
+        },
+      });
+      const headers = screen.getAllByRole('columnheader');
+      expect(headers[0]).toHaveAttribute('aria-colindex', '5');
+      expect(headers[1]).toHaveAttribute('aria-colindex', '6');
+      const cells = screen.getAllByRole('gridcell').slice(0, 3);
+      expect(cells[0]).toHaveAttribute('aria-colindex', '5');
+      expect(cells[1]).toHaveAttribute('aria-colindex', '6');
+    });
+
+    it('has aria-disabled="true" on disabled rows/cells', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createRowsWithDisabled(),
+          ariaLabel: 'Users',
+        },
+      });
+      expect(screen.getByRole('gridcell', { name: 'alice@example.com' })).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
+      const disabledRow = screen.getAllByRole('row')[2];
+      expect(disabledRow).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('has aria-colspan on gridcells with colspan > 1', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createRowsWithSpan(), ariaLabel: 'Users' },
+      });
+      expect(screen.getByRole('gridcell', { name: 'Merged' })).toHaveAttribute('aria-colspan', '2');
+    });
+
+    it('has aria-colspan on columnheaders with colspan > 1', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createColumnsWithSpan(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      expect(screen.getByRole('columnheader', { name: 'Info' })).toHaveAttribute(
+        'aria-colspan',
+        '2'
+      );
+    });
+
+    it('has aria-rowspan on gridcells/rowheaders with rowspan > 1', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createRowsWithSpan(), ariaLabel: 'Users' },
+      });
+      expect(screen.getByRole('rowheader', { name: 'Header' })).toHaveAttribute(
+        'aria-rowspan',
+        '2'
+      );
+    });
+  });
+
+  describe('Keyboard - Base Navigation', () => {
+    it('ArrowRight moves focus one cell right', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getAllByRole('gridcell')[1]).toHaveFocus();
+    });
+
+    it('ArrowLeft moves focus one cell left', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      screen.getAllByRole('gridcell')[1].focus();
+      await user.keyboard('{ArrowLeft}');
+      expect(screen.getAllByRole('gridcell')[0]).toHaveFocus();
+    });
+
+    it('ArrowDown moves focus one row down', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getAllByRole('gridcell')[3]).toHaveFocus();
+    });
+
+    it('ArrowUp moves focus one row up', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      screen.getAllByRole('gridcell')[3].focus();
+      await user.keyboard('{ArrowUp}');
+      expect(screen.getAllByRole('gridcell')[0]).toHaveFocus();
+    });
+
+    it('ArrowRight stops at row end (no wrap by default)', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      const lastCellInRow = screen.getAllByRole('gridcell')[2];
+      lastCellInRow.focus();
+      await user.keyboard('{ArrowRight}');
+      expect(lastCellInRow).toHaveFocus();
+    });
+
+    it('ArrowUp from first data row enters sortable header', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createSortableColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.keyboard('{ArrowUp}');
+      expect(screen.getByRole('columnheader', { name: 'Name' })).toHaveFocus();
+    });
+
+    it('ArrowDown from header enters first data row', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createSortableColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      screen.getByRole('columnheader', { name: 'Name' }).focus();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getAllByRole('gridcell')[0]).toHaveFocus();
+    });
+
+    it('Home moves to first cell in row', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      screen.getAllByRole('gridcell')[2].focus();
+      await user.keyboard('{Home}');
+      expect(screen.getAllByRole('gridcell')[0]).toHaveFocus();
+    });
+
+    it('End moves to last cell in row', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.keyboard('{End}');
+      expect(screen.getAllByRole('gridcell')[2]).toHaveFocus();
+    });
+
+    it('Ctrl+Home moves to first cell in grid', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      screen.getAllByRole('gridcell')[8].focus();
+      await user.keyboard('{Control>}{Home}{/Control}');
+      expect(screen.getAllByRole('gridcell')[0]).toHaveFocus();
+    });
+
+    it('Ctrl+End moves to last cell in grid', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.keyboard('{Control>}{End}{/Control}');
+      expect(screen.getAllByRole('gridcell')[8]).toHaveFocus();
+    });
+
+    it('PageDown moves down by pageSize (when enabled)', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          enablePageNavigation: true,
+          pageSize: 2,
+        },
+      });
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.keyboard('{PageDown}');
+      expect(screen.getAllByRole('gridcell')[6]).toHaveFocus();
+    });
+
+    it('PageUp moves up by pageSize (when enabled)', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          enablePageNavigation: true,
+          pageSize: 2,
+        },
+      });
+      screen.getAllByRole('gridcell')[6].focus();
+      await user.keyboard('{PageUp}');
+      expect(screen.getAllByRole('gridcell')[0]).toHaveFocus();
+    });
+
+    it('Tab exits grid to next focusable element', async () => {
+      const user = userEvent.setup();
+      await renderTree({
+        components: { DataGrid },
+        setup() {
+          return () =>
+            h('div', [
+              h(DataGrid, {
+                columns: createBasicColumns(),
+                rows: createBasicRows(),
+                ariaLabel: 'Users',
+              }),
+              h('button', 'After'),
+            ]);
+        },
+      });
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.tab();
+      expect(screen.getByRole('button', { name: 'After' })).toHaveFocus();
+    });
+
+    it('Shift+Tab exits grid to previous focusable element', async () => {
+      await renderTree({
+        components: { DataGrid },
+        setup() {
+          return () =>
+            h('div', [
+              h('button', 'Before'),
+              h(DataGrid, {
+                columns: createBasicColumns(),
+                rows: createBasicRows(),
+                ariaLabel: 'Users',
+              }),
+            ]);
+        },
+      });
+      const firstCell = screen.getAllByRole('gridcell')[0];
+      firstCell.focus();
+      fireEvent.keyDown(firstCell, { key: 'Tab', shiftKey: true });
+      // Note: actual focus behavior depends on browser
+    });
+
+    it('navigation skips disabled cells', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createRowsWithDisabled(),
+          ariaLabel: 'Users',
+        },
+      });
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('gridcell', { name: 'Admin' })).toHaveFocus();
+    });
+  });
+
+  describe('Keyboard - Sorting', () => {
+    it('Enter on sortable header triggers sort', async () => {
+      const onSort = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createSortableColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          onSort,
+        },
+      });
+      screen.getByRole('columnheader', { name: 'Name' }).focus();
+      await user.keyboard('{Enter}');
+      expect(onSort).toHaveBeenCalledWith('name', 'ascending');
+    });
+
+    it('Space on sortable header triggers sort', async () => {
+      const onSort = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createSortableColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          onSort,
+        },
+      });
+      screen.getByRole('columnheader', { name: 'Name' }).focus();
+      await user.keyboard(' ');
+      expect(onSort).toHaveBeenCalledWith('name', 'ascending');
+    });
+
+    it('sort cycles: none -> ascending -> descending -> ascending', async () => {
+      const onSort = vi.fn();
+      const user = userEvent.setup();
+      const columns: DataGridColumnDef[] = [
+        { id: 'name', header: 'Name', sortable: true, sortDirection: 'none' },
+      ];
+      const { rerender } = await renderTree(DataGrid, {
+        props: { columns, rows: createBasicRows(), ariaLabel: 'Users', onSort },
+      });
+      const header = screen.getByRole('columnheader', { name: 'Name' });
+      header.focus();
+      await user.keyboard('{Enter}');
+      expect(onSort).toHaveBeenLastCalledWith('name', 'ascending');
+      columns[0].sortDirection = 'ascending';
+      await rerender({ columns, rows: createBasicRows(), ariaLabel: 'Users', onSort });
+      await user.keyboard('{Enter}');
+      expect(onSort).toHaveBeenLastCalledWith('name', 'descending');
+      columns[0].sortDirection = 'descending';
+      await rerender({ columns, rows: createBasicRows(), ariaLabel: 'Users', onSort });
+      await user.keyboard('{Enter}');
+      expect(onSort).toHaveBeenLastCalledWith('name', 'ascending');
+    });
+
+    it('non-sortable headers do not respond to Enter/Space', async () => {
+      const onSort = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createSortableColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          onSort,
+        },
+      });
+      const roleHeader = screen.getByRole('columnheader', { name: 'Role' });
+      roleHeader.focus();
+      await user.keyboard('{Enter}');
+      await user.keyboard(' ');
+      expect(onSort).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Keyboard - Range Selection', () => {
+    it('Shift+ArrowDown extends selection downward', async () => {
+      const onRangeSelect = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          enableRangeSelection: true,
+          onRangeSelect,
+        },
+      });
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.keyboard('{Shift>}{ArrowDown}{/Shift}');
+      expect(onRangeSelect).toHaveBeenCalled();
+      const selectedIds = onRangeSelect.mock.calls[0][0];
+      expect(selectedIds).toContain('row1-0');
+      expect(selectedIds).toContain('row2-0');
+    });
+
+    it('Shift+ArrowUp extends selection upward', async () => {
+      const onRangeSelect = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          enableRangeSelection: true,
+          onRangeSelect,
+        },
+      });
+      screen.getAllByRole('gridcell')[3].focus();
+      await user.keyboard('{Shift>}{ArrowUp}{/Shift}');
+      expect(onRangeSelect).toHaveBeenCalled();
+      const selectedIds = onRangeSelect.mock.calls[0][0];
+      expect(selectedIds).toContain('row1-0');
+      expect(selectedIds).toContain('row2-0');
+    });
+
+    it('Shift+Home extends selection to row start', async () => {
+      const onRangeSelect = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          enableRangeSelection: true,
+          onRangeSelect,
+        },
+      });
+      screen.getAllByRole('gridcell')[2].focus();
+      await user.keyboard('{Shift>}{Home}{/Shift}');
+      expect(onRangeSelect).toHaveBeenCalled();
+      const selectedIds = onRangeSelect.mock.calls[0][0];
+      expect(selectedIds).toContain('row1-0');
+      expect(selectedIds).toContain('row1-1');
+      expect(selectedIds).toContain('row1-2');
+    });
+
+    it('Shift+End extends selection to row end', async () => {
+      const onRangeSelect = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          enableRangeSelection: true,
+          onRangeSelect,
+        },
+      });
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.keyboard('{Shift>}{End}{/Shift}');
+      expect(onRangeSelect).toHaveBeenCalled();
+      const selectedIds = onRangeSelect.mock.calls[0][0];
+      expect(selectedIds).toContain('row1-0');
+      expect(selectedIds).toContain('row1-1');
+      expect(selectedIds).toContain('row1-2');
+    });
+
+    it('Ctrl+Shift+Home extends selection to grid start', async () => {
+      const onRangeSelect = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          enableRangeSelection: true,
+          onRangeSelect,
+        },
+      });
+      screen.getAllByRole('gridcell')[8].focus();
+      await user.keyboard('{Control>}{Shift>}{Home}{/Shift}{/Control}');
+      expect(onRangeSelect).toHaveBeenCalled();
+    });
+
+    it('Ctrl+Shift+End extends selection to grid end', async () => {
+      const onRangeSelect = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          enableRangeSelection: true,
+          onRangeSelect,
+        },
+      });
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.keyboard('{Control>}{Shift>}{End}{/Shift}{/Control}');
+      expect(onRangeSelect).toHaveBeenCalled();
+    });
+
+    it('selection anchor is set on first selection', async () => {
+      const onRangeSelect = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          enableRangeSelection: true,
+          onRangeSelect,
+        },
+      });
+      screen.getAllByRole('gridcell')[0].focus();
+      await user.keyboard('{Shift>}{ArrowDown}{/Shift}');
+      const firstCall = onRangeSelect.mock.calls[0][0];
+      await user.keyboard('{Shift>}{ArrowDown}{/Shift}');
+      const secondCall = onRangeSelect.mock.calls[1][0];
+      expect(secondCall.length).toBeGreaterThan(firstCall.length);
+    });
+  });
+
+  describe('Row Selection', () => {
+    it('checkbox click toggles row selection', async () => {
+      const onRowSelectionChange = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          rowSelectable: true,
+          onRowSelectionChange,
+        },
+      });
+      await user.click(screen.getAllByRole('checkbox')[0]);
+      expect(onRowSelectionChange).toHaveBeenCalledWith(['row1']);
+    });
+
+    it('Space on checkbox cell toggles row selection', async () => {
+      const onRowSelectionChange = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          rowSelectable: true,
+          onRowSelectionChange,
+        },
+      });
+      const checkbox = screen.getAllByRole('checkbox')[0];
+      checkbox.focus();
+      await user.keyboard(' ');
+      expect(onRowSelectionChange).toHaveBeenCalledWith(['row1']);
+    });
+
+    it('aria-selected updates on row element', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          rowSelectable: true,
+        },
+      });
+      const dataRow = screen.getAllByRole('row')[1];
+      expect(dataRow).toHaveAttribute('aria-selected', 'false');
+      await user.click(screen.getAllByRole('checkbox')[0]);
+      expect(dataRow).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('onRowSelectionChange callback fires', async () => {
+      const onRowSelectionChange = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          rowSelectable: true,
+          onRowSelectionChange,
+        },
+      });
+      await user.click(screen.getAllByRole('checkbox')[0]);
+      expect(onRowSelectionChange).toHaveBeenCalledTimes(1);
+      expect(onRowSelectionChange).toHaveBeenCalledWith(['row1']);
+    });
+  });
+
+  describe('Selection Model Exclusivity', () => {
+    it('when rowSelectable: aria-selected on rows only', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          rowSelectable: true,
+        },
+      });
+      expect(screen.getAllByRole('row')[1]).toHaveAttribute('aria-selected');
+      screen.getAllByRole('gridcell').forEach((cell) => {
+        expect(cell).not.toHaveAttribute('aria-selected');
+      });
+    });
+
+    it('when selectable (cell): aria-selected on gridcells only', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          selectable: true,
+        },
+      });
+      screen.getAllByRole('gridcell').forEach((cell) => {
+        expect(cell).toHaveAttribute('aria-selected');
+      });
+      expect(screen.getAllByRole('row')[1]).not.toHaveAttribute('aria-selected');
+    });
+
+    it('aria-multiselectable on grid (not on individual elements)', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          rowSelectable: true,
+          rowMultiselectable: true,
+        },
+      });
+      expect(screen.getByRole('grid')).toHaveAttribute('aria-multiselectable', 'true');
+      screen.getAllByRole('row').forEach((row) => {
+        expect(row).not.toHaveAttribute('aria-multiselectable');
+      });
+    });
+  });
+
+  describe('Focus Management', () => {
+    it('sortable columnheaders are focusable (tabindex)', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createSortableColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      expect(screen.getByRole('columnheader', { name: 'Name' })).toHaveAttribute('tabindex');
+    });
+
+    it('non-sortable columnheaders are NOT focusable', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createSortableColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      expect(screen.getByRole('columnheader', { name: 'Role' })).not.toHaveAttribute('tabindex');
+    });
+
+    it('first focusable cell has tabindex="0"', async () => {
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      expect(screen.getAllByRole('gridcell')[0]).toHaveAttribute('tabindex', '0');
+    });
+
+    it('roving tabindex updates correctly', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      const cells = screen.getAllByRole('gridcell');
+      cells[0].focus();
+      await user.keyboard('{ArrowRight}');
+      expect(cells[0]).toHaveAttribute('tabindex', '-1');
+      expect(cells[1]).toHaveAttribute('tabindex', '0');
+    });
+  });
+
+  describe('Cell Editing', () => {
+    it('Enter on editable cell enters edit mode', async () => {
+      const onEditStart = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createEditableRows(),
+          ariaLabel: 'Users',
+          editable: true,
+          onEditStart,
+        },
+      });
+      screen.getByRole('gridcell', { name: 'Alice' }).focus();
+      await user.keyboard('{Enter}');
+      expect(onEditStart).toHaveBeenCalledWith('row1-0', 'row1', 'name');
+    });
+
+    it('F2 on editable cell enters edit mode', async () => {
+      const onEditStart = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createEditableRows(),
+          ariaLabel: 'Users',
+          editable: true,
+          onEditStart,
+        },
+      });
+      screen.getByRole('gridcell', { name: 'Alice' }).focus();
+      await user.keyboard('{F2}');
+      expect(onEditStart).toHaveBeenCalledWith('row1-0', 'row1', 'name');
+    });
+
+    it('Escape in edit mode cancels and restores grid navigation', async () => {
+      const onEditEnd = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createEditableRows(),
+          ariaLabel: 'Users',
+          editable: true,
+          onEditEnd,
+        },
+      });
+      screen.getByRole('gridcell', { name: 'Alice' }).focus();
+      await user.keyboard('{Enter}');
+      await user.keyboard('New Value');
+      await user.keyboard('{Escape}');
+      expect(onEditEnd).toHaveBeenCalledWith('row1-0', expect.any(String), true);
+    });
+
+    it('edit mode disables grid keyboard navigation', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createEditableRows(),
+          ariaLabel: 'Users',
+          editable: true,
+        },
+      });
+      screen.getByRole('gridcell', { name: 'Alice' }).focus();
+      await user.keyboard('{Enter}');
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+    });
+
+    it('focus moves to input field on edit start', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createEditableRows(),
+          ariaLabel: 'Users',
+          editable: true,
+        },
+      });
+      screen.getByRole('gridcell', { name: 'Alice' }).focus();
+      await user.keyboard('{Enter}');
+      expect(screen.getByRole('textbox')).toHaveFocus();
+    });
+
+    it('focus returns to cell on edit end', async () => {
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createEditableRows(),
+          ariaLabel: 'Users',
+          editable: true,
+        },
+      });
+      const editableCell = screen.getByRole('gridcell', { name: 'Alice' });
+      editableCell.focus();
+      await user.keyboard('{Enter}');
+      await waitFor(() => {
+        expect(screen.getByRole('textbox')).toBeInTheDocument();
+      });
+      await user.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(editableCell).toHaveFocus();
+      });
+    });
+
+    it('onEditStart callback fires when entering edit mode', async () => {
+      const onEditStart = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createEditableRows(),
+          ariaLabel: 'Users',
+          editable: true,
+          onEditStart,
+        },
+      });
+      screen.getByRole('gridcell', { name: 'Alice' }).focus();
+      await user.keyboard('{Enter}');
+      expect(onEditStart).toHaveBeenCalledTimes(1);
+    });
+
+    it('onEditEnd callback fires when exiting edit mode', async () => {
+      const onEditEnd = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createEditableRows(),
+          ariaLabel: 'Users',
+          editable: true,
+          onEditEnd,
+        },
+      });
+      screen.getByRole('gridcell', { name: 'Alice' }).focus();
+      await user.keyboard('{Enter}');
+      await user.keyboard('{Escape}');
+      expect(onEditEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it('non-editable cell does not enter edit mode on Enter/F2', async () => {
+      const onEditStart = vi.fn();
+      const user = userEvent.setup();
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createEditableRows(),
+          ariaLabel: 'Users',
+          editable: true,
+          onEditStart,
+        },
+      });
+      const readonlyCell = screen.getByRole('gridcell', { name: 'Admin' });
+      readonlyCell.focus();
+      await user.keyboard('{Enter}');
+      await user.keyboard('{F2}');
+      expect(onEditStart).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('has no axe violations (WCAG 2.1 AA)', async () => {
+      const { container } = await renderTree(DataGrid, {
+        props: { columns: createBasicColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with row selection enabled', async () => {
+      const { container } = await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          rowSelectable: true,
+          rowMultiselectable: true,
+        },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with sorting enabled', async () => {
+      const { container } = await renderTree(DataGrid, {
+        props: { columns: createSortableColumns(), rows: createBasicRows(), ariaLabel: 'Users' },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('sort indicators have accessible names', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: [{ id: 'name', header: 'Name', sortable: true, sortDirection: 'ascending' }],
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+        },
+      });
+      const header = screen.getByRole('columnheader', { name: /Name/ });
+      expect(header).toHaveAttribute('aria-sort', 'ascending');
+    });
+
+    it('checkboxes have accessible labels', async () => {
+      await renderTree(DataGrid, {
+        props: {
+          columns: createBasicColumns(),
+          rows: createBasicRows(),
+          ariaLabel: 'Users',
+          rowSelectable: true,
+        },
+      });
+      screen.getAllByRole('checkbox').forEach((checkbox) => {
+        const label =
+          checkbox.getAttribute('aria-label') || checkbox.getAttribute('aria-labelledby');
+        expect(label).toBeTruthy();
+      });
+    });
+  });
+});

--- a/src/patterns/radio/RadioGroup.test.astro.ts
+++ b/src/patterns/radio/RadioGroup.test.astro.ts
@@ -1,0 +1,278 @@
+/**
+ * RadioGroup Astro Component Tests using Container API
+ *
+ * Verifies the RadioGroup.astro initial HTML structure and ARIA attributes.
+ * Interaction cases (keyboard navigation, click selection, roving focus updates,
+ * onValueChange) are covered by Vue/Svelte unit tests and E2E; the Container API
+ * only renders initial HTML.
+ *
+ * Ported structural/initial-state subset of RadioGroup.test.tsx. Interaction-only
+ * React cases are omitted here.
+ *
+ * @see https://docs.astro.build/en/reference/container-reference/
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+import RadioGroup from './RadioGroup.astro';
+
+const defaultOptions = [
+  { id: 'red', label: 'Red', value: 'red' },
+  { id: 'blue', label: 'Blue', value: 'blue' },
+  { id: 'green', label: 'Green', value: 'green' },
+];
+
+const optionsWithDisabled = [
+  { id: 'red', label: 'Red', value: 'red' },
+  { id: 'blue', label: 'Blue', value: 'blue', disabled: true },
+  { id: 'green', label: 'Green', value: 'green' },
+];
+
+describe('RadioGroup (Astro Container API)', () => {
+  let container: AstroContainer;
+
+  beforeEach(async () => {
+    container = await AstroContainer.create();
+  });
+
+  async function renderGroup(props: Record<string, unknown>): Promise<Document> {
+    const html = await container.renderToString(RadioGroup, { props });
+    const dom = new JSDOM(html);
+    return dom.window.document;
+  }
+
+  function radioByLabel(doc: Document, label: string): Element | null {
+    const radios = Array.from(doc.querySelectorAll('[role="radio"]'));
+    return radios.find((r) => r.textContent?.trim().includes(label)) ?? null;
+  }
+
+  // 🔴 High Priority: APG ARIA Attributes
+  describe('APG ARIA Attributes', () => {
+    it('has role="radiogroup" on container', async () => {
+      const doc = await renderGroup({
+        options: defaultOptions,
+        name: 'color',
+        'aria-label': 'Favorite color',
+      });
+      expect(doc.querySelector('[role="radiogroup"]')).not.toBeNull();
+    });
+
+    it('has role="radio" on each option', async () => {
+      const doc = await renderGroup({
+        options: defaultOptions,
+        name: 'color',
+        'aria-label': 'Favorite color',
+      });
+      expect(doc.querySelectorAll('[role="radio"]')).toHaveLength(3);
+    });
+
+    it('has aria-checked attribute on radios', async () => {
+      const doc = await renderGroup({
+        options: defaultOptions,
+        name: 'color',
+        'aria-label': 'Favorite color',
+      });
+      doc.querySelectorAll('[role="radio"]').forEach((radio) => {
+        expect(radio.hasAttribute('aria-checked')).toBe(true);
+      });
+    });
+
+    it('sets aria-checked="true" on selected radio', async () => {
+      const doc = await renderGroup({
+        options: defaultOptions,
+        name: 'color',
+        'aria-label': 'Favorite color',
+        defaultValue: 'blue',
+      });
+      expect(radioByLabel(doc, 'Blue')?.getAttribute('aria-checked')).toBe('true');
+      expect(radioByLabel(doc, 'Red')?.getAttribute('aria-checked')).toBe('false');
+      expect(radioByLabel(doc, 'Green')?.getAttribute('aria-checked')).toBe('false');
+    });
+
+    it('sets accessible name on radiogroup via aria-label', async () => {
+      const doc = await renderGroup({
+        options: defaultOptions,
+        name: 'color',
+        'aria-label': 'Favorite color',
+      });
+      expect(doc.querySelector('[role="radiogroup"]')?.getAttribute('aria-label')).toBe(
+        'Favorite color'
+      );
+    });
+
+    it('sets accessible name on radiogroup via aria-labelledby', async () => {
+      const doc = await renderGroup({
+        options: defaultOptions,
+        name: 'color',
+        'aria-labelledby': 'color-label',
+      });
+      expect(doc.querySelector('[role="radiogroup"]')?.getAttribute('aria-labelledby')).toBe(
+        'color-label'
+      );
+    });
+
+    it('sets aria-disabled="true" on disabled radio', async () => {
+      const doc = await renderGroup({
+        options: optionsWithDisabled,
+        name: 'color',
+        'aria-label': 'Favorite color',
+      });
+      expect(radioByLabel(doc, 'Blue')?.getAttribute('aria-disabled')).toBe('true');
+    });
+
+    it('sets aria-orientation="horizontal" only when orientation is horizontal', async () => {
+      const horizontal = await renderGroup({
+        options: defaultOptions,
+        name: 'color',
+        'aria-label': 'Favorite color',
+        orientation: 'horizontal',
+      });
+      expect(
+        horizontal.querySelector('[role="radiogroup"]')?.getAttribute('aria-orientation')
+      ).toBe('horizontal');
+
+      const vertical = await renderGroup({
+        options: defaultOptions,
+        name: 'color',
+        'aria-label': 'Favorite color',
+        orientation: 'vertical',
+      });
+      expect(vertical.querySelector('[role="radiogroup"]')?.hasAttribute('aria-orientation')).toBe(
+        false
+      );
+
+      const noOrientation = await renderGroup({
+        options: defaultOptions,
+        name: 'color',
+        'aria-label': 'Favorite color',
+      });
+      expect(
+        noOrientation.querySelector('[role="radiogroup"]')?.hasAttribute('aria-orientation')
+      ).toBe(false);
+    });
+  });
+
+  // 🔴 High Priority: Focus Management (Roving Tabindex) - initial render
+  describe('Focus Management (Roving Tabindex)', () => {
+    it('sets tabindex="0" on selected radio', async () => {
+      const doc = await renderGroup({
+        options: defaultOptions,
+        name: 'color',
+        'aria-label': 'Favorite color',
+        defaultValue: 'blue',
+      });
+      expect(radioByLabel(doc, 'Blue')?.getAttribute('tabindex')).toBe('0');
+    });
+
+    it('sets tabindex="-1" on non-selected radios', async () => {
+      const doc = await renderGroup({
+        options: defaultOptions,
+        name: 'color',
+        'aria-label': 'Favorite color',
+        defaultValue: 'blue',
+      });
+      expect(radioByLabel(doc, 'Red')?.getAttribute('tabindex')).toBe('-1');
+      expect(radioByLabel(doc, 'Green')?.getAttribute('tabindex')).toBe('-1');
+    });
+
+    it('sets tabindex="-1" on disabled radios', async () => {
+      const doc = await renderGroup({
+        options: optionsWithDisabled,
+        name: 'color',
+        'aria-label': 'Favorite color',
+      });
+      expect(radioByLabel(doc, 'Blue')?.getAttribute('tabindex')).toBe('-1');
+    });
+
+    it('sets tabindex="0" on first enabled radio when none selected', async () => {
+      const doc = await renderGroup({
+        options: defaultOptions,
+        name: 'color',
+        'aria-label': 'Favorite color',
+      });
+      expect(radioByLabel(doc, 'Red')?.getAttribute('tabindex')).toBe('0');
+      expect(radioByLabel(doc, 'Blue')?.getAttribute('tabindex')).toBe('-1');
+      expect(radioByLabel(doc, 'Green')?.getAttribute('tabindex')).toBe('-1');
+    });
+
+    it('sets tabindex="0" on first non-disabled radio when first is disabled', async () => {
+      const options = [
+        { id: 'red', label: 'Red', value: 'red', disabled: true },
+        { id: 'blue', label: 'Blue', value: 'blue' },
+        { id: 'green', label: 'Green', value: 'green' },
+      ];
+      const doc = await renderGroup({ options, name: 'color', 'aria-label': 'Favorite color' });
+      expect(radioByLabel(doc, 'Red')?.getAttribute('tabindex')).toBe('-1');
+      expect(radioByLabel(doc, 'Blue')?.getAttribute('tabindex')).toBe('0');
+    });
+
+    it('has only one tabindex="0" in the group', async () => {
+      const doc = await renderGroup({
+        options: defaultOptions,
+        name: 'color',
+        'aria-label': 'Favorite color',
+        defaultValue: 'blue',
+      });
+      const radios = Array.from(doc.querySelectorAll('[role="radio"]'));
+      const tabbable = radios.filter((radio) => radio.getAttribute('tabindex') === '0');
+      expect(tabbable).toHaveLength(1);
+    });
+  });
+
+  // 🟡 Medium Priority: Form Integration
+  describe('Form Integration', () => {
+    it('has hidden input for form submission', async () => {
+      const doc = await renderGroup({
+        options: defaultOptions,
+        name: 'color',
+        'aria-label': 'Favorite color',
+      });
+      expect(doc.querySelector('input[type="hidden"][name="color"]')).not.toBeNull();
+    });
+
+    it('hidden input has correct name attribute', async () => {
+      const doc = await renderGroup({
+        options: defaultOptions,
+        name: 'color',
+        'aria-label': 'Favorite color',
+      });
+      expect(doc.querySelector('input[type="hidden"]')?.getAttribute('name')).toBe('color');
+    });
+
+    it('hidden input has defaultValue on initial render', async () => {
+      const doc = await renderGroup({
+        options: defaultOptions,
+        name: 'color',
+        'aria-label': 'Favorite color',
+        defaultValue: 'green',
+      });
+      const hiddenInput = doc.querySelector('input[type="hidden"]') as HTMLInputElement | null;
+      expect(hiddenInput?.getAttribute('value')).toBe('green');
+    });
+  });
+
+  // 🟢 Low Priority: Props & Behavior
+  describe('Props & Behavior', () => {
+    it('applies className to container', async () => {
+      const doc = await renderGroup({
+        options: defaultOptions,
+        name: 'color',
+        'aria-label': 'Favorite color',
+        class: 'custom-class',
+      });
+      expect(doc.querySelector('[role="radiogroup"]')?.classList.contains('custom-class')).toBe(
+        true
+      );
+    });
+
+    it('renders with defaultValue', async () => {
+      const doc = await renderGroup({
+        options: defaultOptions,
+        name: 'color',
+        'aria-label': 'Favorite color',
+        defaultValue: 'green',
+      });
+      expect(radioByLabel(doc, 'Green')?.getAttribute('aria-checked')).toBe('true');
+    });
+  });
+});

--- a/src/patterns/radio/RadioGroup.test.svelte.ts
+++ b/src/patterns/radio/RadioGroup.test.svelte.ts
@@ -1,0 +1,689 @@
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+import RadioGroup from './RadioGroup.svelte';
+
+// Prop mapping vs React:
+// - React `aria-label` / `aria-labelledby` -> Svelte `aria-label` / `aria-labelledby` props (same names).
+// - React `onValueChange` callback prop -> Svelte `onValueChange` callback prop (same).
+// - React `className` -> Svelte `class`.
+// - DOM attribute `tabindex` (lowercase) used for assertions.
+// Tab-order tests adapt the React sibling-button setup by inserting a real button before/after
+// the rendered group in the document; no React-specific cases are skipped.
+
+const defaultOptions = [
+  { id: 'red', label: 'Red', value: 'red' },
+  { id: 'blue', label: 'Blue', value: 'blue' },
+  { id: 'green', label: 'Green', value: 'green' },
+];
+
+const optionsWithDisabled = [
+  { id: 'red', label: 'Red', value: 'red' },
+  { id: 'blue', label: 'Blue', value: 'blue', disabled: true },
+  { id: 'green', label: 'Green', value: 'green' },
+];
+
+function makeButton(label: string, position: 'before' | 'after', anchor: HTMLElement) {
+  const btn = document.createElement('button');
+  btn.textContent = label;
+  if (position === 'before') {
+    anchor.parentElement!.insertBefore(btn, anchor);
+  } else {
+    anchor.parentElement!.appendChild(btn);
+  }
+  return btn;
+}
+
+describe('RadioGroup (Svelte)', () => {
+  // 🔴 High Priority: APG ARIA Attributes
+  describe('APG ARIA Attributes', () => {
+    it('has role="radiogroup" on container', () => {
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', 'aria-label': 'Favorite color' },
+      });
+      expect(screen.getByRole('radiogroup')).toBeInTheDocument();
+    });
+
+    it('has role="radio" on each option', () => {
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', 'aria-label': 'Favorite color' },
+      });
+      const radios = screen.getAllByRole('radio');
+      expect(radios).toHaveLength(3);
+    });
+
+    it('has aria-checked attribute on radios', () => {
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', 'aria-label': 'Favorite color' },
+      });
+      const radios = screen.getAllByRole('radio');
+      radios.forEach((radio) => {
+        expect(radio).toHaveAttribute('aria-checked');
+      });
+    });
+
+    it('sets aria-checked="true" on selected radio', () => {
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          'aria-label': 'Favorite color',
+          defaultValue: 'blue',
+        },
+      });
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveAttribute('aria-checked', 'true');
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('aria-checked', 'false');
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('sets accessible name on radiogroup via aria-label', () => {
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', 'aria-label': 'Favorite color' },
+      });
+      expect(screen.getByRole('radiogroup', { name: 'Favorite color' })).toBeInTheDocument();
+    });
+
+    it('sets accessible name on radiogroup via aria-labelledby', () => {
+      const label = document.createElement('span');
+      label.id = 'color-label';
+      label.textContent = 'Choose a color';
+      document.body.appendChild(label);
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', 'aria-labelledby': 'color-label' },
+      });
+      expect(screen.getByRole('radiogroup', { name: 'Choose a color' })).toBeInTheDocument();
+    });
+
+    it('sets accessible name on each radio', () => {
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', 'aria-label': 'Favorite color' },
+      });
+      expect(screen.getByRole('radio', { name: 'Red' })).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: 'Blue' })).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: 'Green' })).toBeInTheDocument();
+    });
+
+    it('sets aria-disabled="true" on disabled radio', () => {
+      render(RadioGroup, {
+        props: { options: optionsWithDisabled, name: 'color', 'aria-label': 'Favorite color' },
+      });
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('sets aria-orientation="horizontal" only when orientation is horizontal', async () => {
+      const { rerender } = render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          'aria-label': 'Favorite color',
+          orientation: 'horizontal',
+        },
+      });
+      expect(screen.getByRole('radiogroup')).toHaveAttribute('aria-orientation', 'horizontal');
+
+      await rerender({
+        options: defaultOptions,
+        name: 'color',
+        'aria-label': 'Favorite color',
+        orientation: 'vertical',
+      });
+      expect(screen.getByRole('radiogroup')).not.toHaveAttribute('aria-orientation');
+
+      await rerender({
+        options: defaultOptions,
+        name: 'color',
+        'aria-label': 'Favorite color',
+        orientation: undefined,
+      });
+      expect(screen.getByRole('radiogroup')).not.toHaveAttribute('aria-orientation');
+    });
+  });
+
+  // 🔴 High Priority: APG Keyboard Interaction
+  describe('APG Keyboard Interaction', () => {
+    it('focuses selected radio on Tab when one is selected', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          'aria-label': 'Favorite color',
+          defaultValue: 'blue',
+        },
+      });
+      const before = makeButton('Before', 'before', screen.getByRole('radiogroup'));
+
+      await user.tab();
+      expect(before).toHaveFocus();
+      await user.tab();
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveFocus();
+    });
+
+    it('focuses first radio on Tab when none is selected', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', 'aria-label': 'Favorite color' },
+      });
+      makeButton('Before', 'before', screen.getByRole('radiogroup'));
+
+      await user.tab();
+      await user.tab();
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveFocus();
+    });
+
+    it('exits group on Tab from focused radio', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', 'aria-label': 'Favorite color' },
+      });
+      const after = makeButton('After', 'after', screen.getByRole('radiogroup'));
+
+      await user.tab();
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveFocus();
+      await user.tab();
+      expect(after).toHaveFocus();
+    });
+
+    it('exits group on Shift+Tab from focused radio', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', 'aria-label': 'Favorite color' },
+      });
+      const before = makeButton('Before', 'before', screen.getByRole('radiogroup'));
+
+      await user.tab();
+      expect(before).toHaveFocus();
+      await user.tab();
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveFocus();
+      await user.tab({ shift: true });
+      expect(before).toHaveFocus();
+    });
+
+    it('selects focused radio on Space', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', 'aria-label': 'Favorite color' },
+      });
+
+      await user.tab();
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveFocus();
+      await user.keyboard(' ');
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('does not unselect radio on Space when already selected', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          'aria-label': 'Favorite color',
+          defaultValue: 'red',
+        },
+      });
+
+      await user.tab();
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveFocus();
+      await user.keyboard(' ');
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('moves to next radio and selects on ArrowDown', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', 'aria-label': 'Favorite color' },
+      });
+
+      await user.tab();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('moves to next radio and selects on ArrowRight', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', 'aria-label': 'Favorite color' },
+      });
+
+      await user.tab();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('moves to previous radio and selects on ArrowUp', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          'aria-label': 'Favorite color',
+          defaultValue: 'blue',
+        },
+      });
+
+      await user.tab();
+      await user.keyboard('{ArrowUp}');
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('moves to previous radio and selects on ArrowLeft', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          'aria-label': 'Favorite color',
+          defaultValue: 'blue',
+        },
+      });
+
+      await user.tab();
+      await user.keyboard('{ArrowLeft}');
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('moves to first radio and selects on Home', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          'aria-label': 'Favorite color',
+          defaultValue: 'green',
+        },
+      });
+
+      await user.tab();
+      await user.keyboard('{Home}');
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('moves to last radio and selects on End', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', 'aria-label': 'Favorite color' },
+      });
+
+      await user.tab();
+      await user.keyboard('{End}');
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('wraps from last to first on ArrowDown', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          'aria-label': 'Favorite color',
+          defaultValue: 'green',
+        },
+      });
+
+      await user.tab();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('wraps from first to last on ArrowUp', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', 'aria-label': 'Favorite color' },
+      });
+
+      await user.tab();
+      await user.keyboard('{ArrowUp}');
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('skips disabled radio on ArrowDown', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: optionsWithDisabled, name: 'color', 'aria-label': 'Favorite color' },
+      });
+
+      await user.tab();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('skips disabled radio on ArrowUp', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: {
+          options: optionsWithDisabled,
+          name: 'color',
+          'aria-label': 'Favorite color',
+          defaultValue: 'green',
+        },
+      });
+
+      await user.tab();
+      await user.keyboard('{ArrowUp}');
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('skips disabled radio on ArrowLeft', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: {
+          options: optionsWithDisabled,
+          name: 'color',
+          'aria-label': 'Favorite color',
+          defaultValue: 'green',
+        },
+      });
+
+      await user.tab();
+      await user.keyboard('{ArrowLeft}');
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('skips disabled radio on ArrowRight', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: optionsWithDisabled, name: 'color', 'aria-label': 'Favorite color' },
+      });
+
+      await user.tab();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('does not select disabled radio on Space', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: optionsWithDisabled, name: 'color', 'aria-label': 'Favorite color' },
+      });
+
+      const blueRadio = screen.getByRole('radio', { name: 'Blue' });
+      blueRadio.focus();
+      await user.keyboard(' ');
+      expect(blueRadio).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('does not select disabled radio on click', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: optionsWithDisabled, name: 'color', 'aria-label': 'Favorite color' },
+      });
+
+      const blueRadio = screen.getByRole('radio', { name: 'Blue' });
+      await user.click(blueRadio);
+      expect(blueRadio).toHaveAttribute('aria-checked', 'false');
+    });
+  });
+
+  // 🔴 High Priority: Focus Management (Roving Tabindex)
+  describe('Focus Management (Roving Tabindex)', () => {
+    it('sets tabindex="0" on selected radio', () => {
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          'aria-label': 'Favorite color',
+          defaultValue: 'blue',
+        },
+      });
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveAttribute('tabindex', '0');
+    });
+
+    it('sets tabindex="-1" on non-selected radios', () => {
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          'aria-label': 'Favorite color',
+          defaultValue: 'blue',
+        },
+      });
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('sets tabindex="-1" on disabled radios', () => {
+      render(RadioGroup, {
+        props: { options: optionsWithDisabled, name: 'color', 'aria-label': 'Favorite color' },
+      });
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('sets tabindex="0" on first enabled radio when none selected', () => {
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', 'aria-label': 'Favorite color' },
+      });
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('tabindex', '0');
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('sets tabindex="0" on first non-disabled radio when first is disabled', () => {
+      const options = [
+        { id: 'red', label: 'Red', value: 'red', disabled: true },
+        { id: 'blue', label: 'Blue', value: 'blue' },
+        { id: 'green', label: 'Green', value: 'green' },
+      ];
+      render(RadioGroup, { props: { options, name: 'color', 'aria-label': 'Favorite color' } });
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveAttribute('tabindex', '0');
+    });
+
+    it('has only one tabindex="0" in the group', () => {
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          'aria-label': 'Favorite color',
+          defaultValue: 'blue',
+        },
+      });
+      const radios = screen.getAllByRole('radio');
+      const tabbableRadios = radios.filter((radio) => radio.getAttribute('tabindex') === '0');
+      expect(tabbableRadios).toHaveLength(1);
+    });
+  });
+
+  // 🔴 High Priority: Selection Behavior
+  describe('Selection Behavior', () => {
+    it('selects radio on click', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', 'aria-label': 'Favorite color' },
+      });
+
+      await user.click(screen.getByRole('radio', { name: 'Blue' }));
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('deselects previous radio when clicking another', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          'aria-label': 'Favorite color',
+          defaultValue: 'red',
+        },
+      });
+
+      await user.click(screen.getByRole('radio', { name: 'Blue' }));
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('aria-checked', 'false');
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('updates aria-checked on keyboard selection', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', 'aria-label': 'Favorite color' },
+      });
+
+      await user.tab();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveAttribute('aria-checked', 'true');
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('aria-checked', 'false');
+    });
+  });
+
+  // 🟡 Medium Priority: Form Integration
+  describe('Form Integration', () => {
+    it('has hidden input for form submission', () => {
+      const { container } = render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', 'aria-label': 'Favorite color' },
+      });
+      const hiddenInput = container.querySelector('input[type="hidden"][name="color"]');
+      expect(hiddenInput).toBeInTheDocument();
+    });
+
+    it('hidden input has correct name attribute', () => {
+      const { container } = render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', 'aria-label': 'Favorite color' },
+      });
+      const hiddenInput = container.querySelector('input[type="hidden"]');
+      expect(hiddenInput).toHaveAttribute('name', 'color');
+    });
+
+    it('hidden input value reflects selected value', async () => {
+      const user = userEvent.setup();
+      const { container } = render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', 'aria-label': 'Favorite color' },
+      });
+
+      const hiddenInput = container.querySelector('input[type="hidden"]') as HTMLInputElement;
+      expect(hiddenInput.value).toBe('');
+
+      await user.click(screen.getByRole('radio', { name: 'Blue' }));
+      expect(hiddenInput.value).toBe('blue');
+    });
+
+    it('hidden input has defaultValue on initial render', () => {
+      const { container } = render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          'aria-label': 'Favorite color',
+          defaultValue: 'green',
+        },
+      });
+      const hiddenInput = container.querySelector('input[type="hidden"]') as HTMLInputElement;
+      expect(hiddenInput.value).toBe('green');
+    });
+
+    it('hidden input value updates on keyboard selection', async () => {
+      const user = userEvent.setup();
+      const { container } = render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', 'aria-label': 'Favorite color' },
+      });
+
+      const hiddenInput = container.querySelector('input[type="hidden"]') as HTMLInputElement;
+      expect(hiddenInput.value).toBe('');
+
+      await user.tab();
+      await user.keyboard('{ArrowDown}');
+      expect(hiddenInput.value).toBe('blue');
+
+      await user.keyboard('{ArrowDown}');
+      expect(hiddenInput.value).toBe('green');
+    });
+  });
+
+  // 🟡 Medium Priority: Accessibility
+  describe('Accessibility', () => {
+    it('has no axe violations', async () => {
+      const { container } = render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', 'aria-label': 'Favorite color' },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with selected value', async () => {
+      const { container } = render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          'aria-label': 'Favorite color',
+          defaultValue: 'blue',
+        },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with disabled option', async () => {
+      const { container } = render(RadioGroup, {
+        props: { options: optionsWithDisabled, name: 'color', 'aria-label': 'Favorite color' },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with horizontal orientation', async () => {
+      const { container } = render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          'aria-label': 'Favorite color',
+          orientation: 'horizontal',
+        },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  // 🟢 Low Priority: Props & Behavior
+  describe('Props & Behavior', () => {
+    it('calls onValueChange when selection changes', async () => {
+      const handleValueChange = vi.fn();
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          'aria-label': 'Favorite color',
+          onValueChange: handleValueChange,
+        },
+      });
+
+      await user.click(screen.getByRole('radio', { name: 'Blue' }));
+      expect(handleValueChange).toHaveBeenCalledWith('blue');
+    });
+
+    it('applies className to container', () => {
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          'aria-label': 'Favorite color',
+          class: 'custom-class',
+        },
+      });
+      expect(screen.getByRole('radiogroup')).toHaveClass('custom-class');
+    });
+
+    it('renders with defaultValue', () => {
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          'aria-label': 'Favorite color',
+          defaultValue: 'green',
+        },
+      });
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveAttribute('aria-checked', 'true');
+    });
+  });
+});

--- a/src/patterns/radio/RadioGroup.test.vue.ts
+++ b/src/patterns/radio/RadioGroup.test.vue.ts
@@ -1,0 +1,721 @@
+import { render, screen } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+import { h } from 'vue';
+import RadioGroup from './RadioGroup.vue';
+
+// Prop/event mapping vs React:
+// - React `aria-label` / `aria-labelledby` -> Vue `ariaLabel` / `ariaLabelledby` props.
+// - React `onValueChange` callback prop -> Vue `valueChange` emit (assert via onValueChange listener).
+// - React `className` -> Vue `class`.
+// - DOM attribute `tabindex` (lowercase) used for assertions.
+// No React-specific cases are skipped; all titles are ported 1:1.
+
+const defaultOptions = [
+  { id: 'red', label: 'Red', value: 'red' },
+  { id: 'blue', label: 'Blue', value: 'blue' },
+  { id: 'green', label: 'Green', value: 'green' },
+];
+
+const optionsWithDisabled = [
+  { id: 'red', label: 'Red', value: 'red' },
+  { id: 'blue', label: 'Blue', value: 'blue', disabled: true },
+  { id: 'green', label: 'Green', value: 'green' },
+];
+
+describe('RadioGroup (Vue)', () => {
+  // 🔴 High Priority: APG ARIA Attributes
+  describe('APG ARIA Attributes', () => {
+    it('has role="radiogroup" on container', () => {
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', ariaLabel: 'Favorite color' },
+      });
+      expect(screen.getByRole('radiogroup')).toBeInTheDocument();
+    });
+
+    it('has role="radio" on each option', () => {
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', ariaLabel: 'Favorite color' },
+      });
+      const radios = screen.getAllByRole('radio');
+      expect(radios).toHaveLength(3);
+    });
+
+    it('has aria-checked attribute on radios', () => {
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', ariaLabel: 'Favorite color' },
+      });
+      const radios = screen.getAllByRole('radio');
+      radios.forEach((radio) => {
+        expect(radio).toHaveAttribute('aria-checked');
+      });
+    });
+
+    it('sets aria-checked="true" on selected radio', () => {
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          ariaLabel: 'Favorite color',
+          defaultValue: 'blue',
+        },
+      });
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveAttribute('aria-checked', 'true');
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('aria-checked', 'false');
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('sets accessible name on radiogroup via aria-label', () => {
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', ariaLabel: 'Favorite color' },
+      });
+      expect(screen.getByRole('radiogroup', { name: 'Favorite color' })).toBeInTheDocument();
+    });
+
+    it('sets accessible name on radiogroup via aria-labelledby', () => {
+      render({
+        components: { RadioGroup },
+        setup() {
+          return () =>
+            h('div', [
+              h('span', { id: 'color-label' }, 'Choose a color'),
+              h(RadioGroup, {
+                options: defaultOptions,
+                name: 'color',
+                ariaLabelledby: 'color-label',
+              }),
+            ]);
+        },
+      });
+      expect(screen.getByRole('radiogroup', { name: 'Choose a color' })).toBeInTheDocument();
+    });
+
+    it('sets accessible name on each radio', () => {
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', ariaLabel: 'Favorite color' },
+      });
+      expect(screen.getByRole('radio', { name: 'Red' })).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: 'Blue' })).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: 'Green' })).toBeInTheDocument();
+    });
+
+    it('sets aria-disabled="true" on disabled radio', () => {
+      render(RadioGroup, {
+        props: { options: optionsWithDisabled, name: 'color', ariaLabel: 'Favorite color' },
+      });
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('sets aria-orientation="horizontal" only when orientation is horizontal', async () => {
+      const { rerender } = render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          ariaLabel: 'Favorite color',
+          orientation: 'horizontal',
+        },
+      });
+      expect(screen.getByRole('radiogroup')).toHaveAttribute('aria-orientation', 'horizontal');
+
+      await rerender({
+        options: defaultOptions,
+        name: 'color',
+        ariaLabel: 'Favorite color',
+        orientation: 'vertical',
+      });
+      expect(screen.getByRole('radiogroup')).not.toHaveAttribute('aria-orientation');
+
+      await rerender({
+        options: defaultOptions,
+        name: 'color',
+        ariaLabel: 'Favorite color',
+        orientation: undefined,
+      });
+      expect(screen.getByRole('radiogroup')).not.toHaveAttribute('aria-orientation');
+    });
+  });
+
+  // 🔴 High Priority: APG Keyboard Interaction
+  describe('APG Keyboard Interaction', () => {
+    it('focuses selected radio on Tab when one is selected', async () => {
+      const user = userEvent.setup();
+      render({
+        components: { RadioGroup },
+        setup() {
+          return () =>
+            h('div', [
+              h('button', 'Before'),
+              h(RadioGroup, {
+                options: defaultOptions,
+                name: 'color',
+                ariaLabel: 'Favorite color',
+                defaultValue: 'blue',
+              }),
+            ]);
+        },
+      });
+
+      await user.tab();
+      expect(screen.getByText('Before')).toHaveFocus();
+      await user.tab();
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveFocus();
+    });
+
+    it('focuses first radio on Tab when none is selected', async () => {
+      const user = userEvent.setup();
+      render({
+        components: { RadioGroup },
+        setup() {
+          return () =>
+            h('div', [
+              h('button', 'Before'),
+              h(RadioGroup, {
+                options: defaultOptions,
+                name: 'color',
+                ariaLabel: 'Favorite color',
+              }),
+            ]);
+        },
+      });
+
+      await user.tab();
+      await user.tab();
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveFocus();
+    });
+
+    it('exits group on Tab from focused radio', async () => {
+      const user = userEvent.setup();
+      render({
+        components: { RadioGroup },
+        setup() {
+          return () =>
+            h('div', [
+              h(RadioGroup, {
+                options: defaultOptions,
+                name: 'color',
+                ariaLabel: 'Favorite color',
+              }),
+              h('button', 'After'),
+            ]);
+        },
+      });
+
+      await user.tab();
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveFocus();
+      await user.tab();
+      expect(screen.getByText('After')).toHaveFocus();
+    });
+
+    it('exits group on Shift+Tab from focused radio', async () => {
+      const user = userEvent.setup();
+      render({
+        components: { RadioGroup },
+        setup() {
+          return () =>
+            h('div', [
+              h('button', 'Before'),
+              h(RadioGroup, {
+                options: defaultOptions,
+                name: 'color',
+                ariaLabel: 'Favorite color',
+              }),
+            ]);
+        },
+      });
+
+      await user.tab();
+      expect(screen.getByText('Before')).toHaveFocus();
+      await user.tab();
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveFocus();
+      await user.tab({ shift: true });
+      expect(screen.getByText('Before')).toHaveFocus();
+    });
+
+    it('selects focused radio on Space', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', ariaLabel: 'Favorite color' },
+      });
+
+      await user.tab();
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveFocus();
+      await user.keyboard(' ');
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('does not unselect radio on Space when already selected', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          ariaLabel: 'Favorite color',
+          defaultValue: 'red',
+        },
+      });
+
+      await user.tab();
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveFocus();
+      await user.keyboard(' ');
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('moves to next radio and selects on ArrowDown', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', ariaLabel: 'Favorite color' },
+      });
+
+      await user.tab();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('moves to next radio and selects on ArrowRight', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', ariaLabel: 'Favorite color' },
+      });
+
+      await user.tab();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('moves to previous radio and selects on ArrowUp', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          ariaLabel: 'Favorite color',
+          defaultValue: 'blue',
+        },
+      });
+
+      await user.tab();
+      await user.keyboard('{ArrowUp}');
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('moves to previous radio and selects on ArrowLeft', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          ariaLabel: 'Favorite color',
+          defaultValue: 'blue',
+        },
+      });
+
+      await user.tab();
+      await user.keyboard('{ArrowLeft}');
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('moves to first radio and selects on Home', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          ariaLabel: 'Favorite color',
+          defaultValue: 'green',
+        },
+      });
+
+      await user.tab();
+      await user.keyboard('{Home}');
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('moves to last radio and selects on End', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', ariaLabel: 'Favorite color' },
+      });
+
+      await user.tab();
+      await user.keyboard('{End}');
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('wraps from last to first on ArrowDown', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          ariaLabel: 'Favorite color',
+          defaultValue: 'green',
+        },
+      });
+
+      await user.tab();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('wraps from first to last on ArrowUp', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', ariaLabel: 'Favorite color' },
+      });
+
+      await user.tab();
+      await user.keyboard('{ArrowUp}');
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('skips disabled radio on ArrowDown', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: optionsWithDisabled, name: 'color', ariaLabel: 'Favorite color' },
+      });
+
+      await user.tab();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('skips disabled radio on ArrowUp', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: {
+          options: optionsWithDisabled,
+          name: 'color',
+          ariaLabel: 'Favorite color',
+          defaultValue: 'green',
+        },
+      });
+
+      await user.tab();
+      await user.keyboard('{ArrowUp}');
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('skips disabled radio on ArrowLeft', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: {
+          options: optionsWithDisabled,
+          name: 'color',
+          ariaLabel: 'Favorite color',
+          defaultValue: 'green',
+        },
+      });
+
+      await user.tab();
+      await user.keyboard('{ArrowLeft}');
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('skips disabled radio on ArrowRight', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: optionsWithDisabled, name: 'color', ariaLabel: 'Favorite color' },
+      });
+
+      await user.tab();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveFocus();
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('does not select disabled radio on Space', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: optionsWithDisabled, name: 'color', ariaLabel: 'Favorite color' },
+      });
+
+      const blueRadio = screen.getByRole('radio', { name: 'Blue' });
+      blueRadio.focus();
+      await user.keyboard(' ');
+      expect(blueRadio).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('does not select disabled radio on click', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: optionsWithDisabled, name: 'color', ariaLabel: 'Favorite color' },
+      });
+
+      const blueRadio = screen.getByRole('radio', { name: 'Blue' });
+      await user.click(blueRadio);
+      expect(blueRadio).toHaveAttribute('aria-checked', 'false');
+    });
+  });
+
+  // 🔴 High Priority: Focus Management (Roving Tabindex)
+  describe('Focus Management (Roving Tabindex)', () => {
+    it('sets tabindex="0" on selected radio', () => {
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          ariaLabel: 'Favorite color',
+          defaultValue: 'blue',
+        },
+      });
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveAttribute('tabindex', '0');
+    });
+
+    it('sets tabindex="-1" on non-selected radios', () => {
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          ariaLabel: 'Favorite color',
+          defaultValue: 'blue',
+        },
+      });
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('sets tabindex="-1" on disabled radios', () => {
+      render(RadioGroup, {
+        props: { options: optionsWithDisabled, name: 'color', ariaLabel: 'Favorite color' },
+      });
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('sets tabindex="0" on first enabled radio when none selected', () => {
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', ariaLabel: 'Favorite color' },
+      });
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('tabindex', '0');
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('sets tabindex="0" on first non-disabled radio when first is disabled', () => {
+      const options = [
+        { id: 'red', label: 'Red', value: 'red', disabled: true },
+        { id: 'blue', label: 'Blue', value: 'blue' },
+        { id: 'green', label: 'Green', value: 'green' },
+      ];
+      render(RadioGroup, { props: { options, name: 'color', ariaLabel: 'Favorite color' } });
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveAttribute('tabindex', '0');
+    });
+
+    it('has only one tabindex="0" in the group', () => {
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          ariaLabel: 'Favorite color',
+          defaultValue: 'blue',
+        },
+      });
+      const radios = screen.getAllByRole('radio');
+      const tabbableRadios = radios.filter((radio) => radio.getAttribute('tabindex') === '0');
+      expect(tabbableRadios).toHaveLength(1);
+    });
+  });
+
+  // 🔴 High Priority: Selection Behavior
+  describe('Selection Behavior', () => {
+    it('selects radio on click', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', ariaLabel: 'Favorite color' },
+      });
+
+      await user.click(screen.getByRole('radio', { name: 'Blue' }));
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('deselects previous radio when clicking another', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          ariaLabel: 'Favorite color',
+          defaultValue: 'red',
+        },
+      });
+
+      await user.click(screen.getByRole('radio', { name: 'Blue' }));
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('aria-checked', 'false');
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('updates aria-checked on keyboard selection', async () => {
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', ariaLabel: 'Favorite color' },
+      });
+
+      await user.tab();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('radio', { name: 'Blue' })).toHaveAttribute('aria-checked', 'true');
+      expect(screen.getByRole('radio', { name: 'Red' })).toHaveAttribute('aria-checked', 'false');
+    });
+  });
+
+  // 🟡 Medium Priority: Form Integration
+  describe('Form Integration', () => {
+    it('has hidden input for form submission', () => {
+      const { container } = render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', ariaLabel: 'Favorite color' },
+      });
+      const hiddenInput = container.querySelector('input[type="hidden"][name="color"]');
+      expect(hiddenInput).toBeInTheDocument();
+    });
+
+    it('hidden input has correct name attribute', () => {
+      const { container } = render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', ariaLabel: 'Favorite color' },
+      });
+      const hiddenInput = container.querySelector('input[type="hidden"]');
+      expect(hiddenInput).toHaveAttribute('name', 'color');
+    });
+
+    it('hidden input value reflects selected value', async () => {
+      const user = userEvent.setup();
+      const { container } = render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', ariaLabel: 'Favorite color' },
+      });
+
+      const hiddenInput = container.querySelector('input[type="hidden"]') as HTMLInputElement;
+      expect(hiddenInput.value).toBe('');
+
+      await user.click(screen.getByRole('radio', { name: 'Blue' }));
+      expect(hiddenInput.value).toBe('blue');
+    });
+
+    it('hidden input has defaultValue on initial render', () => {
+      const { container } = render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          ariaLabel: 'Favorite color',
+          defaultValue: 'green',
+        },
+      });
+      const hiddenInput = container.querySelector('input[type="hidden"]') as HTMLInputElement;
+      expect(hiddenInput.value).toBe('green');
+    });
+
+    it('hidden input value updates on keyboard selection', async () => {
+      const user = userEvent.setup();
+      const { container } = render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', ariaLabel: 'Favorite color' },
+      });
+
+      const hiddenInput = container.querySelector('input[type="hidden"]') as HTMLInputElement;
+      expect(hiddenInput.value).toBe('');
+
+      await user.tab();
+      await user.keyboard('{ArrowDown}');
+      expect(hiddenInput.value).toBe('blue');
+
+      await user.keyboard('{ArrowDown}');
+      expect(hiddenInput.value).toBe('green');
+    });
+  });
+
+  // 🟡 Medium Priority: Accessibility
+  describe('Accessibility', () => {
+    it('has no axe violations', async () => {
+      const { container } = render(RadioGroup, {
+        props: { options: defaultOptions, name: 'color', ariaLabel: 'Favorite color' },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with selected value', async () => {
+      const { container } = render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          ariaLabel: 'Favorite color',
+          defaultValue: 'blue',
+        },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with disabled option', async () => {
+      const { container } = render(RadioGroup, {
+        props: { options: optionsWithDisabled, name: 'color', ariaLabel: 'Favorite color' },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with horizontal orientation', async () => {
+      const { container } = render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          ariaLabel: 'Favorite color',
+          orientation: 'horizontal',
+        },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  // 🟢 Low Priority: Props & Behavior
+  describe('Props & Behavior', () => {
+    it('calls onValueChange when selection changes', async () => {
+      const handleValueChange = vi.fn();
+      const user = userEvent.setup();
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          ariaLabel: 'Favorite color',
+          onValueChange: handleValueChange,
+        },
+      });
+
+      await user.click(screen.getByRole('radio', { name: 'Blue' }));
+      expect(handleValueChange).toHaveBeenCalledWith('blue');
+    });
+
+    it('applies className to container', () => {
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          ariaLabel: 'Favorite color',
+          class: 'custom-class',
+        },
+      });
+      expect(screen.getByRole('radiogroup')).toHaveClass('custom-class');
+    });
+
+    it('renders with defaultValue', () => {
+      render(RadioGroup, {
+        props: {
+          options: defaultOptions,
+          name: 'color',
+          ariaLabel: 'Favorite color',
+          defaultValue: 'green',
+        },
+      });
+      expect(screen.getByRole('radio', { name: 'Green' })).toHaveAttribute('aria-checked', 'true');
+    });
+  });
+});

--- a/src/patterns/slider-multithumb/MultiThumbSlider.test.astro.ts
+++ b/src/patterns/slider-multithumb/MultiThumbSlider.test.astro.ts
@@ -1,0 +1,268 @@
+/**
+ * MultiThumbSlider Astro Component Tests using Container API
+ *
+ * Verifies the MultiThumbSlider.astro initial HTML structure and ARIA attributes.
+ * Interaction cases (keyboard, pointer, focus, callbacks) are covered by Vue/Svelte
+ * unit tests and E2E; the Container API only renders initial HTML.
+ *
+ * Astro API differs from React: per-thumb labels are `aria-label-lower` /
+ * `aria-label-upper` (not a tuple), `aria-labelledby-lower` / `aria-labelledby-upper`,
+ * and `aria-describedby` is a single shared id (not a per-thumb tuple). The Astro
+ * component also has no function props (`getAriaLabel`, `getAriaValueText`).
+ *
+ * Ported structural/initial-state subset of MultiThumbSlider.test.tsx. Omitted React
+ * cases (no Astro analogue or interaction-only):
+ * - 'has accessible name via getAriaLabel function' (no function prop in Astro)
+ * - 'sets aria-valuetext with getAriaValueText' (no function prop in Astro)
+ * - 'supports aria-describedby as tuple' (Astro `aria-describedby` is a single shared id)
+ * - all keyboard/pointer/Tab interaction cases (Container API renders initial HTML only)
+ *
+ * @see https://docs.astro.build/en/reference/container-reference/
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+import MultiThumbSlider from './MultiThumbSlider.astro';
+
+describe('MultiThumbSlider (Astro Container API)', () => {
+  let container: AstroContainer;
+
+  beforeEach(async () => {
+    container = await AstroContainer.create();
+  });
+
+  async function renderSlider(props: Record<string, unknown> = {}): Promise<Document> {
+    const html = await container.renderToString(MultiThumbSlider, { props });
+    const dom = new JSDOM(html);
+    return dom.window.document;
+  }
+
+  const labels = { 'aria-label-lower': 'Min', 'aria-label-upper': 'Max' };
+
+  function sliders(doc: Document): Element[] {
+    return Array.from(doc.querySelectorAll('[role="slider"]'));
+  }
+
+  // 🔴 High Priority: ARIA Attributes
+  describe('ARIA Attributes', () => {
+    it('has two elements with role="slider"', async () => {
+      const doc = await renderSlider({ ...labels });
+      expect(sliders(doc)).toHaveLength(2);
+    });
+
+    it('has aria-valuenow set on each thumb', async () => {
+      const doc = await renderSlider({ defaultValue: [20, 80], ...labels });
+      const [lowerThumb, upperThumb] = sliders(doc);
+      expect(lowerThumb.getAttribute('aria-valuenow')).toBe('20');
+      expect(upperThumb.getAttribute('aria-valuenow')).toBe('80');
+    });
+
+    it('has correct static aria-valuemin/max on lower thumb', async () => {
+      const doc = await renderSlider({ defaultValue: [20, 80], min: 0, max: 100, ...labels });
+      const [lowerThumb] = sliders(doc);
+      expect(lowerThumb.getAttribute('aria-valuemin')).toBe('0');
+      expect(lowerThumb.getAttribute('aria-valuemax')).toBe('80');
+    });
+
+    it('has correct dynamic aria-valuemin/max on upper thumb', async () => {
+      const doc = await renderSlider({ defaultValue: [20, 80], min: 0, max: 100, ...labels });
+      const [, upperThumb] = sliders(doc);
+      expect(upperThumb.getAttribute('aria-valuemin')).toBe('20');
+      expect(upperThumb.getAttribute('aria-valuemax')).toBe('100');
+    });
+
+    it('applies minDistance to dynamic bounds', async () => {
+      const doc = await renderSlider({ defaultValue: [20, 80], minDistance: 10, ...labels });
+      const [lowerThumb, upperThumb] = sliders(doc);
+      expect(lowerThumb.getAttribute('aria-valuemax')).toBe('70');
+      expect(upperThumb.getAttribute('aria-valuemin')).toBe('30');
+    });
+
+    it('has aria-disabled="true" when disabled', async () => {
+      const doc = await renderSlider({ disabled: true, ...labels });
+      sliders(doc).forEach((slider) => {
+        expect(slider.getAttribute('aria-disabled')).toBe('true');
+      });
+    });
+
+    it('does not have aria-disabled when not disabled', async () => {
+      const doc = await renderSlider({ ...labels });
+      sliders(doc).forEach((slider) => {
+        expect(slider.hasAttribute('aria-disabled')).toBe(false);
+      });
+    });
+  });
+
+  // 🔴 High Priority: Accessible Name
+  describe('Accessible Name', () => {
+    it('has accessible name via aria-label tuple', async () => {
+      const doc = await renderSlider({
+        'aria-label-lower': 'Minimum Price',
+        'aria-label-upper': 'Maximum Price',
+      });
+      const [lowerThumb, upperThumb] = sliders(doc);
+      expect(lowerThumb.getAttribute('aria-label')).toBe('Minimum Price');
+      expect(upperThumb.getAttribute('aria-label')).toBe('Maximum Price');
+    });
+
+    it('has accessible name via aria-labelledby tuple', async () => {
+      const doc = await renderSlider({
+        'aria-labelledby-lower': 'min-label',
+        'aria-labelledby-upper': 'max-label',
+      });
+      const [lowerThumb, upperThumb] = sliders(doc);
+      expect(lowerThumb.getAttribute('aria-labelledby')).toBe('min-label');
+      expect(upperThumb.getAttribute('aria-labelledby')).toBe('max-label');
+    });
+  });
+
+  // 🔴 High Priority: Focus Management (initial render)
+  describe('Focus Management', () => {
+    it('both thumbs have tabindex="0"', async () => {
+      const doc = await renderSlider({ ...labels });
+      sliders(doc).forEach((slider) => {
+        expect(slider.getAttribute('tabindex')).toBe('0');
+      });
+    });
+
+    it('thumbs have tabindex="-1" when disabled', async () => {
+      const doc = await renderSlider({ disabled: true, ...labels });
+      sliders(doc).forEach((slider) => {
+        expect(slider.getAttribute('tabindex')).toBe('-1');
+      });
+    });
+  });
+
+  // 🔴 High Priority: Orientation
+  describe('Orientation', () => {
+    it('does not have aria-orientation for horizontal slider', async () => {
+      const doc = await renderSlider({ orientation: 'horizontal', ...labels });
+      sliders(doc).forEach((slider) => {
+        expect(slider.hasAttribute('aria-orientation')).toBe(false);
+      });
+    });
+
+    it('has aria-orientation="vertical" for vertical slider', async () => {
+      const doc = await renderSlider({ orientation: 'vertical', ...labels });
+      sliders(doc).forEach((slider) => {
+        expect(slider.getAttribute('aria-orientation')).toBe('vertical');
+      });
+    });
+  });
+
+  // 🔴 High Priority: Value Text
+  describe('Value Text', () => {
+    it('sets aria-valuetext with format', async () => {
+      const doc = await renderSlider({ defaultValue: [20, 80], format: '${value}', ...labels });
+      const [lowerThumb, upperThumb] = sliders(doc);
+      expect(lowerThumb.getAttribute('aria-valuetext')).toBe('$20');
+      expect(upperThumb.getAttribute('aria-valuetext')).toBe('$80');
+    });
+  });
+
+  // 🟡 Medium Priority: Edge Cases
+  describe('Edge Cases', () => {
+    it('handles negative min/max range', async () => {
+      const doc = await renderSlider({ defaultValue: [-30, 30], min: -50, max: 50, ...labels });
+      const [lowerThumb, upperThumb] = sliders(doc);
+      expect(lowerThumb.getAttribute('aria-valuenow')).toBe('-30');
+      expect(upperThumb.getAttribute('aria-valuenow')).toBe('30');
+      expect(lowerThumb.getAttribute('aria-valuemin')).toBe('-50');
+      expect(upperThumb.getAttribute('aria-valuemax')).toBe('50');
+    });
+
+    it('normalizes invalid defaultValue (lower > upper)', async () => {
+      const doc = await renderSlider({ defaultValue: [80, 20], ...labels });
+      const [lowerThumb, upperThumb] = sliders(doc);
+      const lowerValue = Number(lowerThumb.getAttribute('aria-valuenow'));
+      const upperValue = Number(upperThumb.getAttribute('aria-valuenow'));
+      expect(lowerValue).toBeLessThanOrEqual(upperValue);
+    });
+
+    it('clamps defaultValue to min/max', async () => {
+      const doc = await renderSlider({ defaultValue: [-10, 150], min: 0, max: 100, ...labels });
+      const [lowerThumb, upperThumb] = sliders(doc);
+      expect(lowerThumb.getAttribute('aria-valuenow')).toBe('0');
+      expect(upperThumb.getAttribute('aria-valuenow')).toBe('100');
+    });
+
+    it('rounds values to step', async () => {
+      const doc = await renderSlider({ defaultValue: [23, 77], step: 5, ...labels });
+      const [lowerThumb, upperThumb] = sliders(doc);
+      expect(lowerThumb.getAttribute('aria-valuenow')).toBe('25');
+      expect(upperThumb.getAttribute('aria-valuenow')).toBe('75');
+    });
+
+    it('uses default values when not provided', async () => {
+      const doc = await renderSlider({ ...labels });
+      const [lowerThumb, upperThumb] = sliders(doc);
+      expect(lowerThumb.getAttribute('aria-valuenow')).toBe('0');
+      expect(upperThumb.getAttribute('aria-valuenow')).toBe('100');
+    });
+  });
+
+  // 🟡 Medium Priority: Visual Display
+  describe('Visual Display', () => {
+    it('shows values when showValues is true (default)', async () => {
+      const doc = await renderSlider({ defaultValue: [20, 80], ...labels });
+      const values = doc.querySelector('.apg-slider-multithumb-values');
+      expect(values?.textContent).toContain('20');
+      expect(values?.textContent).toContain('80');
+    });
+
+    it('hides values when showValues is false', async () => {
+      const doc = await renderSlider({ defaultValue: [20, 80], showValues: false, ...labels });
+      expect(doc.querySelector('.apg-slider-multithumb-values')).toBeNull();
+    });
+
+    it('displays formatted values when format provided', async () => {
+      const doc = await renderSlider({ defaultValue: [20, 80], format: '${value}', ...labels });
+      const values = doc.querySelector('.apg-slider-multithumb-values');
+      expect(values?.textContent).toContain('$20');
+      expect(values?.textContent).toContain('$80');
+    });
+  });
+
+  // 🟢 Low Priority: HTML Attribute Inheritance
+  describe('HTML Attribute Inheritance', () => {
+    it('applies className to container', async () => {
+      const doc = await renderSlider({ ...labels, class: 'custom-slider' });
+      const containerEl = doc.querySelector('.apg-slider-multithumb');
+      expect(containerEl?.classList.contains('custom-slider')).toBe(true);
+    });
+
+    it('sets id attribute on container', async () => {
+      const doc = await renderSlider({ ...labels, id: 'my-slider' });
+      const containerEl = doc.querySelector('.apg-slider-multithumb');
+      expect(containerEl?.getAttribute('id')).toBe('my-slider');
+    });
+
+    it('passes through data-testid', async () => {
+      const doc = await renderSlider({ ...labels, 'data-testid': 'custom-slider' });
+      expect(doc.querySelector('[data-testid="custom-slider"]')).not.toBeNull();
+    });
+
+    it('supports aria-describedby as string', async () => {
+      const doc = await renderSlider({ ...labels, 'aria-describedby': 'desc' });
+      sliders(doc).forEach((slider) => {
+        expect(slider.getAttribute('aria-describedby')).toBe('desc');
+      });
+    });
+  });
+
+  // 🟢 Low Priority: Group Labeling
+  describe('Group Labeling', () => {
+    it('has role="group" on container', async () => {
+      const doc = await renderSlider({ ...labels, label: 'Price Range' });
+      expect(doc.querySelector('[role="group"]')).not.toBeNull();
+    });
+
+    it('group has accessible name via label prop', async () => {
+      const doc = await renderSlider({ ...labels, label: 'Price Range' });
+      const group = doc.querySelector('[role="group"]');
+      const labelledby = group?.getAttribute('aria-labelledby');
+      expect(labelledby).toBeTruthy();
+      expect(doc.getElementById(labelledby!)?.textContent?.trim()).toBe('Price Range');
+    });
+  });
+});

--- a/src/patterns/slider-multithumb/MultiThumbSlider.test.svelte.ts
+++ b/src/patterns/slider-multithumb/MultiThumbSlider.test.svelte.ts
@@ -1,0 +1,746 @@
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+import MultiThumbSlider from './MultiThumbSlider.svelte';
+
+// Prop/event mapping vs React:
+// - React `aria-label` / `aria-labelledby` / `aria-describedby` tuples -> Svelte
+//   `ariaLabel` / `ariaLabelledby` / `ariaDescribedby` props.
+// - React `onValueChange` callback prop -> Svelte `onvaluechange` callback prop.
+// - React `className` -> Svelte `class` (passed through restProps).
+// - External label/desc elements (for aria-labelledby/describedby) and sibling buttons
+//   (for Tab-order tests) are inserted into the document directly, mirroring the React JSX setup.
+// No React-specific cases are skipped; all titles are ported 1:1.
+
+function appendSpan(id: string, text: string) {
+  const el = document.createElement('span');
+  el.id = id;
+  el.textContent = text;
+  document.body.appendChild(el);
+}
+
+function makeButton(label: string, position: 'before' | 'after', anchor: HTMLElement) {
+  const btn = document.createElement('button');
+  btn.textContent = label;
+  if (position === 'before') {
+    anchor.parentElement!.insertBefore(btn, anchor);
+  } else {
+    anchor.parentElement!.appendChild(btn);
+  }
+  return btn;
+}
+
+function getContainer(): HTMLElement {
+  return screen.getAllByRole('slider')[0].closest('.apg-slider-multithumb') as HTMLElement;
+}
+
+describe('MultiThumbSlider (Svelte)', () => {
+  // 🔴 High Priority: ARIA Attributes
+  describe('ARIA Attributes', () => {
+    it('has two elements with role="slider"', () => {
+      render(MultiThumbSlider, { props: { ariaLabel: ['Minimum', 'Maximum'] } });
+      expect(screen.getAllByRole('slider')).toHaveLength(2);
+    });
+
+    it('has aria-valuenow set on each thumb', () => {
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], ariaLabel: ['Minimum', 'Maximum'] },
+      });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '20');
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '80');
+    });
+
+    it('has correct static aria-valuemin/max on lower thumb', () => {
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], min: 0, max: 100, ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveAttribute('aria-valuemin', '0');
+      expect(lowerThumb).toHaveAttribute('aria-valuemax', '80');
+    });
+
+    it('has correct dynamic aria-valuemin/max on upper thumb', () => {
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], min: 0, max: 100, ariaLabel: ['Min', 'Max'] },
+      });
+      const [, upperThumb] = screen.getAllByRole('slider');
+      expect(upperThumb).toHaveAttribute('aria-valuemin', '20');
+      expect(upperThumb).toHaveAttribute('aria-valuemax', '100');
+    });
+
+    it('updates upper thumb aria-valuemin when lower thumb moves', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], ariaLabel: ['Minimum', 'Maximum'] },
+      });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{ArrowRight}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '21');
+      expect(upperThumb).toHaveAttribute('aria-valuemin', '21');
+    });
+
+    it('updates lower thumb aria-valuemax when upper thumb moves', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], ariaLabel: ['Minimum', 'Maximum'] },
+      });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+
+      await user.click(upperThumb);
+      await user.keyboard('{ArrowLeft}');
+
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '79');
+      expect(lowerThumb).toHaveAttribute('aria-valuemax', '79');
+    });
+
+    it('applies minDistance to dynamic bounds', () => {
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], minDistance: 10, ariaLabel: ['Minimum', 'Maximum'] },
+      });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveAttribute('aria-valuemax', '70');
+      expect(upperThumb).toHaveAttribute('aria-valuemin', '30');
+    });
+
+    it('has aria-disabled="true" when disabled', () => {
+      render(MultiThumbSlider, { props: { disabled: true, ariaLabel: ['Minimum', 'Maximum'] } });
+      screen.getAllByRole('slider').forEach((slider) => {
+        expect(slider).toHaveAttribute('aria-disabled', 'true');
+      });
+    });
+
+    it('does not have aria-disabled when not disabled', () => {
+      render(MultiThumbSlider, { props: { ariaLabel: ['Minimum', 'Maximum'] } });
+      screen.getAllByRole('slider').forEach((slider) => {
+        expect(slider).not.toHaveAttribute('aria-disabled');
+      });
+    });
+  });
+
+  // 🔴 High Priority: Accessible Name
+  describe('Accessible Name', () => {
+    it('has accessible name via aria-label tuple', () => {
+      render(MultiThumbSlider, { props: { ariaLabel: ['Minimum Price', 'Maximum Price'] } });
+      expect(screen.getByRole('slider', { name: 'Minimum Price' })).toBeInTheDocument();
+      expect(screen.getByRole('slider', { name: 'Maximum Price' })).toBeInTheDocument();
+    });
+
+    it('has accessible name via aria-labelledby tuple', () => {
+      appendSpan('min-label', 'Min Value');
+      appendSpan('max-label', 'Max Value');
+      render(MultiThumbSlider, { props: { ariaLabelledby: ['min-label', 'max-label'] } });
+      expect(screen.getByRole('slider', { name: 'Min Value' })).toBeInTheDocument();
+      expect(screen.getByRole('slider', { name: 'Max Value' })).toBeInTheDocument();
+    });
+
+    it('has accessible name via getAriaLabel function', () => {
+      render(MultiThumbSlider, {
+        props: { getAriaLabel: (index: number) => (index === 0 ? 'Start' : 'End') },
+      });
+      expect(screen.getByRole('slider', { name: 'Start' })).toBeInTheDocument();
+      expect(screen.getByRole('slider', { name: 'End' })).toBeInTheDocument();
+    });
+  });
+
+  // 🔴 High Priority: Keyboard Interaction
+  describe('Keyboard Interaction', () => {
+    it('ArrowRight increases lower thumb value', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, { props: { defaultValue: [20, 80], ariaLabel: ['Min', 'Max'] } });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{ArrowRight}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '21');
+    });
+
+    it('ArrowRight increases upper thumb value', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, { props: { defaultValue: [20, 80], ariaLabel: ['Min', 'Max'] } });
+      const [, upperThumb] = screen.getAllByRole('slider');
+
+      await user.click(upperThumb);
+      await user.keyboard('{ArrowRight}');
+
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '81');
+    });
+
+    it('ArrowLeft decreases lower thumb value', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, { props: { defaultValue: [20, 80], ariaLabel: ['Min', 'Max'] } });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{ArrowLeft}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '19');
+    });
+
+    it('ArrowLeft decreases upper thumb value', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, { props: { defaultValue: [20, 80], ariaLabel: ['Min', 'Max'] } });
+      const [, upperThumb] = screen.getAllByRole('slider');
+
+      await user.click(upperThumb);
+      await user.keyboard('{ArrowLeft}');
+
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '79');
+    });
+
+    it('lower thumb cannot exceed upper thumb with ArrowRight', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, { props: { defaultValue: [79, 80], ariaLabel: ['Min', 'Max'] } });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{ArrowRight}');
+      await user.keyboard('{ArrowRight}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '80');
+    });
+
+    it('upper thumb cannot go below lower thumb with ArrowLeft', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, { props: { defaultValue: [20, 21], ariaLabel: ['Min', 'Max'] } });
+      const [, upperThumb] = screen.getAllByRole('slider');
+
+      await user.click(upperThumb);
+      await user.keyboard('{ArrowLeft}');
+      await user.keyboard('{ArrowLeft}');
+
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '20');
+    });
+
+    it('minDistance prevents collision on keyboard', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [45, 55], minDistance: 10, ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{ArrowRight}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '45');
+    });
+
+    it('Home on lower thumb goes to absolute min', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [30, 70], min: 0, ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{Home}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('Home on upper thumb goes to lower thumb value (dynamic min)', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [30, 70], min: 0, ariaLabel: ['Min', 'Max'] },
+      });
+      const [, upperThumb] = screen.getAllByRole('slider');
+
+      await user.click(upperThumb);
+      await user.keyboard('{Home}');
+
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '30');
+    });
+
+    it('End on lower thumb goes to upper thumb value (dynamic max)', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [30, 70], max: 100, ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{End}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '70');
+    });
+
+    it('End on upper thumb goes to absolute max', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [30, 70], max: 100, ariaLabel: ['Min', 'Max'] },
+      });
+      const [, upperThumb] = screen.getAllByRole('slider');
+
+      await user.click(upperThumb);
+      await user.keyboard('{End}');
+
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '100');
+    });
+
+    it('Home/End respects minDistance', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: {
+          defaultValue: [30, 70],
+          minDistance: 10,
+          min: 0,
+          max: 100,
+          ariaLabel: ['Min', 'Max'],
+        },
+      });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{End}');
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '60');
+
+      await user.click(upperThumb);
+      await user.keyboard('{Home}');
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '70');
+    });
+
+    it('PageUp increases value by largeStep', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, { props: { defaultValue: [20, 80], ariaLabel: ['Min', 'Max'] } });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{PageUp}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '30');
+    });
+
+    it('PageDown decreases value by largeStep', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, { props: { defaultValue: [20, 80], ariaLabel: ['Min', 'Max'] } });
+      const [, upperThumb] = screen.getAllByRole('slider');
+
+      await user.click(upperThumb);
+      await user.keyboard('{PageDown}');
+
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '70');
+    });
+
+    it('PageUp respects thumb constraints', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, { props: { defaultValue: [75, 80], ariaLabel: ['Min', 'Max'] } });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{PageUp}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '80');
+    });
+
+    it('does not change value when disabled', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], disabled: true, ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      lowerThumb.focus();
+      await user.keyboard('{ArrowRight}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '20');
+    });
+  });
+
+  // 🔴 High Priority: Focus Management
+  describe('Focus Management', () => {
+    it('both thumbs have tabindex="0"', () => {
+      render(MultiThumbSlider, { props: { ariaLabel: ['Min', 'Max'] } });
+      screen.getAllByRole('slider').forEach((slider) => {
+        expect(slider).toHaveAttribute('tabindex', '0');
+      });
+    });
+
+    it('Tab moves to lower thumb first', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, { props: { ariaLabel: ['Min', 'Max'] } });
+      makeButton('Before', 'before', getContainer());
+
+      await user.tab();
+      await user.tab();
+
+      const [lowerThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveFocus();
+    });
+
+    it('Tab moves from lower to upper thumb', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, { props: { ariaLabel: ['Min', 'Max'] } });
+      makeButton('Before', 'before', getContainer());
+
+      await user.tab();
+      await user.tab();
+      await user.tab();
+
+      const [, upperThumb] = screen.getAllByRole('slider');
+      expect(upperThumb).toHaveFocus();
+    });
+
+    it('Tab order is constant regardless of thumb positions', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, { props: { defaultValue: [80, 90], ariaLabel: ['Min', 'Max'] } });
+      makeButton('Before', 'before', getContainer());
+
+      await user.tab();
+      await user.tab();
+
+      const [lowerThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveFocus();
+    });
+
+    it('thumbs have tabindex="-1" when disabled', () => {
+      render(MultiThumbSlider, { props: { disabled: true, ariaLabel: ['Min', 'Max'] } });
+      screen.getAllByRole('slider').forEach((slider) => {
+        expect(slider).toHaveAttribute('tabindex', '-1');
+      });
+    });
+
+    it('is not focusable via Tab when disabled', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, { props: { disabled: true, ariaLabel: ['Min', 'Max'] } });
+      const container = getContainer();
+      makeButton('Before', 'before', container);
+      makeButton('After', 'after', container);
+
+      await user.tab();
+      await user.tab();
+
+      expect(screen.getByRole('button', { name: 'After' })).toHaveFocus();
+    });
+  });
+
+  // 🔴 High Priority: Orientation
+  describe('Orientation', () => {
+    it('does not have aria-orientation for horizontal slider', () => {
+      render(MultiThumbSlider, { props: { orientation: 'horizontal', ariaLabel: ['Min', 'Max'] } });
+      screen.getAllByRole('slider').forEach((slider) => {
+        expect(slider).not.toHaveAttribute('aria-orientation');
+      });
+    });
+
+    it('has aria-orientation="vertical" for vertical slider', () => {
+      render(MultiThumbSlider, { props: { orientation: 'vertical', ariaLabel: ['Min', 'Max'] } });
+      screen.getAllByRole('slider').forEach((slider) => {
+        expect(slider).toHaveAttribute('aria-orientation', 'vertical');
+      });
+    });
+
+    it('ArrowUp increases value in vertical mode', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], orientation: 'vertical', ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{ArrowUp}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '21');
+    });
+
+    it('ArrowDown decreases value in vertical mode', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], orientation: 'vertical', ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{ArrowDown}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '19');
+    });
+  });
+
+  // 🔴 High Priority: Value Text
+  describe('Value Text', () => {
+    it('sets aria-valuetext with format', () => {
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], format: '${value}', ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveAttribute('aria-valuetext', '$20');
+      expect(upperThumb).toHaveAttribute('aria-valuetext', '$80');
+    });
+
+    it('sets aria-valuetext with getAriaValueText', () => {
+      render(MultiThumbSlider, {
+        props: {
+          defaultValue: [20, 80],
+          getAriaValueText: (value: number, index: number) =>
+            `${index === 0 ? 'From' : 'To'} ${value}%`,
+          ariaLabel: ['Min', 'Max'],
+        },
+      });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveAttribute('aria-valuetext', 'From 20%');
+      expect(upperThumb).toHaveAttribute('aria-valuetext', 'To 80%');
+    });
+
+    it('updates aria-valuetext on value change', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], format: '${value}', ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{ArrowRight}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuetext', '$21');
+    });
+  });
+
+  // 🟡 Medium Priority: Accessibility
+  describe('Accessibility', () => {
+    it('has no axe violations', async () => {
+      const { container } = render(MultiThumbSlider, {
+        props: { ariaLabel: ['Minimum', 'Maximum'] },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with aria-labelledby', async () => {
+      appendSpan('min', 'Min');
+      appendSpan('max', 'Max');
+      const { container } = render(MultiThumbSlider, { props: { ariaLabelledby: ['min', 'max'] } });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations when disabled', async () => {
+      const { container } = render(MultiThumbSlider, {
+        props: { disabled: true, ariaLabel: ['Minimum', 'Maximum'] },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with minDistance', async () => {
+      const { container } = render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], minDistance: 10, ariaLabel: ['Min', 'Max'] },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations for vertical slider', async () => {
+      const { container } = render(MultiThumbSlider, {
+        props: { orientation: 'vertical', ariaLabel: ['Min', 'Max'] },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  // 🟡 Medium Priority: Callbacks
+  describe('Callbacks', () => {
+    it('calls onValueChange with values array and activeIndex', async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], onvaluechange: handleChange, ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{ArrowRight}');
+
+      expect(handleChange).toHaveBeenCalledWith([21, 80], 0);
+    });
+
+    it('calls onValueChange with correct index for upper thumb', async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], onvaluechange: handleChange, ariaLabel: ['Min', 'Max'] },
+      });
+      const [, upperThumb] = screen.getAllByRole('slider');
+
+      await user.click(upperThumb);
+      await user.keyboard('{ArrowLeft}');
+
+      expect(handleChange).toHaveBeenCalledWith([20, 79], 1);
+    });
+
+    it('does not call onValueChange when disabled', async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: {
+          defaultValue: [20, 80],
+          disabled: true,
+          onvaluechange: handleChange,
+          ariaLabel: ['Min', 'Max'],
+        },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      lowerThumb.focus();
+      await user.keyboard('{ArrowRight}');
+
+      expect(handleChange).not.toHaveBeenCalled();
+    });
+
+    it('does not call onValueChange when value does not change', async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [80, 80], onvaluechange: handleChange, ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{ArrowRight}');
+
+      expect(handleChange).not.toHaveBeenCalled();
+    });
+  });
+
+  // 🟡 Medium Priority: Edge Cases
+  describe('Edge Cases', () => {
+    it('handles decimal step values correctly', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [0.2, 0.8], min: 0, max: 1, step: 0.1, ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{ArrowRight}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '0.3');
+    });
+
+    it('handles negative min/max range', () => {
+      render(MultiThumbSlider, {
+        props: { defaultValue: [-30, 30], min: -50, max: 50, ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '-30');
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '30');
+      expect(lowerThumb).toHaveAttribute('aria-valuemin', '-50');
+      expect(upperThumb).toHaveAttribute('aria-valuemax', '50');
+    });
+
+    it('normalizes invalid defaultValue (lower > upper)', () => {
+      render(MultiThumbSlider, { props: { defaultValue: [80, 20], ariaLabel: ['Min', 'Max'] } });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+      const lowerValue = Number(lowerThumb.getAttribute('aria-valuenow'));
+      const upperValue = Number(upperThumb.getAttribute('aria-valuenow'));
+      expect(lowerValue).toBeLessThanOrEqual(upperValue);
+    });
+
+    it('clamps defaultValue to min/max', () => {
+      render(MultiThumbSlider, {
+        props: { defaultValue: [-10, 150], min: 0, max: 100, ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '0');
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '100');
+    });
+
+    it('rounds values to step', () => {
+      render(MultiThumbSlider, {
+        props: { defaultValue: [23, 77], step: 5, ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '25');
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '75');
+    });
+
+    it('uses default values when not provided', () => {
+      render(MultiThumbSlider, { props: { ariaLabel: ['Min', 'Max'] } });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '0');
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '100');
+    });
+  });
+
+  // 🟡 Medium Priority: Visual Display
+  describe('Visual Display', () => {
+    it('shows values when showValues is true (default)', () => {
+      render(MultiThumbSlider, { props: { defaultValue: [20, 80], ariaLabel: ['Min', 'Max'] } });
+      expect(screen.getByText('20')).toBeInTheDocument();
+      expect(screen.getByText('80')).toBeInTheDocument();
+    });
+
+    it('hides values when showValues is false', () => {
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], showValues: false, ariaLabel: ['Min', 'Max'] },
+      });
+      expect(screen.queryByText('20')).not.toBeInTheDocument();
+      expect(screen.queryByText('80')).not.toBeInTheDocument();
+    });
+
+    it('displays formatted values when format provided', () => {
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], format: '${value}', ariaLabel: ['Min', 'Max'] },
+      });
+      expect(screen.getByText('$20')).toBeInTheDocument();
+      expect(screen.getByText('$80')).toBeInTheDocument();
+    });
+  });
+
+  // 🟢 Low Priority: HTML Attribute Inheritance
+  describe('HTML Attribute Inheritance', () => {
+    it('applies className to container', () => {
+      render(MultiThumbSlider, { props: { ariaLabel: ['Min', 'Max'], class: 'custom-slider' } });
+      expect(getContainer()).toHaveClass('custom-slider');
+    });
+
+    it('sets id attribute on container', () => {
+      render(MultiThumbSlider, { props: { ariaLabel: ['Min', 'Max'], id: 'my-slider' } });
+      expect(getContainer()).toHaveAttribute('id', 'my-slider');
+    });
+
+    it('passes through data-testid', () => {
+      render(MultiThumbSlider, {
+        props: { ariaLabel: ['Min', 'Max'], 'data-testid': 'custom-slider' },
+      });
+      expect(screen.getByTestId('custom-slider')).toBeInTheDocument();
+    });
+
+    it('supports aria-describedby as string', () => {
+      appendSpan('desc', 'Select a range');
+      render(MultiThumbSlider, { props: { ariaLabel: ['Min', 'Max'], ariaDescribedby: 'desc' } });
+      screen.getAllByRole('slider').forEach((slider) => {
+        expect(slider).toHaveAttribute('aria-describedby', 'desc');
+      });
+    });
+
+    it('supports aria-describedby as tuple', () => {
+      appendSpan('min-desc', 'Minimum value');
+      appendSpan('max-desc', 'Maximum value');
+      render(MultiThumbSlider, {
+        props: { ariaLabel: ['Min', 'Max'], ariaDescribedby: ['min-desc', 'max-desc'] },
+      });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveAttribute('aria-describedby', 'min-desc');
+      expect(upperThumb).toHaveAttribute('aria-describedby', 'max-desc');
+    });
+  });
+
+  // 🟢 Low Priority: Group Labeling
+  describe('Group Labeling', () => {
+    it('has role="group" on container', () => {
+      render(MultiThumbSlider, { props: { ariaLabel: ['Min', 'Max'], label: 'Price Range' } });
+      expect(screen.getByRole('group')).toBeInTheDocument();
+    });
+
+    it('group has accessible name via label prop', () => {
+      render(MultiThumbSlider, { props: { ariaLabel: ['Min', 'Max'], label: 'Price Range' } });
+      expect(screen.getByRole('group', { name: 'Price Range' })).toBeInTheDocument();
+    });
+  });
+});

--- a/src/patterns/slider-multithumb/MultiThumbSlider.test.vue.ts
+++ b/src/patterns/slider-multithumb/MultiThumbSlider.test.vue.ts
@@ -1,0 +1,783 @@
+import { render, screen } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+import { h } from 'vue';
+import MultiThumbSlider from './MultiThumbSlider.vue';
+
+// Prop/event mapping vs React:
+// - React `aria-label` / `aria-labelledby` / `aria-describedby` tuples -> Vue
+//   `ariaLabel` / `ariaLabelledby` / `ariaDescribedby` props.
+// - React `onValueChange` callback prop -> Vue `valueChange` emit (assert via onValueChange listener).
+// - React `className` -> Vue `class` (passed through $attrs).
+// No React-specific cases are skipped; all titles are ported 1:1.
+
+describe('MultiThumbSlider (Vue)', () => {
+  // 🔴 High Priority: ARIA Attributes
+  describe('ARIA Attributes', () => {
+    it('has two elements with role="slider"', () => {
+      render(MultiThumbSlider, { props: { ariaLabel: ['Minimum', 'Maximum'] } });
+      expect(screen.getAllByRole('slider')).toHaveLength(2);
+    });
+
+    it('has aria-valuenow set on each thumb', () => {
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], ariaLabel: ['Minimum', 'Maximum'] },
+      });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '20');
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '80');
+    });
+
+    it('has correct static aria-valuemin/max on lower thumb', () => {
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], min: 0, max: 100, ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveAttribute('aria-valuemin', '0');
+      expect(lowerThumb).toHaveAttribute('aria-valuemax', '80');
+    });
+
+    it('has correct dynamic aria-valuemin/max on upper thumb', () => {
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], min: 0, max: 100, ariaLabel: ['Min', 'Max'] },
+      });
+      const [, upperThumb] = screen.getAllByRole('slider');
+      expect(upperThumb).toHaveAttribute('aria-valuemin', '20');
+      expect(upperThumb).toHaveAttribute('aria-valuemax', '100');
+    });
+
+    it('updates upper thumb aria-valuemin when lower thumb moves', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], ariaLabel: ['Minimum', 'Maximum'] },
+      });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{ArrowRight}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '21');
+      expect(upperThumb).toHaveAttribute('aria-valuemin', '21');
+    });
+
+    it('updates lower thumb aria-valuemax when upper thumb moves', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], ariaLabel: ['Minimum', 'Maximum'] },
+      });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+
+      await user.click(upperThumb);
+      await user.keyboard('{ArrowLeft}');
+
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '79');
+      expect(lowerThumb).toHaveAttribute('aria-valuemax', '79');
+    });
+
+    it('applies minDistance to dynamic bounds', () => {
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], minDistance: 10, ariaLabel: ['Minimum', 'Maximum'] },
+      });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveAttribute('aria-valuemax', '70');
+      expect(upperThumb).toHaveAttribute('aria-valuemin', '30');
+    });
+
+    it('has aria-disabled="true" when disabled', () => {
+      render(MultiThumbSlider, { props: { disabled: true, ariaLabel: ['Minimum', 'Maximum'] } });
+      screen.getAllByRole('slider').forEach((slider) => {
+        expect(slider).toHaveAttribute('aria-disabled', 'true');
+      });
+    });
+
+    it('does not have aria-disabled when not disabled', () => {
+      render(MultiThumbSlider, { props: { ariaLabel: ['Minimum', 'Maximum'] } });
+      screen.getAllByRole('slider').forEach((slider) => {
+        expect(slider).not.toHaveAttribute('aria-disabled');
+      });
+    });
+  });
+
+  // 🔴 High Priority: Accessible Name
+  describe('Accessible Name', () => {
+    it('has accessible name via aria-label tuple', () => {
+      render(MultiThumbSlider, { props: { ariaLabel: ['Minimum Price', 'Maximum Price'] } });
+      expect(screen.getByRole('slider', { name: 'Minimum Price' })).toBeInTheDocument();
+      expect(screen.getByRole('slider', { name: 'Maximum Price' })).toBeInTheDocument();
+    });
+
+    it('has accessible name via aria-labelledby tuple', () => {
+      render({
+        components: { MultiThumbSlider },
+        setup() {
+          return () =>
+            h('div', [
+              h('span', { id: 'min-label' }, 'Min Value'),
+              h('span', { id: 'max-label' }, 'Max Value'),
+              h(MultiThumbSlider, { ariaLabelledby: ['min-label', 'max-label'] }),
+            ]);
+        },
+      });
+      expect(screen.getByRole('slider', { name: 'Min Value' })).toBeInTheDocument();
+      expect(screen.getByRole('slider', { name: 'Max Value' })).toBeInTheDocument();
+    });
+
+    it('has accessible name via getAriaLabel function', () => {
+      render(MultiThumbSlider, {
+        props: { getAriaLabel: (index: number) => (index === 0 ? 'Start' : 'End') },
+      });
+      expect(screen.getByRole('slider', { name: 'Start' })).toBeInTheDocument();
+      expect(screen.getByRole('slider', { name: 'End' })).toBeInTheDocument();
+    });
+  });
+
+  // 🔴 High Priority: Keyboard Interaction
+  describe('Keyboard Interaction', () => {
+    it('ArrowRight increases lower thumb value', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, { props: { defaultValue: [20, 80], ariaLabel: ['Min', 'Max'] } });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{ArrowRight}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '21');
+    });
+
+    it('ArrowRight increases upper thumb value', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, { props: { defaultValue: [20, 80], ariaLabel: ['Min', 'Max'] } });
+      const [, upperThumb] = screen.getAllByRole('slider');
+
+      await user.click(upperThumb);
+      await user.keyboard('{ArrowRight}');
+
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '81');
+    });
+
+    it('ArrowLeft decreases lower thumb value', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, { props: { defaultValue: [20, 80], ariaLabel: ['Min', 'Max'] } });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{ArrowLeft}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '19');
+    });
+
+    it('ArrowLeft decreases upper thumb value', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, { props: { defaultValue: [20, 80], ariaLabel: ['Min', 'Max'] } });
+      const [, upperThumb] = screen.getAllByRole('slider');
+
+      await user.click(upperThumb);
+      await user.keyboard('{ArrowLeft}');
+
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '79');
+    });
+
+    it('lower thumb cannot exceed upper thumb with ArrowRight', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, { props: { defaultValue: [79, 80], ariaLabel: ['Min', 'Max'] } });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{ArrowRight}');
+      await user.keyboard('{ArrowRight}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '80');
+    });
+
+    it('upper thumb cannot go below lower thumb with ArrowLeft', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, { props: { defaultValue: [20, 21], ariaLabel: ['Min', 'Max'] } });
+      const [, upperThumb] = screen.getAllByRole('slider');
+
+      await user.click(upperThumb);
+      await user.keyboard('{ArrowLeft}');
+      await user.keyboard('{ArrowLeft}');
+
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '20');
+    });
+
+    it('minDistance prevents collision on keyboard', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [45, 55], minDistance: 10, ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{ArrowRight}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '45');
+    });
+
+    it('Home on lower thumb goes to absolute min', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [30, 70], min: 0, ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{Home}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('Home on upper thumb goes to lower thumb value (dynamic min)', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [30, 70], min: 0, ariaLabel: ['Min', 'Max'] },
+      });
+      const [, upperThumb] = screen.getAllByRole('slider');
+
+      await user.click(upperThumb);
+      await user.keyboard('{Home}');
+
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '30');
+    });
+
+    it('End on lower thumb goes to upper thumb value (dynamic max)', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [30, 70], max: 100, ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{End}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '70');
+    });
+
+    it('End on upper thumb goes to absolute max', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [30, 70], max: 100, ariaLabel: ['Min', 'Max'] },
+      });
+      const [, upperThumb] = screen.getAllByRole('slider');
+
+      await user.click(upperThumb);
+      await user.keyboard('{End}');
+
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '100');
+    });
+
+    it('Home/End respects minDistance', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: {
+          defaultValue: [30, 70],
+          minDistance: 10,
+          min: 0,
+          max: 100,
+          ariaLabel: ['Min', 'Max'],
+        },
+      });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{End}');
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '60');
+
+      await user.click(upperThumb);
+      await user.keyboard('{Home}');
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '70');
+    });
+
+    it('PageUp increases value by largeStep', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, { props: { defaultValue: [20, 80], ariaLabel: ['Min', 'Max'] } });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{PageUp}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '30');
+    });
+
+    it('PageDown decreases value by largeStep', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, { props: { defaultValue: [20, 80], ariaLabel: ['Min', 'Max'] } });
+      const [, upperThumb] = screen.getAllByRole('slider');
+
+      await user.click(upperThumb);
+      await user.keyboard('{PageDown}');
+
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '70');
+    });
+
+    it('PageUp respects thumb constraints', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, { props: { defaultValue: [75, 80], ariaLabel: ['Min', 'Max'] } });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{PageUp}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '80');
+    });
+
+    it('does not change value when disabled', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], disabled: true, ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      lowerThumb.focus();
+      await user.keyboard('{ArrowRight}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '20');
+    });
+  });
+
+  // 🔴 High Priority: Focus Management
+  describe('Focus Management', () => {
+    it('both thumbs have tabindex="0"', () => {
+      render(MultiThumbSlider, { props: { ariaLabel: ['Min', 'Max'] } });
+      screen.getAllByRole('slider').forEach((slider) => {
+        expect(slider).toHaveAttribute('tabindex', '0');
+      });
+    });
+
+    it('Tab moves to lower thumb first', async () => {
+      const user = userEvent.setup();
+      render({
+        components: { MultiThumbSlider },
+        setup() {
+          return () =>
+            h('div', [h('button', 'Before'), h(MultiThumbSlider, { ariaLabel: ['Min', 'Max'] })]);
+        },
+      });
+
+      await user.tab();
+      await user.tab();
+
+      const [lowerThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveFocus();
+    });
+
+    it('Tab moves from lower to upper thumb', async () => {
+      const user = userEvent.setup();
+      render({
+        components: { MultiThumbSlider },
+        setup() {
+          return () =>
+            h('div', [h('button', 'Before'), h(MultiThumbSlider, { ariaLabel: ['Min', 'Max'] })]);
+        },
+      });
+
+      await user.tab();
+      await user.tab();
+      await user.tab();
+
+      const [, upperThumb] = screen.getAllByRole('slider');
+      expect(upperThumb).toHaveFocus();
+    });
+
+    it('Tab order is constant regardless of thumb positions', async () => {
+      const user = userEvent.setup();
+      render({
+        components: { MultiThumbSlider },
+        setup() {
+          return () =>
+            h('div', [
+              h('button', 'Before'),
+              h(MultiThumbSlider, { defaultValue: [80, 90], ariaLabel: ['Min', 'Max'] }),
+            ]);
+        },
+      });
+
+      await user.tab();
+      await user.tab();
+
+      const [lowerThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveFocus();
+    });
+
+    it('thumbs have tabindex="-1" when disabled', () => {
+      render(MultiThumbSlider, { props: { disabled: true, ariaLabel: ['Min', 'Max'] } });
+      screen.getAllByRole('slider').forEach((slider) => {
+        expect(slider).toHaveAttribute('tabindex', '-1');
+      });
+    });
+
+    it('is not focusable via Tab when disabled', async () => {
+      const user = userEvent.setup();
+      render({
+        components: { MultiThumbSlider },
+        setup() {
+          return () =>
+            h('div', [
+              h('button', 'Before'),
+              h(MultiThumbSlider, { disabled: true, ariaLabel: ['Min', 'Max'] }),
+              h('button', 'After'),
+            ]);
+        },
+      });
+
+      await user.tab();
+      await user.tab();
+
+      expect(screen.getByRole('button', { name: 'After' })).toHaveFocus();
+    });
+  });
+
+  // 🔴 High Priority: Orientation
+  describe('Orientation', () => {
+    it('does not have aria-orientation for horizontal slider', () => {
+      render(MultiThumbSlider, { props: { orientation: 'horizontal', ariaLabel: ['Min', 'Max'] } });
+      screen.getAllByRole('slider').forEach((slider) => {
+        expect(slider).not.toHaveAttribute('aria-orientation');
+      });
+    });
+
+    it('has aria-orientation="vertical" for vertical slider', () => {
+      render(MultiThumbSlider, { props: { orientation: 'vertical', ariaLabel: ['Min', 'Max'] } });
+      screen.getAllByRole('slider').forEach((slider) => {
+        expect(slider).toHaveAttribute('aria-orientation', 'vertical');
+      });
+    });
+
+    it('ArrowUp increases value in vertical mode', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], orientation: 'vertical', ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{ArrowUp}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '21');
+    });
+
+    it('ArrowDown decreases value in vertical mode', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], orientation: 'vertical', ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{ArrowDown}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '19');
+    });
+  });
+
+  // 🔴 High Priority: Value Text
+  describe('Value Text', () => {
+    it('sets aria-valuetext with format', () => {
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], format: '${value}', ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveAttribute('aria-valuetext', '$20');
+      expect(upperThumb).toHaveAttribute('aria-valuetext', '$80');
+    });
+
+    it('sets aria-valuetext with getAriaValueText', () => {
+      render(MultiThumbSlider, {
+        props: {
+          defaultValue: [20, 80],
+          getAriaValueText: (value: number, index: number) =>
+            `${index === 0 ? 'From' : 'To'} ${value}%`,
+          ariaLabel: ['Min', 'Max'],
+        },
+      });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveAttribute('aria-valuetext', 'From 20%');
+      expect(upperThumb).toHaveAttribute('aria-valuetext', 'To 80%');
+    });
+
+    it('updates aria-valuetext on value change', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], format: '${value}', ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{ArrowRight}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuetext', '$21');
+    });
+  });
+
+  // 🟡 Medium Priority: Accessibility
+  describe('Accessibility', () => {
+    it('has no axe violations', async () => {
+      const { container } = render(MultiThumbSlider, {
+        props: { ariaLabel: ['Minimum', 'Maximum'] },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with aria-labelledby', async () => {
+      const { container } = render({
+        components: { MultiThumbSlider },
+        setup() {
+          return () =>
+            h('div', [
+              h('span', { id: 'min' }, 'Min'),
+              h('span', { id: 'max' }, 'Max'),
+              h(MultiThumbSlider, { ariaLabelledby: ['min', 'max'] }),
+            ]);
+        },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations when disabled', async () => {
+      const { container } = render(MultiThumbSlider, {
+        props: { disabled: true, ariaLabel: ['Minimum', 'Maximum'] },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with minDistance', async () => {
+      const { container } = render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], minDistance: 10, ariaLabel: ['Min', 'Max'] },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations for vertical slider', async () => {
+      const { container } = render(MultiThumbSlider, {
+        props: { orientation: 'vertical', ariaLabel: ['Min', 'Max'] },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  // 🟡 Medium Priority: Callbacks
+  describe('Callbacks', () => {
+    it('calls onValueChange with values array and activeIndex', async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], onValueChange: handleChange, ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{ArrowRight}');
+
+      expect(handleChange).toHaveBeenCalledWith([21, 80], 0);
+    });
+
+    it('calls onValueChange with correct index for upper thumb', async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], onValueChange: handleChange, ariaLabel: ['Min', 'Max'] },
+      });
+      const [, upperThumb] = screen.getAllByRole('slider');
+
+      await user.click(upperThumb);
+      await user.keyboard('{ArrowLeft}');
+
+      expect(handleChange).toHaveBeenCalledWith([20, 79], 1);
+    });
+
+    it('does not call onValueChange when disabled', async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: {
+          defaultValue: [20, 80],
+          disabled: true,
+          onValueChange: handleChange,
+          ariaLabel: ['Min', 'Max'],
+        },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      lowerThumb.focus();
+      await user.keyboard('{ArrowRight}');
+
+      expect(handleChange).not.toHaveBeenCalled();
+    });
+
+    it('does not call onValueChange when value does not change', async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [80, 80], onValueChange: handleChange, ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{ArrowRight}');
+
+      expect(handleChange).not.toHaveBeenCalled();
+    });
+  });
+
+  // 🟡 Medium Priority: Edge Cases
+  describe('Edge Cases', () => {
+    it('handles decimal step values correctly', async () => {
+      const user = userEvent.setup();
+      render(MultiThumbSlider, {
+        props: { defaultValue: [0.2, 0.8], min: 0, max: 1, step: 0.1, ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb] = screen.getAllByRole('slider');
+
+      await user.click(lowerThumb);
+      await user.keyboard('{ArrowRight}');
+
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '0.3');
+    });
+
+    it('handles negative min/max range', () => {
+      render(MultiThumbSlider, {
+        props: { defaultValue: [-30, 30], min: -50, max: 50, ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '-30');
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '30');
+      expect(lowerThumb).toHaveAttribute('aria-valuemin', '-50');
+      expect(upperThumb).toHaveAttribute('aria-valuemax', '50');
+    });
+
+    it('normalizes invalid defaultValue (lower > upper)', () => {
+      render(MultiThumbSlider, { props: { defaultValue: [80, 20], ariaLabel: ['Min', 'Max'] } });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+      const lowerValue = Number(lowerThumb.getAttribute('aria-valuenow'));
+      const upperValue = Number(upperThumb.getAttribute('aria-valuenow'));
+      expect(lowerValue).toBeLessThanOrEqual(upperValue);
+    });
+
+    it('clamps defaultValue to min/max', () => {
+      render(MultiThumbSlider, {
+        props: { defaultValue: [-10, 150], min: 0, max: 100, ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '0');
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '100');
+    });
+
+    it('rounds values to step', () => {
+      render(MultiThumbSlider, {
+        props: { defaultValue: [23, 77], step: 5, ariaLabel: ['Min', 'Max'] },
+      });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '25');
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '75');
+    });
+
+    it('uses default values when not provided', () => {
+      render(MultiThumbSlider, { props: { ariaLabel: ['Min', 'Max'] } });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveAttribute('aria-valuenow', '0');
+      expect(upperThumb).toHaveAttribute('aria-valuenow', '100');
+    });
+  });
+
+  // 🟡 Medium Priority: Visual Display
+  describe('Visual Display', () => {
+    it('shows values when showValues is true (default)', () => {
+      render(MultiThumbSlider, { props: { defaultValue: [20, 80], ariaLabel: ['Min', 'Max'] } });
+      expect(screen.getByText('20')).toBeInTheDocument();
+      expect(screen.getByText('80')).toBeInTheDocument();
+    });
+
+    it('hides values when showValues is false', () => {
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], showValues: false, ariaLabel: ['Min', 'Max'] },
+      });
+      expect(screen.queryByText('20')).not.toBeInTheDocument();
+      expect(screen.queryByText('80')).not.toBeInTheDocument();
+    });
+
+    it('displays formatted values when format provided', () => {
+      render(MultiThumbSlider, {
+        props: { defaultValue: [20, 80], format: '${value}', ariaLabel: ['Min', 'Max'] },
+      });
+      expect(screen.getByText('$20')).toBeInTheDocument();
+      expect(screen.getByText('$80')).toBeInTheDocument();
+    });
+  });
+
+  // 🟢 Low Priority: HTML Attribute Inheritance
+  describe('HTML Attribute Inheritance', () => {
+    it('applies className to container', () => {
+      render(MultiThumbSlider, { props: { ariaLabel: ['Min', 'Max'], class: 'custom-slider' } });
+      const container = screen.getAllByRole('slider')[0].closest('.apg-slider-multithumb');
+      expect(container).toHaveClass('custom-slider');
+    });
+
+    it('sets id attribute on container', () => {
+      render(MultiThumbSlider, { props: { ariaLabel: ['Min', 'Max'], id: 'my-slider' } });
+      const container = screen.getAllByRole('slider')[0].closest('.apg-slider-multithumb');
+      expect(container).toHaveAttribute('id', 'my-slider');
+    });
+
+    it('passes through data-testid', () => {
+      render(MultiThumbSlider, {
+        props: { ariaLabel: ['Min', 'Max'], 'data-testid': 'custom-slider' },
+      });
+      expect(screen.getByTestId('custom-slider')).toBeInTheDocument();
+    });
+
+    it('supports aria-describedby as string', () => {
+      render({
+        components: { MultiThumbSlider },
+        setup() {
+          return () =>
+            h('div', [
+              h(MultiThumbSlider, { ariaLabel: ['Min', 'Max'], ariaDescribedby: 'desc' }),
+              h('p', { id: 'desc' }, 'Select a range'),
+            ]);
+        },
+      });
+      screen.getAllByRole('slider').forEach((slider) => {
+        expect(slider).toHaveAttribute('aria-describedby', 'desc');
+      });
+    });
+
+    it('supports aria-describedby as tuple', () => {
+      render({
+        components: { MultiThumbSlider },
+        setup() {
+          return () =>
+            h('div', [
+              h(MultiThumbSlider, {
+                ariaLabel: ['Min', 'Max'],
+                ariaDescribedby: ['min-desc', 'max-desc'],
+              }),
+              h('p', { id: 'min-desc' }, 'Minimum value'),
+              h('p', { id: 'max-desc' }, 'Maximum value'),
+            ]);
+        },
+      });
+      const [lowerThumb, upperThumb] = screen.getAllByRole('slider');
+      expect(lowerThumb).toHaveAttribute('aria-describedby', 'min-desc');
+      expect(upperThumb).toHaveAttribute('aria-describedby', 'max-desc');
+    });
+  });
+
+  // 🟢 Low Priority: Group Labeling
+  describe('Group Labeling', () => {
+    it('has role="group" on container', () => {
+      render(MultiThumbSlider, { props: { ariaLabel: ['Min', 'Max'], label: 'Price Range' } });
+      expect(screen.getByRole('group')).toBeInTheDocument();
+    });
+
+    it('group has accessible name via label prop', () => {
+      render(MultiThumbSlider, { props: { ariaLabel: ['Min', 'Max'], label: 'Price Range' } });
+      expect(screen.getByRole('group', { name: 'Price Range' })).toBeInTheDocument();
+    });
+  });
+});

--- a/src/patterns/treegrid/TreeGrid.test.astro.ts
+++ b/src/patterns/treegrid/TreeGrid.test.astro.ts
@@ -1,0 +1,442 @@
+/**
+ * TreeGrid Astro Component Tests using Container API
+ *
+ * Verifies the TreeGrid.astro initial HTML structure and ARIA attributes.
+ * Interaction cases (keyboard navigation, selection, expansion toggles, focus
+ * movement, mouse) are covered by the Vue unit tests and E2E; the Container API
+ * only renders initial HTML.
+ *
+ * Astro renders ALL data rows up-front and hides collapsed subtrees with
+ * `style="display: none"` (rather than omitting them from the DOM). Structural
+ * counts therefore reflect the full row/cell set.
+ *
+ * Ported structural/initial-state subset of TreeGrid.test.tsx. Interaction-only
+ * React cases are omitted here — they require a browser and are covered elsewhere.
+ *
+ * @see https://docs.astro.build/en/reference/container-reference/
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+import TreeGrid from './TreeGrid.astro';
+
+const createBasicColumns = () => [
+  { id: 'name', header: 'Name', isRowHeader: true },
+  { id: 'size', header: 'Size' },
+  { id: 'date', header: 'Date Modified' },
+];
+
+const createBasicNodes = () => [
+  {
+    id: 'docs',
+    cells: [
+      { id: 'docs-name', value: 'Documents' },
+      { id: 'docs-size', value: '--' },
+      { id: 'docs-date', value: '2024-01-15' },
+    ],
+    children: [
+      {
+        id: 'report',
+        cells: [
+          { id: 'report-name', value: 'report.pdf' },
+          { id: 'report-size', value: '2.5 MB' },
+          { id: 'report-date', value: '2024-01-10' },
+        ],
+      },
+      {
+        id: 'notes',
+        cells: [
+          { id: 'notes-name', value: 'notes.txt' },
+          { id: 'notes-size', value: '1 KB' },
+          { id: 'notes-date', value: '2024-01-05' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'images',
+    cells: [
+      { id: 'images-name', value: 'Images' },
+      { id: 'images-size', value: '--' },
+      { id: 'images-date', value: '2024-01-20' },
+    ],
+    children: [
+      {
+        id: 'photo1',
+        cells: [
+          { id: 'photo1-name', value: 'photo1.jpg' },
+          { id: 'photo1-size', value: '3 MB' },
+          { id: 'photo1-date', value: '2024-01-18' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'readme',
+    cells: [
+      { id: 'readme-name', value: 'README.md' },
+      { id: 'readme-size', value: '4 KB' },
+      { id: 'readme-date', value: '2024-01-01' },
+    ],
+  },
+];
+
+const createNestedNodes = () => [
+  {
+    id: 'root',
+    cells: [
+      { id: 'root-name', value: 'Root' },
+      { id: 'root-size', value: '--' },
+    ],
+    children: [
+      {
+        id: 'level2',
+        cells: [
+          { id: 'level2-name', value: 'Level 2' },
+          { id: 'level2-size', value: '--' },
+        ],
+        children: [
+          {
+            id: 'level3',
+            cells: [
+              { id: 'level3-name', value: 'Level 3' },
+              { id: 'level3-size', value: '1 KB' },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const createNodesWithDisabled = () => [
+  {
+    id: 'docs',
+    cells: [
+      { id: 'docs-name', value: 'Documents' },
+      { id: 'docs-size', value: '--' },
+    ],
+    disabled: true,
+    children: [
+      {
+        id: 'report',
+        cells: [
+          { id: 'report-name', value: 'report.pdf' },
+          { id: 'report-size', value: '2.5 MB' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'readme',
+    cells: [
+      { id: 'readme-name', value: 'README.md' },
+      { id: 'readme-size', value: '4 KB' },
+    ],
+  },
+];
+
+describe('TreeGrid (Astro Container API)', () => {
+  let container: AstroContainer;
+
+  beforeEach(async () => {
+    container = await AstroContainer.create();
+  });
+
+  async function renderGrid(props: Record<string, unknown>): Promise<Document> {
+    const html = await container.renderToString(TreeGrid, { props });
+    const dom = new JSDOM(html);
+    return dom.window.document;
+  }
+
+  function rowByHeaderText(doc: Document, text: string): Element | undefined {
+    return Array.from(doc.querySelectorAll('[role="row"]')).find((r) =>
+      r.querySelector('[role="rowheader"]')?.textContent?.includes(text)
+    );
+  }
+
+  describe('ARIA Attributes', () => {
+    it('has role="treegrid" on container', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        nodes: createBasicNodes(),
+        ariaLabel: 'Files',
+      });
+      expect(doc.querySelector('[role="treegrid"]')).not.toBeNull();
+    });
+
+    it('has role="row" on all rows', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        nodes: createBasicNodes(),
+        ariaLabel: 'Files',
+        defaultExpandedIds: ['docs', 'images'],
+      });
+      // Header row + 6 data rows (Astro renders all rows up-front) = 7
+      expect(doc.querySelectorAll('[role="row"]')).toHaveLength(7);
+    });
+
+    it('has role="gridcell" on data cells', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        nodes: createBasicNodes(),
+        ariaLabel: 'Files',
+        defaultExpandedIds: ['docs', 'images'],
+      });
+      expect(doc.querySelectorAll('[role="gridcell"]')).toHaveLength(12);
+    });
+
+    it('has role="columnheader" on header cells', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        nodes: createBasicNodes(),
+        ariaLabel: 'Files',
+      });
+      expect(doc.querySelectorAll('[role="columnheader"]')).toHaveLength(3);
+    });
+
+    it('has role="rowheader" on first column cells', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        nodes: createBasicNodes(),
+        ariaLabel: 'Files',
+        defaultExpandedIds: ['docs', 'images'],
+      });
+      expect(doc.querySelectorAll('[role="rowheader"]')).toHaveLength(6);
+    });
+
+    it('has accessible name via aria-label', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        nodes: createBasicNodes(),
+        ariaLabel: 'Files',
+      });
+      expect(doc.querySelector('[role="treegrid"]')?.getAttribute('aria-label')).toBe('Files');
+    });
+
+    it('has accessible name via aria-labelledby', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        nodes: createBasicNodes(),
+        ariaLabelledby: 'grid-title',
+      });
+      expect(doc.querySelector('[role="treegrid"]')?.getAttribute('aria-labelledby')).toBe(
+        'grid-title'
+      );
+    });
+
+    it('parent rows have aria-expanded', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        nodes: createBasicNodes(),
+        ariaLabel: 'Files',
+      });
+      expect(rowByHeaderText(doc, 'Documents')?.hasAttribute('aria-expanded')).toBe(true);
+      expect(rowByHeaderText(doc, 'Images')?.hasAttribute('aria-expanded')).toBe(true);
+    });
+
+    it('leaf rows do NOT have aria-expanded', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        nodes: createBasicNodes(),
+        ariaLabel: 'Files',
+      });
+      expect(rowByHeaderText(doc, 'README.md')?.hasAttribute('aria-expanded')).toBe(false);
+    });
+
+    it('has aria-level on all data rows', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        nodes: createBasicNodes(),
+        ariaLabel: 'Files',
+        defaultExpandedIds: ['docs', 'images'],
+      });
+      const dataRows = Array.from(doc.querySelectorAll('[role="row"]')).filter((r) =>
+        r.hasAttribute('aria-level')
+      );
+      expect(dataRows.length).toBeGreaterThan(0);
+      dataRows.forEach((row) => {
+        expect(row.hasAttribute('aria-level')).toBe(true);
+      });
+    });
+
+    it('aria-level increments with depth (1-based)', async () => {
+      const columns = [
+        { id: 'name', header: 'Name', isRowHeader: true },
+        { id: 'size', header: 'Size' },
+      ];
+      const doc = await renderGrid({
+        columns,
+        nodes: createNestedNodes(),
+        ariaLabel: 'Files',
+        defaultExpandedIds: ['root', 'level2'],
+      });
+      expect(rowByHeaderText(doc, 'Root')?.getAttribute('aria-level')).toBe('1');
+      expect(rowByHeaderText(doc, 'Level 2')?.getAttribute('aria-level')).toBe('2');
+      expect(rowByHeaderText(doc, 'Level 3')?.getAttribute('aria-level')).toBe('3');
+    });
+
+    it('has aria-selected on row (not gridcell) when selectable', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        nodes: createBasicNodes(),
+        ariaLabel: 'Files',
+        selectable: true,
+      });
+      const dataRows = Array.from(doc.querySelectorAll('[role="row"]')).filter((r) =>
+        r.hasAttribute('aria-level')
+      );
+      dataRows.forEach((row) => {
+        expect(row.getAttribute('aria-selected')).toBe('false');
+      });
+      doc.querySelectorAll('[role="gridcell"]').forEach((cell) => {
+        expect(cell.hasAttribute('aria-selected')).toBe(false);
+      });
+    });
+
+    it('has aria-multiselectable when multiselectable', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        nodes: createBasicNodes(),
+        ariaLabel: 'Files',
+        selectable: true,
+        multiselectable: true,
+      });
+      expect(doc.querySelector('[role="treegrid"]')?.getAttribute('aria-multiselectable')).toBe(
+        'true'
+      );
+    });
+
+    it('has aria-disabled on disabled rows', async () => {
+      const columns = [
+        { id: 'name', header: 'Name', isRowHeader: true },
+        { id: 'size', header: 'Size' },
+      ];
+      const doc = await renderGrid({
+        columns,
+        nodes: createNodesWithDisabled(),
+        ariaLabel: 'Files',
+      });
+      expect(rowByHeaderText(doc, 'Documents')?.getAttribute('aria-disabled')).toBe('true');
+    });
+  });
+
+  describe('Focus Management', () => {
+    it('only one cell has tabIndex="0"', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        nodes: createBasicNodes(),
+        ariaLabel: 'Files',
+        defaultExpandedIds: ['docs'],
+      });
+      const cells = Array.from(doc.querySelectorAll('[role="rowheader"], [role="gridcell"]'));
+      const tab0 = cells.filter((c) => c.getAttribute('tabindex') === '0');
+      expect(tab0).toHaveLength(1);
+    });
+
+    it('other cells have tabIndex="-1"', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        nodes: createBasicNodes(),
+        ariaLabel: 'Files',
+      });
+      const cells = Array.from(doc.querySelectorAll('[role="gridcell"]'));
+      const minus1 = cells.filter((c) => c.getAttribute('tabindex') === '-1');
+      expect(minus1.length).toBe(cells.length);
+    });
+
+    it('columnheader cells are not focusable', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        nodes: createBasicNodes(),
+        ariaLabel: 'Files',
+      });
+      doc.querySelectorAll('[role="columnheader"]').forEach((header) => {
+        expect(header.hasAttribute('tabindex')).toBe(false);
+      });
+    });
+
+    it('disabled cells are focusable', async () => {
+      const columns = [
+        { id: 'name', header: 'Name', isRowHeader: true },
+        { id: 'size', header: 'Size' },
+      ];
+      const doc = await renderGrid({
+        columns,
+        nodes: createNodesWithDisabled(),
+        ariaLabel: 'Files',
+      });
+      const docsRowheader = Array.from(doc.querySelectorAll('[role="rowheader"]')).find((r) =>
+        r.textContent?.includes('Documents')
+      );
+      expect(docsRowheader?.hasAttribute('tabindex')).toBe(true);
+    });
+  });
+
+  describe('Virtualization Support', () => {
+    it('has aria-rowcount when totalRows provided', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        nodes: createBasicNodes(),
+        ariaLabel: 'Files',
+        totalRows: 100,
+      });
+      expect(doc.querySelector('[role="treegrid"]')?.getAttribute('aria-rowcount')).toBe('100');
+    });
+
+    it('has aria-colcount when totalColumns provided', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        nodes: createBasicNodes(),
+        ariaLabel: 'Files',
+        totalColumns: 10,
+      });
+      expect(doc.querySelector('[role="treegrid"]')?.getAttribute('aria-colcount')).toBe('10');
+    });
+
+    it('has aria-rowindex on rows when virtualizing', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        nodes: createBasicNodes(),
+        ariaLabel: 'Files',
+        totalRows: 100,
+        startRowIndex: 10,
+      });
+      const rows = Array.from(doc.querySelectorAll('[role="row"]')).filter((r) =>
+        r.hasAttribute('aria-level')
+      );
+      expect(rows[0].getAttribute('aria-rowindex')).toBe('10');
+      expect(rows[1].getAttribute('aria-rowindex')).toBe('11');
+      expect(rows[2].getAttribute('aria-rowindex')).toBe('12');
+    });
+
+    it('has aria-colindex on cells when virtualizing', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        nodes: createBasicNodes(),
+        ariaLabel: 'Files',
+        totalColumns: 10,
+        startColIndex: 5,
+      });
+      const firstRowCells = [
+        doc.querySelectorAll('[role="rowheader"]')[0],
+        ...Array.from(doc.querySelectorAll('[role="gridcell"]')).slice(0, 2),
+      ];
+      expect(firstRowCells[0].getAttribute('aria-colindex')).toBe('5');
+      expect(firstRowCells[1].getAttribute('aria-colindex')).toBe('6');
+      expect(firstRowCells[2].getAttribute('aria-colindex')).toBe('7');
+    });
+  });
+
+  describe('Props', () => {
+    it('applies className to container', async () => {
+      const doc = await renderGrid({
+        columns: createBasicColumns(),
+        nodes: createBasicNodes(),
+        ariaLabel: 'Files',
+        class: 'custom-grid',
+      });
+      expect(doc.querySelector('.apg-treegrid')?.classList.contains('custom-grid')).toBe(true);
+    });
+  });
+});

--- a/src/patterns/treegrid/TreeGrid.test.svelte.ts
+++ b/src/patterns/treegrid/TreeGrid.test.svelte.ts
@@ -1,0 +1,1081 @@
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+import { tick } from 'svelte';
+import TreeGrid from './TreeGrid.svelte';
+import type { TreeGridColumnDef, TreeGridNodeData } from './TreeGrid.svelte';
+
+// Prop/event mapping vs React:
+// - React `ariaLabel` / `ariaLabelledby` -> Vue `ariaLabel` / `ariaLabelledby` (same names).
+// - React `onCellActivate` / `onSelectionChange` / `onExpandedChange` / `onFocusChange` callback
+//   props -> Svelte same-named callback props.
+// - External label element (aria-labelledby) and sibling buttons (Tab-exit test) are inserted
+//   into the document directly, mirroring the React JSX setup.
+// - The Svelte TreeGrid sets up focusable-element tabindex via an $effect, so `renderTree`
+//   awaits a tick after mounting (mirrors React's synchronous render) before assertions.
+//
+// All titles are ported 1:1, but 9 expand/collapse/selection interaction cases are it.skip
+// (NOT React-specific). They PASS when run in isolation but FAIL when a preceding test in the
+// same file collapses a `defaultExpandedIds` node: the Svelte 5 reactivity scheduler leaks
+// across testing-library/svelte cleanup so the next instance's first expand/collapse/selection
+// keyboard or click action does not flush to the DOM. cleanup() + flushSync() + extra tick()s
+// in afterEach do not resolve it. This is an environmental Svelte-5-under-jsdom interaction
+// (the same family as the two treeview skips), not an APG/component defect — verified by the
+// identical cases passing standalone and by the Vue/Astro ports passing. Reported for the reviewer.
+const renderTree = async (
+  ...args: Parameters<typeof render>
+): Promise<ReturnType<typeof render>> => {
+  const result = render(...args);
+  await tick();
+  return result;
+};
+
+const createBasicColumns = (): TreeGridColumnDef[] => [
+  { id: 'name', header: 'Name', isRowHeader: true },
+  { id: 'size', header: 'Size' },
+  { id: 'date', header: 'Date Modified' },
+];
+
+const createBasicNodes = (): TreeGridNodeData[] => [
+  {
+    id: 'docs',
+    cells: [
+      { id: 'docs-name', value: 'Documents' },
+      { id: 'docs-size', value: '--' },
+      { id: 'docs-date', value: '2024-01-15' },
+    ],
+    children: [
+      {
+        id: 'report',
+        cells: [
+          { id: 'report-name', value: 'report.pdf' },
+          { id: 'report-size', value: '2.5 MB' },
+          { id: 'report-date', value: '2024-01-10' },
+        ],
+      },
+      {
+        id: 'notes',
+        cells: [
+          { id: 'notes-name', value: 'notes.txt' },
+          { id: 'notes-size', value: '1 KB' },
+          { id: 'notes-date', value: '2024-01-05' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'images',
+    cells: [
+      { id: 'images-name', value: 'Images' },
+      { id: 'images-size', value: '--' },
+      { id: 'images-date', value: '2024-01-20' },
+    ],
+    children: [
+      {
+        id: 'photo1',
+        cells: [
+          { id: 'photo1-name', value: 'photo1.jpg' },
+          { id: 'photo1-size', value: '3 MB' },
+          { id: 'photo1-date', value: '2024-01-18' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'readme',
+    cells: [
+      { id: 'readme-name', value: 'README.md' },
+      { id: 'readme-size', value: '4 KB' },
+      { id: 'readme-date', value: '2024-01-01' },
+    ],
+  },
+];
+
+const createNestedNodes = (): TreeGridNodeData[] => [
+  {
+    id: 'root',
+    cells: [
+      { id: 'root-name', value: 'Root' },
+      { id: 'root-size', value: '--' },
+    ],
+    children: [
+      {
+        id: 'level2',
+        cells: [
+          { id: 'level2-name', value: 'Level 2' },
+          { id: 'level2-size', value: '--' },
+        ],
+        children: [
+          {
+            id: 'level3',
+            cells: [
+              { id: 'level3-name', value: 'Level 3' },
+              { id: 'level3-size', value: '1 KB' },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const createNodesWithDisabled = (): TreeGridNodeData[] => [
+  {
+    id: 'docs',
+    cells: [
+      { id: 'docs-name', value: 'Documents' },
+      { id: 'docs-size', value: '--' },
+    ],
+    disabled: true,
+    children: [
+      {
+        id: 'report',
+        cells: [
+          { id: 'report-name', value: 'report.pdf' },
+          { id: 'report-size', value: '2.5 MB' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'readme',
+    cells: [
+      { id: 'readme-name', value: 'README.md' },
+      { id: 'readme-size', value: '4 KB' },
+    ],
+  },
+];
+
+describe('TreeGrid (Svelte)', () => {
+  describe('ARIA Attributes', () => {
+    it('has role="treegrid" on container', async () => {
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      expect(screen.getByRole('treegrid')).toBeInTheDocument();
+    });
+
+    it('has role="row" on all rows', async () => {
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs', 'images'],
+        },
+      });
+      expect(screen.getAllByRole('row')).toHaveLength(7);
+    });
+
+    it('has role="gridcell" on data cells', async () => {
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs', 'images'],
+        },
+      });
+      expect(screen.getAllByRole('gridcell')).toHaveLength(12);
+    });
+
+    it('has role="columnheader" on header cells', async () => {
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      expect(screen.getAllByRole('columnheader')).toHaveLength(3);
+    });
+
+    it('has role="rowheader" on first column cells', async () => {
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs', 'images'],
+        },
+      });
+      expect(screen.getAllByRole('rowheader')).toHaveLength(6);
+    });
+
+    it('has accessible name via aria-label', async () => {
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      expect(screen.getByRole('treegrid', { name: 'Files' })).toBeInTheDocument();
+    });
+
+    it('has accessible name via aria-labelledby', async () => {
+      const heading = document.createElement('h2');
+      heading.id = 'grid-title';
+      heading.textContent = 'File Browser';
+      document.body.appendChild(heading);
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabelledby: 'grid-title',
+        },
+      });
+      expect(screen.getByRole('treegrid')).toHaveAttribute('aria-labelledby', 'grid-title');
+    });
+
+    it('parent rows have aria-expanded', async () => {
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const rows = screen.getAllByRole('row').filter((r) => r.hasAttribute('aria-level'));
+      const docsRow = rows.find((r) =>
+        r.querySelector('[role="rowheader"]')?.textContent?.includes('Documents')
+      );
+      const imagesRow = rows.find((r) =>
+        r.querySelector('[role="rowheader"]')?.textContent?.includes('Images')
+      );
+      expect(docsRow).toHaveAttribute('aria-expanded');
+      expect(imagesRow).toHaveAttribute('aria-expanded');
+    });
+
+    it('leaf rows do NOT have aria-expanded', async () => {
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const rows = screen.getAllByRole('row').filter((r) => r.hasAttribute('aria-level'));
+      const readmeRow = rows.find((r) =>
+        r.querySelector('[role="rowheader"]')?.textContent?.includes('README.md')
+      );
+      expect(readmeRow).not.toHaveAttribute('aria-expanded');
+    });
+
+    it('has aria-level on all data rows', async () => {
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs', 'images'],
+        },
+      });
+      const dataRows = screen.getAllByRole('row').filter((r) => r.hasAttribute('aria-level'));
+      expect(dataRows.length).toBeGreaterThan(0);
+      dataRows.forEach((row) => {
+        expect(row).toHaveAttribute('aria-level');
+      });
+    });
+
+    it('aria-level increments with depth (1-based)', async () => {
+      const columns: TreeGridColumnDef[] = [
+        { id: 'name', header: 'Name', isRowHeader: true },
+        { id: 'size', header: 'Size' },
+      ];
+      await renderTree(TreeGrid, {
+        props: {
+          columns,
+          nodes: createNestedNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['root', 'level2'],
+        },
+      });
+      const rows = screen.getAllByRole('row').filter((r) => r.hasAttribute('aria-level'));
+      const rootRow = rows.find((r) =>
+        r.querySelector('[role="rowheader"]')?.textContent?.includes('Root')
+      );
+      const level2Row = rows.find((r) =>
+        r.querySelector('[role="rowheader"]')?.textContent?.includes('Level 2')
+      );
+      const level3Row = rows.find((r) =>
+        r.querySelector('[role="rowheader"]')?.textContent?.includes('Level 3')
+      );
+      expect(rootRow).toHaveAttribute('aria-level', '1');
+      expect(level2Row).toHaveAttribute('aria-level', '2');
+      expect(level3Row).toHaveAttribute('aria-level', '3');
+    });
+
+    it('has aria-selected on row (not gridcell) when selectable', async () => {
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          selectable: true,
+        },
+      });
+      const dataRows = screen.getAllByRole('row').filter((r) => r.hasAttribute('aria-level'));
+      dataRows.forEach((row) => {
+        expect(row).toHaveAttribute('aria-selected', 'false');
+      });
+      screen.getAllByRole('gridcell').forEach((cell) => {
+        expect(cell).not.toHaveAttribute('aria-selected');
+      });
+    });
+
+    it('has aria-multiselectable when multiselectable', async () => {
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          selectable: true,
+          multiselectable: true,
+        },
+      });
+      expect(screen.getByRole('treegrid')).toHaveAttribute('aria-multiselectable', 'true');
+    });
+
+    it('has aria-disabled on disabled rows', async () => {
+      const columns: TreeGridColumnDef[] = [
+        { id: 'name', header: 'Name', isRowHeader: true },
+        { id: 'size', header: 'Size' },
+      ];
+      await renderTree(TreeGrid, {
+        props: { columns, nodes: createNodesWithDisabled(), ariaLabel: 'Files' },
+      });
+      const docsRow = screen
+        .getAllByRole('row')
+        .find((r) => r.querySelector('[role="rowheader"]')?.textContent?.includes('Documents'));
+      expect(docsRow).toHaveAttribute('aria-disabled', 'true');
+    });
+  });
+
+  describe('Keyboard - Row Navigation', () => {
+    it('ArrowDown moves to same column in next visible row', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+        },
+      });
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('rowheader', { name: 'report.pdf' })).toHaveFocus();
+    });
+
+    it('ArrowUp moves to same column in previous visible row', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+        },
+      });
+      screen.getByRole('rowheader', { name: 'report.pdf' }).focus();
+      await user.keyboard('{ArrowUp}');
+      expect(screen.getByRole('rowheader', { name: 'Documents' })).toHaveFocus();
+    });
+
+    it('ArrowDown skips collapsed child rows', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('rowheader', { name: 'Images' })).toHaveFocus();
+    });
+
+    it('ArrowUp stops at first visible row', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      docsRowheader.focus();
+      await user.keyboard('{ArrowUp}');
+      expect(docsRowheader).toHaveFocus();
+    });
+
+    it('ArrowDown stops at last visible row', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const readmeRowheader = screen.getByRole('rowheader', { name: 'README.md' });
+      readmeRowheader.focus();
+      await user.keyboard('{ArrowDown}');
+      expect(readmeRowheader).toHaveFocus();
+    });
+
+    it('maintains column position during row navigation', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+        },
+      });
+      const docsSizeCell = screen.getAllByRole('gridcell', { name: '--' })[0];
+      docsSizeCell.focus();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('gridcell', { name: '2.5 MB' })).toHaveFocus();
+    });
+  });
+
+  describe('Keyboard - Cell Navigation', () => {
+    it('ArrowRight moves right at non-rowheader cells', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const sizeCell = screen.getAllByRole('gridcell', { name: '--' })[0];
+      sizeCell.focus();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('gridcell', { name: '2024-01-15' })).toHaveFocus();
+    });
+
+    it('ArrowLeft moves left at non-rowheader cells', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const dateCell = screen.getByRole('gridcell', { name: '2024-01-15' });
+      dateCell.focus();
+      await user.keyboard('{ArrowLeft}');
+      expect(screen.getAllByRole('gridcell', { name: '--' })[0]).toHaveFocus();
+    });
+
+    it('ArrowRight at non-rowheader does NOT expand', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const sizeCell = screen.getAllByRole('gridcell', { name: '--' })[0];
+      sizeCell.focus();
+      const parentRow = sizeCell.closest('[role="row"]');
+      expect(parentRow).toHaveAttribute('aria-expanded', 'false');
+      await user.keyboard('{ArrowRight}');
+      expect(parentRow).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('ArrowLeft at non-rowheader does NOT collapse', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+        },
+      });
+      const dateCell = screen.getByRole('gridcell', { name: '2024-01-15' });
+      dateCell.focus();
+      const parentRow = dateCell.closest('[role="row"]');
+      expect(parentRow).toHaveAttribute('aria-expanded', 'true');
+      await user.keyboard('{ArrowLeft}');
+      expect(parentRow).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('Home moves to first cell in row', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const dateCell = screen.getByRole('gridcell', { name: '2024-01-15' });
+      dateCell.focus();
+      await user.keyboard('{Home}');
+      expect(screen.getByRole('rowheader', { name: 'Documents' })).toHaveFocus();
+    });
+
+    it('End moves to last cell in row', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.keyboard('{End}');
+      expect(screen.getByRole('gridcell', { name: '2024-01-15' })).toHaveFocus();
+    });
+
+    it('Ctrl+Home moves to first cell in grid', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      screen.getByRole('rowheader', { name: 'README.md' }).focus();
+      await user.keyboard('{Control>}{Home}{/Control}');
+      expect(screen.getByRole('rowheader', { name: 'Documents' })).toHaveFocus();
+    });
+
+    it('Ctrl+End moves to last cell in grid', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.keyboard('{Control>}{End}{/Control}');
+      expect(screen.getByRole('gridcell', { name: '2024-01-01' })).toHaveFocus();
+    });
+  });
+
+  describe('Keyboard - Tree Operations', () => {
+    // SKIP: see file header — Svelte-5 reactivity scheduler leak across tests (passes in isolation; not an APG/component defect).
+    it.skip('ArrowRight expands collapsed parent row at rowheader', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      docsRowheader.focus();
+      const parentRow = docsRowheader.closest('[role="row"]');
+      expect(parentRow).toHaveAttribute('aria-expanded', 'false');
+      await user.keyboard('{ArrowRight}');
+      expect(parentRow).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('ArrowRight moves to next cell when expanded at rowheader', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+        },
+      });
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getAllByRole('gridcell', { name: '--' })[0]).toHaveFocus();
+    });
+
+    it('ArrowRight moves to next cell on leaf row at rowheader', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      screen.getByRole('rowheader', { name: 'README.md' }).focus();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('gridcell', { name: '4 KB' })).toHaveFocus();
+    });
+
+    // SKIP: see file header — Svelte-5 reactivity scheduler leak across tests (passes in isolation; not an APG/component defect).
+    it.skip('ArrowLeft collapses expanded parent row at rowheader', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+        },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      docsRowheader.focus();
+      const parentRow = docsRowheader.closest('[role="row"]');
+      expect(parentRow).toHaveAttribute('aria-expanded', 'true');
+      await user.keyboard('{ArrowLeft}');
+      expect(parentRow).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('ArrowLeft moves to parent when collapsed at rowheader', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+        },
+      });
+      screen.getByRole('rowheader', { name: 'report.pdf' }).focus();
+      await user.keyboard('{ArrowLeft}');
+      expect(screen.getByRole('rowheader', { name: 'Documents' })).toHaveFocus();
+    });
+
+    it('ArrowLeft does nothing at root level collapsed row', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      docsRowheader.focus();
+      const parentRow = docsRowheader.closest('[role="row"]');
+      expect(parentRow).toHaveAttribute('aria-expanded', 'false');
+      await user.keyboard('{ArrowLeft}');
+      expect(docsRowheader).toHaveFocus();
+    });
+  });
+
+  describe('Keyboard - Selection & Activation', () => {
+    it('Enter activates cell (calls onCellActivate)', async () => {
+      const user = userEvent.setup();
+      const onCellActivate = vi.fn();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          onCellActivate,
+        },
+      });
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.keyboard('{Enter}');
+      expect(onCellActivate).toHaveBeenCalledWith('docs-name', 'docs', 'name');
+    });
+
+    it('Enter does NOT expand/collapse', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      docsRowheader.focus();
+      const parentRow = docsRowheader.closest('[role="row"]');
+      expect(parentRow).toHaveAttribute('aria-expanded', 'false');
+      await user.keyboard('{Enter}');
+      expect(parentRow).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    // SKIP: see file header — Svelte-5 reactivity scheduler leak across tests (passes in isolation; not an APG/component defect).
+    it.skip('Space toggles row selection', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          selectable: true,
+        },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      docsRowheader.focus();
+      const row = docsRowheader.closest('[role="row"]');
+      expect(row).toHaveAttribute('aria-selected', 'false');
+      await user.keyboard(' ');
+      expect(row).toHaveAttribute('aria-selected', 'true');
+      await user.keyboard(' ');
+      expect(row).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('Space does not select disabled row', async () => {
+      const user = userEvent.setup();
+      const columns: TreeGridColumnDef[] = [
+        { id: 'name', header: 'Name', isRowHeader: true },
+        { id: 'size', header: 'Size' },
+      ];
+      await renderTree(TreeGrid, {
+        props: { columns, nodes: createNodesWithDisabled(), ariaLabel: 'Files', selectable: true },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      docsRowheader.focus();
+      const row = docsRowheader.closest('[role="row"]');
+      expect(row).toHaveAttribute('aria-disabled', 'true');
+      expect(row).toHaveAttribute('aria-selected', 'false');
+      await user.keyboard(' ');
+      expect(row).toHaveAttribute('aria-selected', 'false');
+    });
+
+    // SKIP: see file header — Svelte-5 reactivity scheduler leak across tests (passes in isolation; not an APG/component defect).
+    it.skip('Ctrl+A selects all visible rows (multiselectable)', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          selectable: true,
+          multiselectable: true,
+        },
+      });
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.keyboard('{Control>}a{/Control}');
+      const dataRows = screen.getAllByRole('row').filter((r) => r.hasAttribute('aria-level'));
+      dataRows.forEach((row) => {
+        expect(row).toHaveAttribute('aria-selected', 'true');
+      });
+    });
+
+    // SKIP: see file header — Svelte-5 reactivity scheduler leak across tests (passes in isolation; not an APG/component defect).
+    it.skip('single selection clears previous on Space', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          selectable: true,
+        },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      docsRowheader.focus();
+      await user.keyboard(' ');
+      const docsRow = docsRowheader.closest('[role="row"]');
+      expect(docsRow).toHaveAttribute('aria-selected', 'true');
+      await user.keyboard('{ArrowDown}');
+      await user.keyboard(' ');
+      const imagesRow = screen.getByRole('rowheader', { name: 'Images' }).closest('[role="row"]');
+      expect(imagesRow).toHaveAttribute('aria-selected', 'true');
+      expect(docsRow).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('calls onSelectionChange callback', async () => {
+      const user = userEvent.setup();
+      const onSelectionChange = vi.fn();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          selectable: true,
+          onSelectionChange,
+        },
+      });
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.keyboard(' ');
+      expect(onSelectionChange).toHaveBeenCalledWith(['docs']);
+    });
+  });
+
+  describe('Focus Management', () => {
+    it('only one cell has tabIndex="0"', async () => {
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+        },
+      });
+      const allFocusableCells = screen
+        .getAllByRole('rowheader')
+        .concat(screen.getAllByRole('gridcell'));
+      const tabIndex0Cells = allFocusableCells.filter(
+        (cell) => cell.getAttribute('tabindex') === '0'
+      );
+      expect(tabIndex0Cells).toHaveLength(1);
+    });
+
+    it('other cells have tabIndex="-1"', async () => {
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const cells = screen.getAllByRole('gridcell');
+      const tabIndexMinus1Cells = cells.filter((cell) => cell.getAttribute('tabindex') === '-1');
+      expect(tabIndexMinus1Cells.length).toBe(cells.length);
+    });
+
+    it("focus moves to parent when child's parent collapses", async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+        },
+      });
+      screen.getByRole('rowheader', { name: 'report.pdf' }).focus();
+      await user.keyboard('{ArrowLeft}');
+      await user.keyboard('{ArrowLeft}');
+      expect(screen.getByRole('rowheader', { name: 'Documents' })).toHaveFocus();
+    });
+
+    it('columnheader cells are not focusable', async () => {
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      screen.getAllByRole('columnheader').forEach((header) => {
+        expect(header).not.toHaveAttribute('tabindex');
+      });
+    });
+
+    it('disabled cells are focusable', async () => {
+      const columns: TreeGridColumnDef[] = [
+        { id: 'name', header: 'Name', isRowHeader: true },
+        { id: 'size', header: 'Size' },
+      ];
+      await renderTree(TreeGrid, {
+        props: { columns, nodes: createNodesWithDisabled(), ariaLabel: 'Files' },
+      });
+      expect(screen.getByRole('rowheader', { name: 'Documents' })).toHaveAttribute('tabindex');
+    });
+
+    it('Tab exits grid', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const grid = screen.getByRole('treegrid');
+      const before = document.createElement('button');
+      before.textContent = 'Before';
+      grid.parentElement!.insertBefore(before, grid);
+      const after = document.createElement('button');
+      after.textContent = 'After';
+      grid.parentElement!.appendChild(after);
+
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.tab();
+      expect(screen.getByRole('button', { name: 'After' })).toHaveFocus();
+    });
+  });
+
+  describe('Virtualization Support', () => {
+    it('has aria-rowcount when totalRows provided', async () => {
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          totalRows: 100,
+        },
+      });
+      expect(screen.getByRole('treegrid')).toHaveAttribute('aria-rowcount', '100');
+    });
+
+    it('has aria-colcount when totalColumns provided', async () => {
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          totalColumns: 10,
+        },
+      });
+      expect(screen.getByRole('treegrid')).toHaveAttribute('aria-colcount', '10');
+    });
+
+    it('has aria-rowindex on rows when virtualizing', async () => {
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          totalRows: 100,
+          startRowIndex: 10,
+        },
+      });
+      const rows = screen.getAllByRole('row').filter((r) => r.hasAttribute('aria-level'));
+      expect(rows[0]).toHaveAttribute('aria-rowindex', '10');
+      expect(rows[1]).toHaveAttribute('aria-rowindex', '11');
+      expect(rows[2]).toHaveAttribute('aria-rowindex', '12');
+    });
+
+    it('has aria-colindex on cells when virtualizing', async () => {
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          totalColumns: 10,
+          startColIndex: 5,
+        },
+      });
+      const firstRowCells = [
+        screen.getAllByRole('rowheader')[0],
+        ...screen.getAllByRole('gridcell').slice(0, 2),
+      ];
+      expect(firstRowCells[0]).toHaveAttribute('aria-colindex', '5');
+      expect(firstRowCells[1]).toHaveAttribute('aria-colindex', '6');
+      expect(firstRowCells[2]).toHaveAttribute('aria-colindex', '7');
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('has no axe violations', async () => {
+      const { container } = await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations when expanded', async () => {
+      const { container } = await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs', 'images'],
+        },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with selection enabled', async () => {
+      const { container } = await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          selectable: true,
+          multiselectable: true,
+        },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  describe('Callbacks', () => {
+    it('calls onExpandedChange when expanding', async () => {
+      const user = userEvent.setup();
+      const onExpandedChange = vi.fn();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          onExpandedChange,
+        },
+      });
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowRight}');
+      expect(onExpandedChange).toHaveBeenCalledWith(['docs']);
+    });
+
+    it('calls onExpandedChange when collapsing', async () => {
+      const user = userEvent.setup();
+      const onExpandedChange = vi.fn();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+          onExpandedChange,
+        },
+      });
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowLeft}');
+      expect(onExpandedChange).toHaveBeenCalledWith([]);
+    });
+
+    it('calls onFocusChange when focus moves', async () => {
+      const user = userEvent.setup();
+      const onFocusChange = vi.fn();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          onFocusChange,
+        },
+      });
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowRight}');
+      expect(onFocusChange).toHaveBeenCalled();
+    });
+  });
+
+  describe('Mouse interactions', () => {
+    // SKIP: see file header — Svelte-5 reactivity scheduler leak across tests (passes in isolation; not an APG/component defect).
+    it.skip('clicking a rowheader of a collapsed parent expands it', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      expect(docsRowheader.closest('[role="row"]')).toHaveAttribute('aria-expanded', 'false');
+      await user.click(docsRowheader);
+      expect(docsRowheader.closest('[role="row"]')).toHaveAttribute('aria-expanded', 'true');
+      expect(screen.getByRole('rowheader', { name: 'report.pdf' })).toBeInTheDocument();
+    });
+
+    // SKIP: see file header — Svelte-5 reactivity scheduler leak across tests (passes in isolation; not an APG/component defect).
+    it.skip('clicking a rowheader of an expanded parent collapses it', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+        },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      expect(docsRowheader.closest('[role="row"]')).toHaveAttribute('aria-expanded', 'true');
+      await user.click(docsRowheader);
+      expect(docsRowheader.closest('[role="row"]')).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.queryByRole('rowheader', { name: 'report.pdf' })).not.toBeInTheDocument();
+    });
+
+    // SKIP: see file header — Svelte-5 reactivity scheduler leak across tests (passes in isolation; not an APG/component defect).
+    it.skip('clicking a non-rowheader cell does not toggle expansion', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const sizeCell = screen
+        .getAllByRole('gridcell')
+        .find(
+          (el) =>
+            el.textContent === '--' &&
+            el.closest('[role="row"]')?.getAttribute('aria-level') === '1'
+        );
+      expect(sizeCell).toBeDefined();
+      await user.click(sizeCell!);
+      expect(sizeCell!.closest('[role="row"]')).toHaveAttribute('aria-expanded', 'false');
+      expect(sizeCell).toHaveAttribute('tabindex', '0');
+    });
+
+    it('clicking a cell moves focus and roving tabindex to it', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const readmeRowheader = screen.getByRole('rowheader', { name: 'README.md' });
+      await user.click(readmeRowheader);
+      expect(readmeRowheader).toHaveAttribute('tabindex', '0');
+      expect(document.activeElement).toBe(readmeRowheader);
+      expect(screen.getByRole('rowheader', { name: 'Documents' })).toHaveAttribute(
+        'tabindex',
+        '-1'
+      );
+    });
+
+    it('clicking a rowheader of a disabled row does not toggle expansion', async () => {
+      const user = userEvent.setup();
+      const onExpandedChange = vi.fn();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createNodesWithDisabled(),
+          ariaLabel: 'Files',
+          onExpandedChange,
+        },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      expect(docsRowheader.closest('[role="row"]')).toHaveAttribute('aria-expanded', 'false');
+      await user.click(docsRowheader);
+      expect(docsRowheader.closest('[role="row"]')).toHaveAttribute('aria-expanded', 'false');
+      expect(onExpandedChange).not.toHaveBeenCalled();
+    });
+
+    // SKIP: see file header — Svelte-5 reactivity scheduler leak across tests (passes in isolation; not an APG/component defect).
+    it.skip('clicking the chevron icon inside a rowheader also toggles expansion', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      // Svelte uses the `expand-icon` class for the chevron (React: `apg-treegrid-expand-icon`).
+      const chevron = docsRowheader.querySelector('.expand-icon');
+      expect(chevron).not.toBeNull();
+      await user.click(chevron as Element);
+      expect(docsRowheader.closest('[role="row"]')).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('clicking does not change row selection (aria-selected)', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          selectable: true,
+        },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      const row = docsRowheader.closest('[role="row"]')!;
+      expect(row).toHaveAttribute('aria-selected', 'false');
+      await user.click(docsRowheader);
+      expect(row).toHaveAttribute('aria-selected', 'false');
+    });
+  });
+});

--- a/src/patterns/treegrid/TreeGrid.test.svelte.ts
+++ b/src/patterns/treegrid/TreeGrid.test.svelte.ts
@@ -15,14 +15,22 @@ import type { TreeGridColumnDef, TreeGridNodeData } from './TreeGrid.svelte';
 // - The Svelte TreeGrid sets up focusable-element tabindex via an $effect, so `renderTree`
 //   awaits a tick after mounting (mirrors React's synchronous render) before assertions.
 //
-// All titles are ported 1:1, but 9 expand/collapse/selection interaction cases are it.skip
-// (NOT React-specific). They PASS when run in isolation but FAIL when a preceding test in the
-// same file collapses a `defaultExpandedIds` node: the Svelte 5 reactivity scheduler leaks
-// across testing-library/svelte cleanup so the next instance's first expand/collapse/selection
-// keyboard or click action does not flush to the DOM. cleanup() + flushSync() + extra tick()s
-// in afterEach do not resolve it. This is an environmental Svelte-5-under-jsdom interaction
-// (the same family as the two treeview skips), not an APG/component defect — verified by the
-// identical cases passing standalone and by the Vue/Astro ports passing. Reported for the reviewer.
+// All titles are ported 1:1. 8 expand/collapse/selection interaction cases are it.skip because
+// they expose a REAL Svelte-only component reactivity bug (NOT an environment/scheduler issue —
+// they fail identically run alone or in the full file, verified). Mechanism: TreeGrid.svelte
+// declares `internalExpandedIds` / `internalSelectedRowIds` as plain `let` bindings (not `$state`)
+// holding `SvelteSet`s. Every expand/collapse/select handler creates a NEW `SvelteSet` and
+// REASSIGNS the binding (`internalExpandedIds = newSet`, `internalSelectedRowIds = newSet`).
+// In Svelte 5 runes mode a plain-`let` reassignment is not tracked, so the `$derived`
+// `expandedIds`/`selectedRowIds` never re-run and `aria-expanded`/`aria-selected` never update in
+// the DOM. The `onExpandedChange`/`onSelectionChange` callbacks DO fire with the right payload
+// (the logic is correct; only the view binding is dead), which is why the callback-only tests
+// pass. `await tick()`/`flushSync()` cannot rescue a non-reactive reassignment. React/Vue update
+// the DOM. Fix is component-side (declare the bindings with `$state`, or mutate the existing
+// SvelteSet via add/delete like TreeView does) — out of scope here. Reported for the reviewer.
+// (The 9th originally-skipped case, "clicking a non-rowheader cell does not toggle expansion",
+// was a test-side query bug — gridcell textContent is " -- " with whitespace, so the exact
+// `=== '--'` match found nothing — now fixed with `.trim()` and un-skipped.)
 const renderTree = async (
   ...args: Parameters<typeof render>
 ): Promise<ReturnType<typeof render>> => {
@@ -514,7 +522,11 @@ describe('TreeGrid (Svelte)', () => {
   });
 
   describe('Keyboard - Tree Operations', () => {
-    // SKIP: see file header — Svelte-5 reactivity scheduler leak across tests (passes in isolation; not an APG/component defect).
+    // SKIP: real Svelte component reactivity bug (see file header). The expand/collapse/select
+    // handler reassigns the plain-`let` `internal*Ids` binding to a new SvelteSet; in runes mode
+    // that reassignment is not tracked, so the `aria-expanded`/`aria-selected` `$derived` never
+    // re-runs. The callback fires with the correct payload but the DOM attribute never updates.
+    // Fails alone and in the full run alike. Component-side fix needed — do not weaken the assertion.
     it.skip('ArrowRight expands collapsed parent row at rowheader', async () => {
       const user = userEvent.setup();
       await renderTree(TreeGrid, {
@@ -553,7 +565,11 @@ describe('TreeGrid (Svelte)', () => {
       expect(screen.getByRole('gridcell', { name: '4 KB' })).toHaveFocus();
     });
 
-    // SKIP: see file header — Svelte-5 reactivity scheduler leak across tests (passes in isolation; not an APG/component defect).
+    // SKIP: real Svelte component reactivity bug (see file header). The expand/collapse/select
+    // handler reassigns the plain-`let` `internal*Ids` binding to a new SvelteSet; in runes mode
+    // that reassignment is not tracked, so the `aria-expanded`/`aria-selected` `$derived` never
+    // re-runs. The callback fires with the correct payload but the DOM attribute never updates.
+    // Fails alone and in the full run alike. Component-side fix needed — do not weaken the assertion.
     it.skip('ArrowLeft collapses expanded parent row at rowheader', async () => {
       const user = userEvent.setup();
       await renderTree(TreeGrid, {
@@ -631,7 +647,11 @@ describe('TreeGrid (Svelte)', () => {
       expect(parentRow).toHaveAttribute('aria-expanded', 'false');
     });
 
-    // SKIP: see file header — Svelte-5 reactivity scheduler leak across tests (passes in isolation; not an APG/component defect).
+    // SKIP: real Svelte component reactivity bug (see file header). The expand/collapse/select
+    // handler reassigns the plain-`let` `internal*Ids` binding to a new SvelteSet; in runes mode
+    // that reassignment is not tracked, so the `aria-expanded`/`aria-selected` `$derived` never
+    // re-runs. The callback fires with the correct payload but the DOM attribute never updates.
+    // Fails alone and in the full run alike. Component-side fix needed — do not weaken the assertion.
     it.skip('Space toggles row selection', async () => {
       const user = userEvent.setup();
       await renderTree(TreeGrid, {
@@ -670,7 +690,11 @@ describe('TreeGrid (Svelte)', () => {
       expect(row).toHaveAttribute('aria-selected', 'false');
     });
 
-    // SKIP: see file header — Svelte-5 reactivity scheduler leak across tests (passes in isolation; not an APG/component defect).
+    // SKIP: real Svelte component reactivity bug (see file header). The expand/collapse/select
+    // handler reassigns the plain-`let` `internal*Ids` binding to a new SvelteSet; in runes mode
+    // that reassignment is not tracked, so the `aria-expanded`/`aria-selected` `$derived` never
+    // re-runs. The callback fires with the correct payload but the DOM attribute never updates.
+    // Fails alone and in the full run alike. Component-side fix needed — do not weaken the assertion.
     it.skip('Ctrl+A selects all visible rows (multiselectable)', async () => {
       const user = userEvent.setup();
       await renderTree(TreeGrid, {
@@ -690,7 +714,11 @@ describe('TreeGrid (Svelte)', () => {
       });
     });
 
-    // SKIP: see file header — Svelte-5 reactivity scheduler leak across tests (passes in isolation; not an APG/component defect).
+    // SKIP: real Svelte component reactivity bug (see file header). The expand/collapse/select
+    // handler reassigns the plain-`let` `internal*Ids` binding to a new SvelteSet; in runes mode
+    // that reassignment is not tracked, so the `aria-expanded`/`aria-selected` `$derived` never
+    // re-runs. The callback fires with the correct payload but the DOM attribute never updates.
+    // Fails alone and in the full run alike. Component-side fix needed — do not weaken the assertion.
     it.skip('single selection clears previous on Space', async () => {
       const user = userEvent.setup();
       await renderTree(TreeGrid, {
@@ -964,7 +992,11 @@ describe('TreeGrid (Svelte)', () => {
   });
 
   describe('Mouse interactions', () => {
-    // SKIP: see file header — Svelte-5 reactivity scheduler leak across tests (passes in isolation; not an APG/component defect).
+    // SKIP: real Svelte component reactivity bug (see file header). The expand/collapse/select
+    // handler reassigns the plain-`let` `internal*Ids` binding to a new SvelteSet; in runes mode
+    // that reassignment is not tracked, so the `aria-expanded`/`aria-selected` `$derived` never
+    // re-runs. The callback fires with the correct payload but the DOM attribute never updates.
+    // Fails alone and in the full run alike. Component-side fix needed — do not weaken the assertion.
     it.skip('clicking a rowheader of a collapsed parent expands it', async () => {
       const user = userEvent.setup();
       await renderTree(TreeGrid, {
@@ -977,7 +1009,11 @@ describe('TreeGrid (Svelte)', () => {
       expect(screen.getByRole('rowheader', { name: 'report.pdf' })).toBeInTheDocument();
     });
 
-    // SKIP: see file header — Svelte-5 reactivity scheduler leak across tests (passes in isolation; not an APG/component defect).
+    // SKIP: real Svelte component reactivity bug (see file header). The expand/collapse/select
+    // handler reassigns the plain-`let` `internal*Ids` binding to a new SvelteSet; in runes mode
+    // that reassignment is not tracked, so the `aria-expanded`/`aria-selected` `$derived` never
+    // re-runs. The callback fires with the correct payload but the DOM attribute never updates.
+    // Fails alone and in the full run alike. Component-side fix needed — do not weaken the assertion.
     it.skip('clicking a rowheader of an expanded parent collapses it', async () => {
       const user = userEvent.setup();
       await renderTree(TreeGrid, {
@@ -995,17 +1031,18 @@ describe('TreeGrid (Svelte)', () => {
       expect(screen.queryByRole('rowheader', { name: 'report.pdf' })).not.toBeInTheDocument();
     });
 
-    // SKIP: see file header — Svelte-5 reactivity scheduler leak across tests (passes in isolation; not an APG/component defect).
-    it.skip('clicking a non-rowheader cell does not toggle expansion', async () => {
+    it('clicking a non-rowheader cell does not toggle expansion', async () => {
       const user = userEvent.setup();
       await renderTree(TreeGrid, {
         props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
       });
+      // Svelte renders the cell value with surrounding template whitespace, so the gridcell's
+      // textContent is " -- " (not "--"); trim before the exact match (React's JSX has no padding).
       const sizeCell = screen
         .getAllByRole('gridcell')
         .find(
           (el) =>
-            el.textContent === '--' &&
+            el.textContent?.trim() === '--' &&
             el.closest('[role="row"]')?.getAttribute('aria-level') === '1'
         );
       expect(sizeCell).toBeDefined();
@@ -1047,7 +1084,11 @@ describe('TreeGrid (Svelte)', () => {
       expect(onExpandedChange).not.toHaveBeenCalled();
     });
 
-    // SKIP: see file header — Svelte-5 reactivity scheduler leak across tests (passes in isolation; not an APG/component defect).
+    // SKIP: real Svelte component reactivity bug (see file header). The expand/collapse/select
+    // handler reassigns the plain-`let` `internal*Ids` binding to a new SvelteSet; in runes mode
+    // that reassignment is not tracked, so the `aria-expanded`/`aria-selected` `$derived` never
+    // re-runs. The callback fires with the correct payload but the DOM attribute never updates.
+    // Fails alone and in the full run alike. Component-side fix needed — do not weaken the assertion.
     it.skip('clicking the chevron icon inside a rowheader also toggles expansion', async () => {
       const user = userEvent.setup();
       await renderTree(TreeGrid, {

--- a/src/patterns/treegrid/TreeGrid.test.vue.ts
+++ b/src/patterns/treegrid/TreeGrid.test.vue.ts
@@ -1,0 +1,1070 @@
+import { render, screen } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+import { h, nextTick } from 'vue';
+import TreeGrid from './TreeGrid.vue';
+import type { TreeGridColumnDef, TreeGridNodeData } from './TreeGrid.vue';
+
+// Prop/event mapping vs React:
+// - React `ariaLabel` / `ariaLabelledby` -> Vue `ariaLabel` / `ariaLabelledby` (same names).
+// - React `onCellActivate` / `onSelectionChange` / `onExpandedChange` / `onFocusChange` callback
+//   props -> Vue `cellActivate` / `selectionChange` / `expandedChange` / `focusChange` emits
+//   (assert via on* listeners).
+// - The Vue TreeGrid sets the initial roving-tabindex focus inside onMounted, so `renderTree`
+//   awaits a tick after mounting (mirrors React's synchronous render) before assertions.
+// No React-specific cases are skipped; all titles are ported 1:1.
+const renderTree = async (
+  ...args: Parameters<typeof render>
+): Promise<ReturnType<typeof render>> => {
+  const result = render(...args);
+  await nextTick();
+  return result;
+};
+
+const createBasicColumns = (): TreeGridColumnDef[] => [
+  { id: 'name', header: 'Name', isRowHeader: true },
+  { id: 'size', header: 'Size' },
+  { id: 'date', header: 'Date Modified' },
+];
+
+const createBasicNodes = (): TreeGridNodeData[] => [
+  {
+    id: 'docs',
+    cells: [
+      { id: 'docs-name', value: 'Documents' },
+      { id: 'docs-size', value: '--' },
+      { id: 'docs-date', value: '2024-01-15' },
+    ],
+    children: [
+      {
+        id: 'report',
+        cells: [
+          { id: 'report-name', value: 'report.pdf' },
+          { id: 'report-size', value: '2.5 MB' },
+          { id: 'report-date', value: '2024-01-10' },
+        ],
+      },
+      {
+        id: 'notes',
+        cells: [
+          { id: 'notes-name', value: 'notes.txt' },
+          { id: 'notes-size', value: '1 KB' },
+          { id: 'notes-date', value: '2024-01-05' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'images',
+    cells: [
+      { id: 'images-name', value: 'Images' },
+      { id: 'images-size', value: '--' },
+      { id: 'images-date', value: '2024-01-20' },
+    ],
+    children: [
+      {
+        id: 'photo1',
+        cells: [
+          { id: 'photo1-name', value: 'photo1.jpg' },
+          { id: 'photo1-size', value: '3 MB' },
+          { id: 'photo1-date', value: '2024-01-18' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'readme',
+    cells: [
+      { id: 'readme-name', value: 'README.md' },
+      { id: 'readme-size', value: '4 KB' },
+      { id: 'readme-date', value: '2024-01-01' },
+    ],
+  },
+];
+
+const createNestedNodes = (): TreeGridNodeData[] => [
+  {
+    id: 'root',
+    cells: [
+      { id: 'root-name', value: 'Root' },
+      { id: 'root-size', value: '--' },
+    ],
+    children: [
+      {
+        id: 'level2',
+        cells: [
+          { id: 'level2-name', value: 'Level 2' },
+          { id: 'level2-size', value: '--' },
+        ],
+        children: [
+          {
+            id: 'level3',
+            cells: [
+              { id: 'level3-name', value: 'Level 3' },
+              { id: 'level3-size', value: '1 KB' },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const createNodesWithDisabled = (): TreeGridNodeData[] => [
+  {
+    id: 'docs',
+    cells: [
+      { id: 'docs-name', value: 'Documents' },
+      { id: 'docs-size', value: '--' },
+    ],
+    disabled: true,
+    children: [
+      {
+        id: 'report',
+        cells: [
+          { id: 'report-name', value: 'report.pdf' },
+          { id: 'report-size', value: '2.5 MB' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'readme',
+    cells: [
+      { id: 'readme-name', value: 'README.md' },
+      { id: 'readme-size', value: '4 KB' },
+    ],
+  },
+];
+
+describe('TreeGrid (Vue)', () => {
+  describe('ARIA Attributes', () => {
+    it('has role="treegrid" on container', async () => {
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      expect(screen.getByRole('treegrid')).toBeInTheDocument();
+    });
+
+    it('has role="row" on all rows', async () => {
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs', 'images'],
+        },
+      });
+      expect(screen.getAllByRole('row')).toHaveLength(7);
+    });
+
+    it('has role="gridcell" on data cells', async () => {
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs', 'images'],
+        },
+      });
+      expect(screen.getAllByRole('gridcell')).toHaveLength(12);
+    });
+
+    it('has role="columnheader" on header cells', async () => {
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      expect(screen.getAllByRole('columnheader')).toHaveLength(3);
+    });
+
+    it('has role="rowheader" on first column cells', async () => {
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs', 'images'],
+        },
+      });
+      expect(screen.getAllByRole('rowheader')).toHaveLength(6);
+    });
+
+    it('has accessible name via aria-label', async () => {
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      expect(screen.getByRole('treegrid', { name: 'Files' })).toBeInTheDocument();
+    });
+
+    it('has accessible name via aria-labelledby', async () => {
+      await renderTree({
+        components: { TreeGrid },
+        setup() {
+          return () =>
+            h('div', [
+              h('h2', { id: 'grid-title' }, 'File Browser'),
+              h(TreeGrid, {
+                columns: createBasicColumns(),
+                nodes: createBasicNodes(),
+                ariaLabelledby: 'grid-title',
+              }),
+            ]);
+        },
+      });
+      expect(screen.getByRole('treegrid')).toHaveAttribute('aria-labelledby', 'grid-title');
+    });
+
+    it('parent rows have aria-expanded', async () => {
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const rows = screen.getAllByRole('row').filter((r) => r.hasAttribute('aria-level'));
+      const docsRow = rows.find((r) =>
+        r.querySelector('[role="rowheader"]')?.textContent?.includes('Documents')
+      );
+      const imagesRow = rows.find((r) =>
+        r.querySelector('[role="rowheader"]')?.textContent?.includes('Images')
+      );
+      expect(docsRow).toHaveAttribute('aria-expanded');
+      expect(imagesRow).toHaveAttribute('aria-expanded');
+    });
+
+    it('leaf rows do NOT have aria-expanded', async () => {
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const rows = screen.getAllByRole('row').filter((r) => r.hasAttribute('aria-level'));
+      const readmeRow = rows.find((r) =>
+        r.querySelector('[role="rowheader"]')?.textContent?.includes('README.md')
+      );
+      expect(readmeRow).not.toHaveAttribute('aria-expanded');
+    });
+
+    it('has aria-level on all data rows', async () => {
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs', 'images'],
+        },
+      });
+      const dataRows = screen.getAllByRole('row').filter((r) => r.hasAttribute('aria-level'));
+      expect(dataRows.length).toBeGreaterThan(0);
+      dataRows.forEach((row) => {
+        expect(row).toHaveAttribute('aria-level');
+      });
+    });
+
+    it('aria-level increments with depth (1-based)', async () => {
+      const columns: TreeGridColumnDef[] = [
+        { id: 'name', header: 'Name', isRowHeader: true },
+        { id: 'size', header: 'Size' },
+      ];
+      await renderTree(TreeGrid, {
+        props: {
+          columns,
+          nodes: createNestedNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['root', 'level2'],
+        },
+      });
+      const rows = screen.getAllByRole('row').filter((r) => r.hasAttribute('aria-level'));
+      const rootRow = rows.find((r) =>
+        r.querySelector('[role="rowheader"]')?.textContent?.includes('Root')
+      );
+      const level2Row = rows.find((r) =>
+        r.querySelector('[role="rowheader"]')?.textContent?.includes('Level 2')
+      );
+      const level3Row = rows.find((r) =>
+        r.querySelector('[role="rowheader"]')?.textContent?.includes('Level 3')
+      );
+      expect(rootRow).toHaveAttribute('aria-level', '1');
+      expect(level2Row).toHaveAttribute('aria-level', '2');
+      expect(level3Row).toHaveAttribute('aria-level', '3');
+    });
+
+    it('has aria-selected on row (not gridcell) when selectable', async () => {
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          selectable: true,
+        },
+      });
+      const dataRows = screen.getAllByRole('row').filter((r) => r.hasAttribute('aria-level'));
+      dataRows.forEach((row) => {
+        expect(row).toHaveAttribute('aria-selected', 'false');
+      });
+      screen.getAllByRole('gridcell').forEach((cell) => {
+        expect(cell).not.toHaveAttribute('aria-selected');
+      });
+    });
+
+    it('has aria-multiselectable when multiselectable', async () => {
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          selectable: true,
+          multiselectable: true,
+        },
+      });
+      expect(screen.getByRole('treegrid')).toHaveAttribute('aria-multiselectable', 'true');
+    });
+
+    it('has aria-disabled on disabled rows', async () => {
+      const columns: TreeGridColumnDef[] = [
+        { id: 'name', header: 'Name', isRowHeader: true },
+        { id: 'size', header: 'Size' },
+      ];
+      await renderTree(TreeGrid, {
+        props: { columns, nodes: createNodesWithDisabled(), ariaLabel: 'Files' },
+      });
+      const docsRow = screen
+        .getAllByRole('row')
+        .find((r) => r.querySelector('[role="rowheader"]')?.textContent?.includes('Documents'));
+      expect(docsRow).toHaveAttribute('aria-disabled', 'true');
+    });
+  });
+
+  describe('Keyboard - Row Navigation', () => {
+    it('ArrowDown moves to same column in next visible row', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+        },
+      });
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('rowheader', { name: 'report.pdf' })).toHaveFocus();
+    });
+
+    it('ArrowUp moves to same column in previous visible row', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+        },
+      });
+      screen.getByRole('rowheader', { name: 'report.pdf' }).focus();
+      await user.keyboard('{ArrowUp}');
+      expect(screen.getByRole('rowheader', { name: 'Documents' })).toHaveFocus();
+    });
+
+    it('ArrowDown skips collapsed child rows', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('rowheader', { name: 'Images' })).toHaveFocus();
+    });
+
+    it('ArrowUp stops at first visible row', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      docsRowheader.focus();
+      await user.keyboard('{ArrowUp}');
+      expect(docsRowheader).toHaveFocus();
+    });
+
+    it('ArrowDown stops at last visible row', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const readmeRowheader = screen.getByRole('rowheader', { name: 'README.md' });
+      readmeRowheader.focus();
+      await user.keyboard('{ArrowDown}');
+      expect(readmeRowheader).toHaveFocus();
+    });
+
+    it('maintains column position during row navigation', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+        },
+      });
+      const docsSizeCell = screen.getAllByRole('gridcell', { name: '--' })[0];
+      docsSizeCell.focus();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('gridcell', { name: '2.5 MB' })).toHaveFocus();
+    });
+  });
+
+  describe('Keyboard - Cell Navigation', () => {
+    it('ArrowRight moves right at non-rowheader cells', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const sizeCell = screen.getAllByRole('gridcell', { name: '--' })[0];
+      sizeCell.focus();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('gridcell', { name: '2024-01-15' })).toHaveFocus();
+    });
+
+    it('ArrowLeft moves left at non-rowheader cells', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const dateCell = screen.getByRole('gridcell', { name: '2024-01-15' });
+      dateCell.focus();
+      await user.keyboard('{ArrowLeft}');
+      expect(screen.getAllByRole('gridcell', { name: '--' })[0]).toHaveFocus();
+    });
+
+    it('ArrowRight at non-rowheader does NOT expand', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const sizeCell = screen.getAllByRole('gridcell', { name: '--' })[0];
+      sizeCell.focus();
+      const parentRow = sizeCell.closest('[role="row"]');
+      expect(parentRow).toHaveAttribute('aria-expanded', 'false');
+      await user.keyboard('{ArrowRight}');
+      expect(parentRow).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('ArrowLeft at non-rowheader does NOT collapse', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+        },
+      });
+      const dateCell = screen.getByRole('gridcell', { name: '2024-01-15' });
+      dateCell.focus();
+      const parentRow = dateCell.closest('[role="row"]');
+      expect(parentRow).toHaveAttribute('aria-expanded', 'true');
+      await user.keyboard('{ArrowLeft}');
+      expect(parentRow).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('Home moves to first cell in row', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const dateCell = screen.getByRole('gridcell', { name: '2024-01-15' });
+      dateCell.focus();
+      await user.keyboard('{Home}');
+      expect(screen.getByRole('rowheader', { name: 'Documents' })).toHaveFocus();
+    });
+
+    it('End moves to last cell in row', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.keyboard('{End}');
+      expect(screen.getByRole('gridcell', { name: '2024-01-15' })).toHaveFocus();
+    });
+
+    it('Ctrl+Home moves to first cell in grid', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      screen.getByRole('rowheader', { name: 'README.md' }).focus();
+      await user.keyboard('{Control>}{Home}{/Control}');
+      expect(screen.getByRole('rowheader', { name: 'Documents' })).toHaveFocus();
+    });
+
+    it('Ctrl+End moves to last cell in grid', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.keyboard('{Control>}{End}{/Control}');
+      expect(screen.getByRole('gridcell', { name: '2024-01-01' })).toHaveFocus();
+    });
+  });
+
+  describe('Keyboard - Tree Operations', () => {
+    it('ArrowRight expands collapsed parent row at rowheader', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      docsRowheader.focus();
+      const parentRow = docsRowheader.closest('[role="row"]');
+      expect(parentRow).toHaveAttribute('aria-expanded', 'false');
+      await user.keyboard('{ArrowRight}');
+      expect(parentRow).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('ArrowRight moves to next cell when expanded at rowheader', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+        },
+      });
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getAllByRole('gridcell', { name: '--' })[0]).toHaveFocus();
+    });
+
+    it('ArrowRight moves to next cell on leaf row at rowheader', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      screen.getByRole('rowheader', { name: 'README.md' }).focus();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('gridcell', { name: '4 KB' })).toHaveFocus();
+    });
+
+    it('ArrowLeft collapses expanded parent row at rowheader', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+        },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      docsRowheader.focus();
+      const parentRow = docsRowheader.closest('[role="row"]');
+      expect(parentRow).toHaveAttribute('aria-expanded', 'true');
+      await user.keyboard('{ArrowLeft}');
+      expect(parentRow).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('ArrowLeft moves to parent when collapsed at rowheader', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+        },
+      });
+      screen.getByRole('rowheader', { name: 'report.pdf' }).focus();
+      await user.keyboard('{ArrowLeft}');
+      expect(screen.getByRole('rowheader', { name: 'Documents' })).toHaveFocus();
+    });
+
+    it('ArrowLeft does nothing at root level collapsed row', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      docsRowheader.focus();
+      const parentRow = docsRowheader.closest('[role="row"]');
+      expect(parentRow).toHaveAttribute('aria-expanded', 'false');
+      await user.keyboard('{ArrowLeft}');
+      expect(docsRowheader).toHaveFocus();
+    });
+  });
+
+  describe('Keyboard - Selection & Activation', () => {
+    it('Enter activates cell (calls onCellActivate)', async () => {
+      const user = userEvent.setup();
+      const onCellActivate = vi.fn();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          onCellActivate,
+        },
+      });
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.keyboard('{Enter}');
+      expect(onCellActivate).toHaveBeenCalledWith('docs-name', 'docs', 'name');
+    });
+
+    it('Enter does NOT expand/collapse', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      docsRowheader.focus();
+      const parentRow = docsRowheader.closest('[role="row"]');
+      expect(parentRow).toHaveAttribute('aria-expanded', 'false');
+      await user.keyboard('{Enter}');
+      expect(parentRow).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('Space toggles row selection', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          selectable: true,
+        },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      docsRowheader.focus();
+      const row = docsRowheader.closest('[role="row"]');
+      expect(row).toHaveAttribute('aria-selected', 'false');
+      await user.keyboard(' ');
+      expect(row).toHaveAttribute('aria-selected', 'true');
+      await user.keyboard(' ');
+      expect(row).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('Space does not select disabled row', async () => {
+      const user = userEvent.setup();
+      const columns: TreeGridColumnDef[] = [
+        { id: 'name', header: 'Name', isRowHeader: true },
+        { id: 'size', header: 'Size' },
+      ];
+      await renderTree(TreeGrid, {
+        props: { columns, nodes: createNodesWithDisabled(), ariaLabel: 'Files', selectable: true },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      docsRowheader.focus();
+      const row = docsRowheader.closest('[role="row"]');
+      expect(row).toHaveAttribute('aria-disabled', 'true');
+      expect(row).toHaveAttribute('aria-selected', 'false');
+      await user.keyboard(' ');
+      expect(row).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('Ctrl+A selects all visible rows (multiselectable)', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          selectable: true,
+          multiselectable: true,
+        },
+      });
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.keyboard('{Control>}a{/Control}');
+      const dataRows = screen.getAllByRole('row').filter((r) => r.hasAttribute('aria-level'));
+      dataRows.forEach((row) => {
+        expect(row).toHaveAttribute('aria-selected', 'true');
+      });
+    });
+
+    it('single selection clears previous on Space', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          selectable: true,
+        },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      docsRowheader.focus();
+      await user.keyboard(' ');
+      const docsRow = docsRowheader.closest('[role="row"]');
+      expect(docsRow).toHaveAttribute('aria-selected', 'true');
+      await user.keyboard('{ArrowDown}');
+      await user.keyboard(' ');
+      const imagesRow = screen.getByRole('rowheader', { name: 'Images' }).closest('[role="row"]');
+      expect(imagesRow).toHaveAttribute('aria-selected', 'true');
+      expect(docsRow).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('calls onSelectionChange callback', async () => {
+      const user = userEvent.setup();
+      const onSelectionChange = vi.fn();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          selectable: true,
+          onSelectionChange,
+        },
+      });
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.keyboard(' ');
+      expect(onSelectionChange).toHaveBeenCalledWith(['docs']);
+    });
+  });
+
+  describe('Focus Management', () => {
+    it('only one cell has tabIndex="0"', async () => {
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+        },
+      });
+      const allFocusableCells = screen
+        .getAllByRole('rowheader')
+        .concat(screen.getAllByRole('gridcell'));
+      const tabIndex0Cells = allFocusableCells.filter(
+        (cell) => cell.getAttribute('tabindex') === '0'
+      );
+      expect(tabIndex0Cells).toHaveLength(1);
+    });
+
+    it('other cells have tabIndex="-1"', async () => {
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const cells = screen.getAllByRole('gridcell');
+      const tabIndexMinus1Cells = cells.filter((cell) => cell.getAttribute('tabindex') === '-1');
+      expect(tabIndexMinus1Cells.length).toBe(cells.length);
+    });
+
+    it("focus moves to parent when child's parent collapses", async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+        },
+      });
+      screen.getByRole('rowheader', { name: 'report.pdf' }).focus();
+      await user.keyboard('{ArrowLeft}');
+      await user.keyboard('{ArrowLeft}');
+      expect(screen.getByRole('rowheader', { name: 'Documents' })).toHaveFocus();
+    });
+
+    it('columnheader cells are not focusable', async () => {
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      screen.getAllByRole('columnheader').forEach((header) => {
+        expect(header).not.toHaveAttribute('tabindex');
+      });
+    });
+
+    it('disabled cells are focusable', async () => {
+      const columns: TreeGridColumnDef[] = [
+        { id: 'name', header: 'Name', isRowHeader: true },
+        { id: 'size', header: 'Size' },
+      ];
+      await renderTree(TreeGrid, {
+        props: { columns, nodes: createNodesWithDisabled(), ariaLabel: 'Files' },
+      });
+      expect(screen.getByRole('rowheader', { name: 'Documents' })).toHaveAttribute('tabindex');
+    });
+
+    it('Tab exits grid', async () => {
+      const user = userEvent.setup();
+      await renderTree({
+        components: { TreeGrid },
+        setup() {
+          return () =>
+            h('div', [
+              h('button', 'Before'),
+              h(TreeGrid, {
+                columns: createBasicColumns(),
+                nodes: createBasicNodes(),
+                ariaLabel: 'Files',
+              }),
+              h('button', 'After'),
+            ]);
+        },
+      });
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.tab();
+      expect(screen.getByRole('button', { name: 'After' })).toHaveFocus();
+    });
+  });
+
+  describe('Virtualization Support', () => {
+    it('has aria-rowcount when totalRows provided', async () => {
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          totalRows: 100,
+        },
+      });
+      expect(screen.getByRole('treegrid')).toHaveAttribute('aria-rowcount', '100');
+    });
+
+    it('has aria-colcount when totalColumns provided', async () => {
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          totalColumns: 10,
+        },
+      });
+      expect(screen.getByRole('treegrid')).toHaveAttribute('aria-colcount', '10');
+    });
+
+    it('has aria-rowindex on rows when virtualizing', async () => {
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          totalRows: 100,
+          startRowIndex: 10,
+        },
+      });
+      const rows = screen.getAllByRole('row').filter((r) => r.hasAttribute('aria-level'));
+      expect(rows[0]).toHaveAttribute('aria-rowindex', '10');
+      expect(rows[1]).toHaveAttribute('aria-rowindex', '11');
+      expect(rows[2]).toHaveAttribute('aria-rowindex', '12');
+    });
+
+    it('has aria-colindex on cells when virtualizing', async () => {
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          totalColumns: 10,
+          startColIndex: 5,
+        },
+      });
+      const firstRowCells = [
+        screen.getAllByRole('rowheader')[0],
+        ...screen.getAllByRole('gridcell').slice(0, 2),
+      ];
+      expect(firstRowCells[0]).toHaveAttribute('aria-colindex', '5');
+      expect(firstRowCells[1]).toHaveAttribute('aria-colindex', '6');
+      expect(firstRowCells[2]).toHaveAttribute('aria-colindex', '7');
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('has no axe violations', async () => {
+      const { container } = await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations when expanded', async () => {
+      const { container } = await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs', 'images'],
+        },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with selection enabled', async () => {
+      const { container } = await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          selectable: true,
+          multiselectable: true,
+        },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  describe('Callbacks', () => {
+    it('calls onExpandedChange when expanding', async () => {
+      const user = userEvent.setup();
+      const onExpandedChange = vi.fn();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          onExpandedChange,
+        },
+      });
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowRight}');
+      expect(onExpandedChange).toHaveBeenCalledWith(['docs']);
+    });
+
+    it('calls onExpandedChange when collapsing', async () => {
+      const user = userEvent.setup();
+      const onExpandedChange = vi.fn();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+          onExpandedChange,
+        },
+      });
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowLeft}');
+      expect(onExpandedChange).toHaveBeenCalledWith([]);
+    });
+
+    it('calls onFocusChange when focus moves', async () => {
+      const user = userEvent.setup();
+      const onFocusChange = vi.fn();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          onFocusChange,
+        },
+      });
+      screen.getByRole('rowheader', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowRight}');
+      expect(onFocusChange).toHaveBeenCalled();
+    });
+  });
+
+  describe('Mouse interactions', () => {
+    it('clicking a rowheader of a collapsed parent expands it', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      expect(docsRowheader.closest('[role="row"]')).toHaveAttribute('aria-expanded', 'false');
+      await user.click(docsRowheader);
+      expect(docsRowheader.closest('[role="row"]')).toHaveAttribute('aria-expanded', 'true');
+      expect(screen.getByRole('rowheader', { name: 'report.pdf' })).toBeInTheDocument();
+    });
+
+    it('clicking a rowheader of an expanded parent collapses it', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+        },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      expect(docsRowheader.closest('[role="row"]')).toHaveAttribute('aria-expanded', 'true');
+      await user.click(docsRowheader);
+      expect(docsRowheader.closest('[role="row"]')).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.queryByRole('rowheader', { name: 'report.pdf' })).not.toBeInTheDocument();
+    });
+
+    it('clicking a non-rowheader cell does not toggle expansion', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const sizeCell = screen
+        .getAllByRole('gridcell')
+        .find(
+          (el) =>
+            el.textContent === '--' &&
+            el.closest('[role="row"]')?.getAttribute('aria-level') === '1'
+        );
+      expect(sizeCell).toBeDefined();
+      await user.click(sizeCell!);
+      expect(sizeCell!.closest('[role="row"]')).toHaveAttribute('aria-expanded', 'false');
+      expect(sizeCell).toHaveAttribute('tabindex', '0');
+    });
+
+    it('clicking a cell moves focus and roving tabindex to it', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const readmeRowheader = screen.getByRole('rowheader', { name: 'README.md' });
+      await user.click(readmeRowheader);
+      expect(readmeRowheader).toHaveAttribute('tabindex', '0');
+      expect(document.activeElement).toBe(readmeRowheader);
+      expect(screen.getByRole('rowheader', { name: 'Documents' })).toHaveAttribute(
+        'tabindex',
+        '-1'
+      );
+    });
+
+    it('clicking a rowheader of a disabled row does not toggle expansion', async () => {
+      const user = userEvent.setup();
+      const onExpandedChange = vi.fn();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createNodesWithDisabled(),
+          ariaLabel: 'Files',
+          onExpandedChange,
+        },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      expect(docsRowheader.closest('[role="row"]')).toHaveAttribute('aria-expanded', 'false');
+      await user.click(docsRowheader);
+      expect(docsRowheader.closest('[role="row"]')).toHaveAttribute('aria-expanded', 'false');
+      expect(onExpandedChange).not.toHaveBeenCalled();
+    });
+
+    it('clicking the chevron icon inside a rowheader also toggles expansion', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      // Vue uses the `expand-icon` class for the chevron (React: `apg-treegrid-expand-icon`).
+      const chevron = docsRowheader.querySelector('.expand-icon');
+      expect(chevron).not.toBeNull();
+      await user.click(chevron as Element);
+      expect(docsRowheader.closest('[role="row"]')).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('clicking does not change row selection (aria-selected)', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeGrid, {
+        props: {
+          columns: createBasicColumns(),
+          nodes: createBasicNodes(),
+          ariaLabel: 'Files',
+          selectable: true,
+        },
+      });
+      const docsRowheader = screen.getByRole('rowheader', { name: 'Documents' });
+      const row = docsRowheader.closest('[role="row"]')!;
+      expect(row).toHaveAttribute('aria-selected', 'false');
+      await user.click(docsRowheader);
+      expect(row).toHaveAttribute('aria-selected', 'false');
+    });
+  });
+});

--- a/src/patterns/treeview/TreeView.test.astro.ts
+++ b/src/patterns/treeview/TreeView.test.astro.ts
@@ -1,0 +1,212 @@
+/**
+ * TreeView Astro Component Tests using Container API
+ *
+ * Verifies the TreeView.astro initial HTML structure and ARIA attributes.
+ * Interaction cases (keyboard navigation, type-ahead, selection, expansion,
+ * focus management) are covered by the Vue unit tests and E2E; the Container
+ * API only renders initial HTML.
+ *
+ * Astro renders the FULL tree up-front and hides collapsed subtrees with the
+ * `hidden` attribute on the child `<ul role="group">` (rather than omitting
+ * them from the DOM as React/Vue do). Structural assertions account for this.
+ *
+ * Ported structural/initial-state subset of TreeView.test.tsx. Interaction-only
+ * React cases (keyboard, type-ahead, selection toggles, expansion callbacks,
+ * focus movement) are omitted here — they require a browser and are covered
+ * elsewhere.
+ *
+ * @see https://docs.astro.build/en/reference/container-reference/
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+import TreeView from './TreeView.astro';
+
+const simpleNodes = [
+  {
+    id: 'docs',
+    label: 'Documents',
+    children: [
+      { id: 'report', label: 'report.pdf' },
+      { id: 'notes', label: 'notes.txt' },
+    ],
+  },
+  {
+    id: 'images',
+    label: 'Images',
+    children: [
+      { id: 'photo1', label: 'photo1.jpg' },
+      { id: 'photo2', label: 'photo2.jpg' },
+    ],
+  },
+  { id: 'readme', label: 'readme.md' },
+];
+
+const nodesWithDisabled = [
+  { id: 'item1', label: 'Item 1' },
+  { id: 'item2', label: 'Item 2', disabled: true },
+  { id: 'item3', label: 'Item 3' },
+];
+
+describe('TreeView (Astro Container API)', () => {
+  let container: AstroContainer;
+
+  beforeEach(async () => {
+    container = await AstroContainer.create();
+  });
+
+  async function renderTree(props: Record<string, unknown>): Promise<Document> {
+    const html = await container.renderToString(TreeView, { props });
+    const dom = new JSDOM(html);
+    return dom.window.document;
+  }
+
+  function itemByLabel(doc: Document, label: string): Element | null {
+    return (
+      Array.from(doc.querySelectorAll('[role="treeitem"]')).find(
+        (item) => item.querySelector('.apg-treeview-item-label')?.textContent?.trim() === label
+      ) ?? null
+    );
+  }
+
+  // 🔴 High Priority: APG ARIA Attributes
+  describe('APG: ARIA Attributes', () => {
+    it('has role="tree" on container', async () => {
+      const doc = await renderTree({ nodes: simpleNodes, 'aria-label': 'Files' });
+      expect(doc.querySelector('[role="tree"]')).not.toBeNull();
+    });
+
+    it('has role="treeitem" on all nodes', async () => {
+      const doc = await renderTree({
+        nodes: simpleNodes,
+        'aria-label': 'Files',
+        defaultExpandedIds: ['docs', 'images'],
+      });
+      // Astro renders the full tree up-front, so all 7 treeitems are present.
+      expect(doc.querySelectorAll('[role="treeitem"]')).toHaveLength(7);
+    });
+
+    it('has role="group" on child containers', async () => {
+      const doc = await renderTree({
+        nodes: simpleNodes,
+        'aria-label': 'Files',
+        defaultExpandedIds: ['docs'],
+      });
+      expect(doc.querySelector('[role="group"]')).not.toBeNull();
+    });
+
+    it('has aria-expanded on parent nodes only', async () => {
+      const doc = await renderTree({ nodes: simpleNodes, 'aria-label': 'Files' });
+      expect(itemByLabel(doc, 'Documents')?.hasAttribute('aria-expanded')).toBe(true);
+      expect(itemByLabel(doc, 'Images')?.hasAttribute('aria-expanded')).toBe(true);
+      expect(itemByLabel(doc, 'readme.md')?.hasAttribute('aria-expanded')).toBe(false);
+    });
+
+    it('leaf nodes do NOT have aria-expanded', async () => {
+      const doc = await renderTree({
+        nodes: simpleNodes,
+        'aria-label': 'Files',
+        defaultExpandedIds: ['docs', 'images'],
+      });
+      expect(itemByLabel(doc, 'report.pdf')?.hasAttribute('aria-expanded')).toBe(false);
+      expect(itemByLabel(doc, 'readme.md')?.hasAttribute('aria-expanded')).toBe(false);
+    });
+
+    it('all treeitems have aria-selected when selection enabled', async () => {
+      const doc = await renderTree({
+        nodes: simpleNodes,
+        'aria-label': 'Files',
+        defaultExpandedIds: ['docs', 'images'],
+      });
+      doc.querySelectorAll('[role="treeitem"]').forEach((item) => {
+        expect(item.hasAttribute('aria-selected')).toBe(true);
+      });
+    });
+
+    it('selected node has aria-selected="true", others have "false"', async () => {
+      const doc = await renderTree({
+        nodes: simpleNodes,
+        'aria-label': 'Files',
+        defaultSelectedIds: ['readme'],
+      });
+      expect(itemByLabel(doc, 'readme.md')?.getAttribute('aria-selected')).toBe('true');
+      expect(itemByLabel(doc, 'Documents')?.getAttribute('aria-selected')).toBe('false');
+    });
+
+    it('has aria-multiselectable="true" on multi-select tree', async () => {
+      const doc = await renderTree({
+        nodes: simpleNodes,
+        'aria-label': 'Files',
+        multiselectable: true,
+      });
+      expect(doc.querySelector('[role="tree"]')?.getAttribute('aria-multiselectable')).toBe('true');
+    });
+
+    it('does not have aria-multiselectable on single-select tree', async () => {
+      const doc = await renderTree({ nodes: simpleNodes, 'aria-label': 'Files' });
+      expect(doc.querySelector('[role="tree"]')?.hasAttribute('aria-multiselectable')).toBe(false);
+    });
+
+    it('has accessible name via aria-label', async () => {
+      const doc = await renderTree({ nodes: simpleNodes, 'aria-label': 'File Explorer' });
+      expect(doc.querySelector('[role="tree"]')?.getAttribute('aria-label')).toBe('File Explorer');
+    });
+
+    it('has accessible name via aria-labelledby', async () => {
+      const doc = await renderTree({ nodes: simpleNodes, 'aria-labelledby': 'tree-label' });
+      expect(doc.querySelector('[role="tree"]')?.getAttribute('aria-labelledby')).toBe(
+        'tree-label'
+      );
+    });
+
+    it('disabled nodes have aria-disabled="true"', async () => {
+      const doc = await renderTree({ nodes: nodesWithDisabled, 'aria-label': 'Items' });
+      expect(itemByLabel(doc, 'Item 2')?.getAttribute('aria-disabled')).toBe('true');
+    });
+  });
+
+  // 🔴 High Priority: Focus Management (initial roving tabindex)
+  describe('APG: Focus Management', () => {
+    it('focused node has tabindex="0"', async () => {
+      const doc = await renderTree({ nodes: simpleNodes, 'aria-label': 'Files' });
+      expect(itemByLabel(doc, 'Documents')?.getAttribute('tabindex')).toBe('0');
+    });
+
+    it('other nodes have tabindex="-1"', async () => {
+      const doc = await renderTree({ nodes: simpleNodes, 'aria-label': 'Files' });
+      expect(itemByLabel(doc, 'Images')?.getAttribute('tabindex')).toBe('-1');
+      expect(itemByLabel(doc, 'readme.md')?.getAttribute('tabindex')).toBe('-1');
+    });
+  });
+
+  // 🟢 Low Priority: Props & Behavior
+  describe('Props & Behavior', () => {
+    it('respects defaultExpandedIds', async () => {
+      const doc = await renderTree({
+        nodes: simpleNodes,
+        'aria-label': 'Files',
+        defaultExpandedIds: ['docs', 'images'],
+      });
+      expect(itemByLabel(doc, 'Documents')?.getAttribute('aria-expanded')).toBe('true');
+      expect(itemByLabel(doc, 'Images')?.getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it('respects defaultSelectedIds', async () => {
+      const doc = await renderTree({
+        nodes: simpleNodes,
+        'aria-label': 'Files',
+        defaultSelectedIds: ['readme'],
+      });
+      expect(itemByLabel(doc, 'readme.md')?.getAttribute('aria-selected')).toBe('true');
+    });
+
+    it('applies className to container', async () => {
+      const doc = await renderTree({
+        nodes: simpleNodes,
+        'aria-label': 'Files',
+        class: 'custom-tree',
+      });
+      expect(doc.querySelector('[role="tree"]')?.classList.contains('custom-tree')).toBe(true);
+    });
+  });
+});

--- a/src/patterns/treeview/TreeView.test.svelte.ts
+++ b/src/patterns/treeview/TreeView.test.svelte.ts
@@ -1,0 +1,976 @@
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+import { tick } from 'svelte';
+import TreeView from './TreeView.svelte';
+import type { TreeNode } from './TreeView.svelte';
+
+// Prop/event mapping vs React:
+// - React `aria-label` / `aria-labelledby` -> Vue `ariaLabel` / `ariaLabelledby` props.
+// - React `onSelectionChange` / `onExpandedChange` / `onActivate` callback props ->
+//   Svelte `onSelectionChange` / `onExpandedChange` / `onActivate` callback props (same names).
+// - React `className` -> Svelte `class`.
+// - External label element (aria-labelledby) and sibling buttons (single-Tab-stop test) are
+//   inserted into the document directly, mirroring the React JSX setup.
+// All titles are ported 1:1. Two cases are it.skip (NOT React-specific): they expose a real
+// Svelte-only divergence where collapsing a `defaultExpandedIds` node re-fires the init $effect
+// and re-expands it — see the inline notes on those two tests. Reported for the reviewer.
+//
+// The Svelte TreeView initializes expansion/selection/focus state inside onMounted, so the
+// resulting DOM only reflects defaults after a microtask flush. `renderTree` awaits a tick
+// after mounting so initial-state assertions see the applied props (mirrors React's sync render).
+const renderTree = async (
+  ...args: Parameters<typeof render>
+): Promise<ReturnType<typeof render>> => {
+  const result = render(...args);
+  await tick();
+  return result;
+};
+
+const simpleNodes: TreeNode[] = [
+  {
+    id: 'docs',
+    label: 'Documents',
+    children: [
+      { id: 'report', label: 'report.pdf' },
+      { id: 'notes', label: 'notes.txt' },
+    ],
+  },
+  {
+    id: 'images',
+    label: 'Images',
+    children: [
+      { id: 'photo1', label: 'photo1.jpg' },
+      { id: 'photo2', label: 'photo2.jpg' },
+    ],
+  },
+  { id: 'readme', label: 'readme.md' },
+];
+
+const nestedNodes: TreeNode[] = [
+  {
+    id: 'root',
+    label: 'Root',
+    children: [
+      {
+        id: 'level1',
+        label: 'Level 1',
+        children: [
+          {
+            id: 'level2',
+            label: 'Level 2',
+            children: [{ id: 'level3', label: 'Level 3' }],
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const nodesWithDisabled: TreeNode[] = [
+  { id: 'item1', label: 'Item 1' },
+  { id: 'item2', label: 'Item 2', disabled: true },
+  { id: 'item3', label: 'Item 3' },
+];
+
+const nodesWithDisabledParent: TreeNode[] = [
+  {
+    id: 'parent',
+    label: 'Disabled Parent',
+    disabled: true,
+    children: [{ id: 'child', label: 'Child' }],
+  },
+  { id: 'item', label: 'Item' },
+];
+
+describe('TreeView (Svelte)', () => {
+  // 🔴 High Priority: APG ARIA Attributes
+  describe('APG: ARIA Attributes', () => {
+    it('has role="tree" on container', async () => {
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+      expect(screen.getByRole('tree')).toBeInTheDocument();
+    });
+
+    it('has role="treeitem" on all nodes', async () => {
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs', 'images'] },
+      });
+      expect(screen.getAllByRole('treeitem')).toHaveLength(7);
+    });
+
+    it('has role="group" on child containers', async () => {
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs'] },
+      });
+      expect(screen.getByRole('group')).toBeInTheDocument();
+    });
+
+    it('has aria-expanded on parent nodes only', async () => {
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveAttribute('aria-expanded');
+      expect(screen.getByRole('treeitem', { name: 'Images' })).toHaveAttribute('aria-expanded');
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).not.toHaveAttribute(
+        'aria-expanded'
+      );
+    });
+
+    it('leaf nodes do NOT have aria-expanded', async () => {
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs', 'images'] },
+      });
+      expect(screen.getByRole('treeitem', { name: 'report.pdf' })).not.toHaveAttribute(
+        'aria-expanded'
+      );
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).not.toHaveAttribute(
+        'aria-expanded'
+      );
+    });
+
+    it('updates aria-expanded on expand/collapse', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      expect(docs).toHaveAttribute('aria-expanded', 'false');
+
+      docs.focus();
+      await user.keyboard('{ArrowRight}');
+      expect(docs).toHaveAttribute('aria-expanded', 'true');
+
+      await user.keyboard('{ArrowLeft}');
+      expect(docs).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('all treeitems have aria-selected when selection enabled', async () => {
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+      screen.getAllByRole('treeitem').forEach((item) => {
+        expect(item).toHaveAttribute('aria-selected');
+      });
+    });
+
+    it('selected node has aria-selected="true", others have "false"', async () => {
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultSelectedIds: ['readme'] },
+      });
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveAttribute(
+        'aria-selected',
+        'false'
+      );
+    });
+
+    it('has aria-multiselectable="true" on multi-select tree', async () => {
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', multiselectable: true },
+      });
+      expect(screen.getByRole('tree')).toHaveAttribute('aria-multiselectable', 'true');
+    });
+
+    it('does not have aria-multiselectable on single-select tree', async () => {
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+      expect(screen.getByRole('tree')).not.toHaveAttribute('aria-multiselectable');
+    });
+
+    it('has accessible name via aria-label', async () => {
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'File Explorer' } });
+      expect(screen.getByRole('tree', { name: 'File Explorer' })).toBeInTheDocument();
+    });
+
+    it('has accessible name via aria-labelledby', async () => {
+      const heading = document.createElement('h2');
+      heading.id = 'tree-label';
+      heading.textContent = 'My Files';
+      document.body.appendChild(heading);
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabelledby: 'tree-label' } });
+      expect(screen.getByRole('tree', { name: 'My Files' })).toBeInTheDocument();
+    });
+
+    it('disabled nodes have aria-disabled="true"', async () => {
+      await renderTree(TreeView, { props: { nodes: nodesWithDisabled, ariaLabel: 'Items' } });
+      expect(screen.getByRole('treeitem', { name: 'Item 2' })).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
+    });
+  });
+
+  // 🔴 High Priority: Keyboard Navigation
+  describe('APG: Keyboard Navigation', () => {
+    it('ArrowDown moves to next visible node', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('treeitem', { name: 'Images' })).toHaveFocus();
+    });
+
+    it('ArrowDown moves into expanded children', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs'] },
+      });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('treeitem', { name: 'report.pdf' })).toHaveFocus();
+    });
+
+    it('ArrowUp moves to previous visible node', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      screen.getByRole('treeitem', { name: 'Images' }).focus();
+      await user.keyboard('{ArrowUp}');
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveFocus();
+    });
+
+    it('ArrowUp moves to parent from first child', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs'] },
+      });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('treeitem', { name: 'report.pdf' })).toHaveFocus();
+
+      await user.keyboard('{ArrowUp}');
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveFocus();
+    });
+
+    it('ArrowRight expands closed parent', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      expect(docs).toHaveAttribute('aria-expanded', 'false');
+      await user.keyboard('{ArrowRight}');
+      expect(docs).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('ArrowRight moves to first child when parent is expanded', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs'] },
+      });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('treeitem', { name: 'report.pdf' })).toHaveFocus();
+    });
+
+    it('ArrowRight does nothing on leaf node', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs'] },
+      });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowRight}');
+      const report = screen.getByRole('treeitem', { name: 'report.pdf' });
+      expect(report).toHaveFocus();
+      await user.keyboard('{ArrowRight}');
+      expect(report).toHaveFocus();
+    });
+
+    // SKIPPED — real Svelte-only divergence (do not "fix" by weakening the assertion).
+    // The Svelte TreeView initializes defaults in an $effect guarded by
+    // `internalExpandedIds.size === 0 && internalSelectedIds.size === 0`. When a node
+    // expanded via `defaultExpandedIds` (and no default selection) is collapsed, both sets
+    // become empty again and the init $effect RE-FIRES, re-applying `defaultExpandedIds` and
+    // undoing the collapse. React/Vue initialize once in render/onMounted and do not regress.
+    // Setting `defaultSelectedIds` makes this pass (proves the cause). Reported for the reviewer.
+    it.skip('ArrowLeft collapses open parent', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs'] },
+      });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      expect(docs).toHaveAttribute('aria-expanded', 'true');
+      await user.keyboard('{ArrowLeft}');
+      expect(docs).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('ArrowLeft moves to parent from child', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs'] },
+      });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('treeitem', { name: 'report.pdf' })).toHaveFocus();
+      await user.keyboard('{ArrowLeft}');
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveFocus();
+    });
+
+    it('ArrowLeft moves to parent from closed parent', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: nestedNodes, ariaLabel: 'Nested', defaultExpandedIds: ['root'] },
+      });
+
+      screen.getByRole('treeitem', { name: 'Root' }).focus();
+      await user.keyboard('{ArrowRight}');
+      const level1 = screen.getByRole('treeitem', { name: 'Level 1' });
+      expect(level1).toHaveFocus();
+      expect(level1).toHaveAttribute('aria-expanded', 'false');
+      await user.keyboard('{ArrowLeft}');
+      expect(screen.getByRole('treeitem', { name: 'Root' })).toHaveFocus();
+    });
+
+    it('ArrowLeft does nothing on root node', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      expect(docs).toHaveAttribute('aria-expanded', 'false');
+      await user.keyboard('{ArrowLeft}');
+      expect(docs).toHaveFocus();
+    });
+
+    it('Home moves focus to first node', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      screen.getByRole('treeitem', { name: 'readme.md' }).focus();
+      await user.keyboard('{Home}');
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveFocus();
+    });
+
+    it('End moves focus to last visible node', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{End}');
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).toHaveFocus();
+    });
+
+    it('End moves to last visible node when children are expanded', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['images'] },
+      });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{End}');
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).toHaveFocus();
+    });
+
+    it('Enter activates node but does not toggle expansion', async () => {
+      const user = userEvent.setup();
+      const onActivate = vi.fn();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files', onActivate } });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      expect(docs).toHaveAttribute('aria-expanded', 'false');
+      await user.keyboard('{Enter}');
+      expect(docs).toHaveAttribute('aria-expanded', 'false');
+      expect(onActivate).toHaveBeenCalledWith('docs');
+    });
+
+    it('* expands all siblings at current level', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      await user.keyboard('*');
+      expect(docs).toHaveAttribute('aria-expanded', 'true');
+      expect(screen.getByRole('treeitem', { name: 'Images' })).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+    });
+
+    it('collapsed children are skipped during navigation', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('treeitem', { name: 'Images' })).toHaveFocus();
+    });
+  });
+
+  // 🔴 High Priority: Type-ahead
+  describe('APG: Type-ahead', () => {
+    it('focuses matching visible node on character input', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('r');
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).toHaveFocus();
+    });
+
+    it('cycles through matches on repeated character', async () => {
+      const user = userEvent.setup();
+      const nodesWithSamePrefix: TreeNode[] = [
+        { id: 'apple', label: 'Apple' },
+        { id: 'apricot', label: 'Apricot' },
+        { id: 'avocado', label: 'Avocado' },
+      ];
+      await renderTree(TreeView, { props: { nodes: nodesWithSamePrefix, ariaLabel: 'Fruits' } });
+
+      screen.getByRole('treeitem', { name: 'Apple' }).focus();
+      await user.keyboard('a');
+      expect(screen.getByRole('treeitem', { name: 'Apricot' })).toHaveFocus();
+      await user.keyboard('a');
+      expect(screen.getByRole('treeitem', { name: 'Avocado' })).toHaveFocus();
+      await user.keyboard('a');
+      expect(screen.getByRole('treeitem', { name: 'Apple' })).toHaveFocus();
+    });
+
+    it('only searches visible nodes', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('r');
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).toHaveFocus();
+    });
+
+    it('matches multiple characters typed quickly', async () => {
+      const user = userEvent.setup();
+      const nodesForTypeAhead: TreeNode[] = [
+        { id: 'readme', label: 'readme.md' },
+        { id: 'report', label: 'report.pdf' },
+        { id: 'resources', label: 'resources' },
+      ];
+      await renderTree(TreeView, { props: { nodes: nodesForTypeAhead, ariaLabel: 'Files' } });
+
+      screen.getByRole('treeitem', { name: 'readme.md' }).focus();
+      await user.keyboard('rep');
+      expect(screen.getByRole('treeitem', { name: 'report.pdf' })).toHaveFocus();
+    });
+
+    it('resets buffer after timeout', async () => {
+      const user = userEvent.setup();
+      const nodesForTypeAhead: TreeNode[] = [
+        { id: 'readme', label: 'readme.md' },
+        { id: 'report', label: 'report.pdf' },
+        { id: 'resources', label: 'resources' },
+      ];
+      await renderTree(TreeView, {
+        props: { nodes: nodesForTypeAhead, ariaLabel: 'Files', typeAheadTimeout: 100 },
+      });
+
+      screen.getByRole('treeitem', { name: 'readme.md' }).focus();
+      await user.keyboard('r');
+      expect(screen.getByRole('treeitem', { name: 'report.pdf' })).toHaveFocus();
+
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      await user.keyboard('r');
+      expect(screen.getByRole('treeitem', { name: 'resources' })).toHaveFocus();
+    });
+  });
+
+  // 🔴 High Priority: Focus Management
+  describe('APG: Focus Management', () => {
+    it('tree is single Tab stop', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+      const tree = screen.getByRole('tree');
+      const before = document.createElement('button');
+      before.textContent = 'Before';
+      tree.parentElement!.insertBefore(before, tree);
+      const after = document.createElement('button');
+      after.textContent = 'After';
+      tree.parentElement!.appendChild(after);
+
+      screen.getByRole('button', { name: 'Before' }).focus();
+      await user.keyboard('{Tab}');
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveFocus();
+      await user.keyboard('{Tab}');
+      expect(screen.getByRole('button', { name: 'After' })).toHaveFocus();
+    });
+
+    it('focused node has tabindex="0"', async () => {
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveAttribute('tabindex', '0');
+    });
+
+    it('other nodes have tabindex="-1"', async () => {
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+      expect(screen.getByRole('treeitem', { name: 'Images' })).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).toHaveAttribute('tabindex', '-1');
+    });
+
+    // SKIPPED — same real Svelte-only divergence as 'ArrowLeft collapses open parent':
+    // collapsing a `defaultExpandedIds` node (no default selection) re-fires the init
+    // $effect, which re-expands it. See the detailed note on that test. Reported for the reviewer.
+    it.skip('focus moves to parent when child is focused and parent collapses', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs'] },
+      });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('treeitem', { name: 'report.pdf' })).toHaveFocus();
+      await user.keyboard('{ArrowLeft}');
+      expect(docs).toHaveFocus();
+      await user.keyboard('{ArrowLeft}');
+      expect(docs).toHaveFocus();
+      expect(docs).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('focus moves to parent when parent is collapsed programmatically while child has focus', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs'] },
+      });
+
+      const report = screen.getByRole('treeitem', { name: 'report.pdf' });
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      report.focus();
+      expect(report).toHaveFocus();
+      await user.click(docs);
+      expect(docs).toHaveFocus();
+    });
+
+    it('disabled nodes are focusable', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: nodesWithDisabled, ariaLabel: 'Items' } });
+
+      screen.getByRole('treeitem', { name: 'Item 1' }).focus();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('treeitem', { name: 'Item 2' })).toHaveFocus();
+    });
+
+    it('disabled nodes cannot be selected', async () => {
+      await renderTree(TreeView, { props: { nodes: nodesWithDisabled, ariaLabel: 'Items' } });
+
+      const disabled = screen.getByRole('treeitem', { name: 'Item 2' });
+      disabled.focus();
+      expect(disabled).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('disabled parent nodes cannot be expanded', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: nodesWithDisabledParent, ariaLabel: 'Items' } });
+
+      const parent = screen.getByRole('treeitem', { name: 'Disabled Parent' });
+      parent.focus();
+      expect(parent).toHaveAttribute('aria-expanded', 'false');
+      await user.keyboard('{ArrowRight}');
+      expect(parent).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('disabled nodes do not trigger onActivate on Enter', async () => {
+      const user = userEvent.setup();
+      const onActivate = vi.fn();
+      await renderTree(TreeView, {
+        props: { nodes: nodesWithDisabled, ariaLabel: 'Items', onActivate },
+      });
+
+      screen.getByRole('treeitem', { name: 'Item 2' }).focus();
+      await user.keyboard('{Enter}');
+      expect(onActivate).not.toHaveBeenCalled();
+    });
+
+    it('disabled nodes do not toggle selection on Space in multi-select', async () => {
+      const user = userEvent.setup();
+      const onSelectionChange = vi.fn();
+      await renderTree(TreeView, {
+        props: {
+          nodes: nodesWithDisabled,
+          ariaLabel: 'Items',
+          multiselectable: true,
+          onSelectionChange,
+        },
+      });
+
+      const disabled = screen.getByRole('treeitem', { name: 'Item 2' });
+      disabled.focus();
+      onSelectionChange.mockClear();
+      await user.keyboard(' ');
+      expect(onSelectionChange).not.toHaveBeenCalled();
+      expect(disabled).toHaveAttribute('aria-selected', 'false');
+    });
+  });
+
+  // 🔴 High Priority: Boundary Navigation
+  describe('APG: Boundary Navigation', () => {
+    it('ArrowUp at first node does nothing', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      await user.keyboard('{ArrowUp}');
+      expect(docs).toHaveFocus();
+    });
+
+    it('ArrowDown at last visible node does nothing', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      const readme = screen.getByRole('treeitem', { name: 'readme.md' });
+      readme.focus();
+      await user.keyboard('{ArrowDown}');
+      expect(readme).toHaveFocus();
+    });
+
+    it('ArrowDown at last visible node with expanded children does nothing', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['images'] },
+      });
+
+      const readme = screen.getByRole('treeitem', { name: 'readme.md' });
+      readme.focus();
+      await user.keyboard('{ArrowDown}');
+      expect(readme).toHaveFocus();
+    });
+  });
+
+  // 🔴 High Priority: Selection (Single-Select)
+  describe('APG: Selection (Single-Select)', () => {
+    it('arrow keys move focus only (selection does NOT follow focus)', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultSelectedIds: ['docs'] },
+      });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      const images = screen.getByRole('treeitem', { name: 'Images' });
+      docs.focus();
+      expect(docs).toHaveAttribute('aria-selected', 'true');
+      expect(images).toHaveAttribute('aria-selected', 'false');
+      await user.keyboard('{ArrowDown}');
+      expect(images).toHaveFocus();
+      expect(docs).toHaveAttribute('aria-selected', 'true');
+      expect(images).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('only one node is selected at a time', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      const images = screen.getByRole('treeitem', { name: 'Images' });
+      docs.focus();
+      await user.keyboard('{Enter}');
+      expect(docs).toHaveAttribute('aria-selected', 'true');
+      await user.keyboard('{ArrowDown}');
+      await user.keyboard('{Enter}');
+      expect(docs).toHaveAttribute('aria-selected', 'false');
+      expect(images).toHaveAttribute('aria-selected', 'true');
+      const selected = screen
+        .getAllByRole('treeitem')
+        .filter((item) => item.getAttribute('aria-selected') === 'true');
+      expect(selected).toHaveLength(1);
+    });
+
+    it('Space selects focused node in single-select mode', async () => {
+      const user = userEvent.setup();
+      const onSelectionChange = vi.fn();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', onSelectionChange },
+      });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      await user.keyboard(' ');
+      expect(onSelectionChange).toHaveBeenCalledWith(['docs']);
+      expect(docs).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('calls onSelectionChange when Enter selects a node', async () => {
+      const user = userEvent.setup();
+      const onSelectionChange = vi.fn();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', onSelectionChange },
+      });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{Enter}');
+      expect(onSelectionChange).toHaveBeenCalledWith(['docs']);
+    });
+  });
+
+  // 🔴 High Priority: Selection (Multi-Select)
+  describe('APG: Selection (Multi-Select)', () => {
+    it('Space toggles selection', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', multiselectable: true },
+      });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      expect(docs).toHaveAttribute('aria-selected', 'false');
+      await user.keyboard(' ');
+      expect(docs).toHaveAttribute('aria-selected', 'true');
+      await user.keyboard(' ');
+      expect(docs).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('arrow keys move focus without changing selection', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: {
+          nodes: simpleNodes,
+          ariaLabel: 'Files',
+          multiselectable: true,
+          defaultSelectedIds: ['docs'],
+        },
+      });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      await user.keyboard('{ArrowDown}');
+      expect(docs).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByRole('treeitem', { name: 'Images' })).toHaveAttribute(
+        'aria-selected',
+        'false'
+      );
+    });
+
+    it('Shift+Arrow extends selection range', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', multiselectable: true },
+      });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      await user.keyboard(' ');
+      await user.keyboard('{Shift>}{ArrowDown}{/Shift}');
+      await user.keyboard('{Shift>}{ArrowDown}{/Shift}');
+      expect(docs).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByRole('treeitem', { name: 'Images' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+    });
+
+    it('Ctrl+A selects all visible nodes', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', multiselectable: true },
+      });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{Control>}a{/Control}');
+      screen.getAllByRole('treeitem').forEach((item) => {
+        expect(item).toHaveAttribute('aria-selected', 'true');
+      });
+    });
+
+    it('Ctrl+A selects only visible nodes (not collapsed children)', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: {
+          nodes: simpleNodes,
+          ariaLabel: 'Files',
+          multiselectable: true,
+          defaultExpandedIds: ['docs'],
+        },
+      });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{Control>}a{/Control}');
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+      expect(screen.getByRole('treeitem', { name: 'report.pdf' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+      expect(screen.getByRole('treeitem', { name: 'notes.txt' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+      expect(screen.getByRole('treeitem', { name: 'Images' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+    });
+
+    it('Ctrl+Space toggles selection without updating anchor', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', multiselectable: true },
+      });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      const images = screen.getByRole('treeitem', { name: 'Images' });
+      const readme = screen.getByRole('treeitem', { name: 'readme.md' });
+      docs.focus();
+      await user.keyboard(' ');
+      expect(docs).toHaveAttribute('aria-selected', 'true');
+      await user.keyboard('{ArrowDown}');
+      expect(images).toHaveFocus();
+      await user.keyboard('{Control>} {/Control}');
+      expect(images).toHaveAttribute('aria-selected', 'true');
+      await user.keyboard('{Shift>}{ArrowDown}{/Shift}');
+      expect(docs).toHaveAttribute('aria-selected', 'true');
+      expect(images).toHaveAttribute('aria-selected', 'true');
+      expect(readme).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('Shift+Home extends selection from anchor to first node', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', multiselectable: true },
+      });
+
+      const readme = screen.getByRole('treeitem', { name: 'readme.md' });
+      readme.focus();
+      await user.keyboard(' ');
+      expect(readme).toHaveAttribute('aria-selected', 'true');
+      await user.keyboard('{Shift>}{Home}{/Shift}');
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveFocus();
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+      expect(screen.getByRole('treeitem', { name: 'Images' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+      expect(readme).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('Shift+End extends selection from anchor to last visible node', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', multiselectable: true },
+      });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      await user.keyboard(' ');
+      expect(docs).toHaveAttribute('aria-selected', 'true');
+      await user.keyboard('{Shift>}{End}{/Shift}');
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).toHaveFocus();
+      expect(docs).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByRole('treeitem', { name: 'Images' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+    });
+  });
+
+  // 🔴 High Priority: Expansion Callbacks
+  describe('Expansion', () => {
+    it('calls onExpandedChange when nodes are expanded', async () => {
+      const user = userEvent.setup();
+      const onExpandedChange = vi.fn();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', onExpandedChange },
+      });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowRight}');
+      expect(onExpandedChange).toHaveBeenCalledWith(['docs']);
+    });
+
+    it('calls onExpandedChange when nodes are collapsed', async () => {
+      const user = userEvent.setup();
+      const onExpandedChange = vi.fn();
+      await renderTree(TreeView, {
+        props: {
+          nodes: simpleNodes,
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+          onExpandedChange,
+        },
+      });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowLeft}');
+      expect(onExpandedChange).toHaveBeenCalledWith([]);
+    });
+  });
+
+  // 🟡 Medium Priority: Accessibility
+  describe('Accessibility', () => {
+    it('has no axe violations', async () => {
+      const { container } = await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs'] },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with multi-select', async () => {
+      const { container } = await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', multiselectable: true },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with disabled nodes', async () => {
+      const { container } = await renderTree(TreeView, {
+        props: { nodes: nodesWithDisabled, ariaLabel: 'Items' },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  // 🟢 Low Priority: Props & Behavior
+  describe('Props & Behavior', () => {
+    it('respects defaultExpandedIds', async () => {
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs', 'images'] },
+      });
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+      expect(screen.getByRole('treeitem', { name: 'Images' })).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+    });
+
+    it('respects defaultSelectedIds', async () => {
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultSelectedIds: ['readme'] },
+      });
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+    });
+
+    it('applies className to container', async () => {
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', class: 'custom-tree' },
+      });
+      expect(screen.getByRole('tree')).toHaveClass('custom-tree');
+    });
+  });
+});

--- a/src/patterns/treeview/TreeView.test.vue.ts
+++ b/src/patterns/treeview/TreeView.test.vue.ts
@@ -1,0 +1,970 @@
+import { render, screen } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+import { h, nextTick } from 'vue';
+import TreeView from './TreeView.vue';
+import type { TreeNodeData } from './TreeView.vue';
+
+// Prop/event mapping vs React:
+// - React `aria-label` / `aria-labelledby` -> Vue `ariaLabel` / `ariaLabelledby` props.
+// - React `onSelectionChange` / `onExpandedChange` / `onActivate` callback props ->
+//   Vue `selectionChange` / `expandedChange` / `activate` emits (assert via on* listeners).
+// - React `className` -> Vue `class`.
+// No React-specific cases are skipped; all titles are ported 1:1.
+//
+// The Vue TreeView initializes expansion/selection/focus state inside onMounted, so the
+// resulting DOM only reflects defaults after a reactivity flush. `renderTree` awaits a tick
+// after mounting so initial-state assertions see the applied props (mirrors React's sync render).
+const renderTree = async (
+  ...args: Parameters<typeof render>
+): Promise<ReturnType<typeof render>> => {
+  const result = render(...args);
+  await nextTick();
+  return result;
+};
+
+const simpleNodes: TreeNodeData[] = [
+  {
+    id: 'docs',
+    label: 'Documents',
+    children: [
+      { id: 'report', label: 'report.pdf' },
+      { id: 'notes', label: 'notes.txt' },
+    ],
+  },
+  {
+    id: 'images',
+    label: 'Images',
+    children: [
+      { id: 'photo1', label: 'photo1.jpg' },
+      { id: 'photo2', label: 'photo2.jpg' },
+    ],
+  },
+  { id: 'readme', label: 'readme.md' },
+];
+
+const nestedNodes: TreeNodeData[] = [
+  {
+    id: 'root',
+    label: 'Root',
+    children: [
+      {
+        id: 'level1',
+        label: 'Level 1',
+        children: [
+          {
+            id: 'level2',
+            label: 'Level 2',
+            children: [{ id: 'level3', label: 'Level 3' }],
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const nodesWithDisabled: TreeNodeData[] = [
+  { id: 'item1', label: 'Item 1' },
+  { id: 'item2', label: 'Item 2', disabled: true },
+  { id: 'item3', label: 'Item 3' },
+];
+
+const nodesWithDisabledParent: TreeNodeData[] = [
+  {
+    id: 'parent',
+    label: 'Disabled Parent',
+    disabled: true,
+    children: [{ id: 'child', label: 'Child' }],
+  },
+  { id: 'item', label: 'Item' },
+];
+
+describe('TreeView (Vue)', () => {
+  // 🔴 High Priority: APG ARIA Attributes
+  describe('APG: ARIA Attributes', () => {
+    it('has role="tree" on container', async () => {
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+      expect(screen.getByRole('tree')).toBeInTheDocument();
+    });
+
+    it('has role="treeitem" on all nodes', async () => {
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs', 'images'] },
+      });
+      expect(screen.getAllByRole('treeitem')).toHaveLength(7);
+    });
+
+    it('has role="group" on child containers', async () => {
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs'] },
+      });
+      expect(screen.getByRole('group')).toBeInTheDocument();
+    });
+
+    it('has aria-expanded on parent nodes only', async () => {
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveAttribute('aria-expanded');
+      expect(screen.getByRole('treeitem', { name: 'Images' })).toHaveAttribute('aria-expanded');
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).not.toHaveAttribute(
+        'aria-expanded'
+      );
+    });
+
+    it('leaf nodes do NOT have aria-expanded', async () => {
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs', 'images'] },
+      });
+      expect(screen.getByRole('treeitem', { name: 'report.pdf' })).not.toHaveAttribute(
+        'aria-expanded'
+      );
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).not.toHaveAttribute(
+        'aria-expanded'
+      );
+    });
+
+    it('updates aria-expanded on expand/collapse', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      expect(docs).toHaveAttribute('aria-expanded', 'false');
+
+      docs.focus();
+      await user.keyboard('{ArrowRight}');
+      expect(docs).toHaveAttribute('aria-expanded', 'true');
+
+      await user.keyboard('{ArrowLeft}');
+      expect(docs).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('all treeitems have aria-selected when selection enabled', async () => {
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+      screen.getAllByRole('treeitem').forEach((item) => {
+        expect(item).toHaveAttribute('aria-selected');
+      });
+    });
+
+    it('selected node has aria-selected="true", others have "false"', async () => {
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultSelectedIds: ['readme'] },
+      });
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveAttribute(
+        'aria-selected',
+        'false'
+      );
+    });
+
+    it('has aria-multiselectable="true" on multi-select tree', async () => {
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', multiselectable: true },
+      });
+      expect(screen.getByRole('tree')).toHaveAttribute('aria-multiselectable', 'true');
+    });
+
+    it('does not have aria-multiselectable on single-select tree', async () => {
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+      expect(screen.getByRole('tree')).not.toHaveAttribute('aria-multiselectable');
+    });
+
+    it('has accessible name via aria-label', async () => {
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'File Explorer' } });
+      expect(screen.getByRole('tree', { name: 'File Explorer' })).toBeInTheDocument();
+    });
+
+    it('has accessible name via aria-labelledby', async () => {
+      await renderTree({
+        components: { TreeView },
+        setup() {
+          return () =>
+            h('div', [
+              h('h2', { id: 'tree-label' }, 'My Files'),
+              h(TreeView, { nodes: simpleNodes, ariaLabelledby: 'tree-label' }),
+            ]);
+        },
+      });
+      expect(screen.getByRole('tree', { name: 'My Files' })).toBeInTheDocument();
+    });
+
+    it('disabled nodes have aria-disabled="true"', async () => {
+      await renderTree(TreeView, { props: { nodes: nodesWithDisabled, ariaLabel: 'Items' } });
+      expect(screen.getByRole('treeitem', { name: 'Item 2' })).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
+    });
+  });
+
+  // 🔴 High Priority: Keyboard Navigation
+  describe('APG: Keyboard Navigation', () => {
+    it('ArrowDown moves to next visible node', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('treeitem', { name: 'Images' })).toHaveFocus();
+    });
+
+    it('ArrowDown moves into expanded children', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs'] },
+      });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('treeitem', { name: 'report.pdf' })).toHaveFocus();
+    });
+
+    it('ArrowUp moves to previous visible node', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      screen.getByRole('treeitem', { name: 'Images' }).focus();
+      await user.keyboard('{ArrowUp}');
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveFocus();
+    });
+
+    it('ArrowUp moves to parent from first child', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs'] },
+      });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('treeitem', { name: 'report.pdf' })).toHaveFocus();
+
+      await user.keyboard('{ArrowUp}');
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveFocus();
+    });
+
+    it('ArrowRight expands closed parent', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      expect(docs).toHaveAttribute('aria-expanded', 'false');
+      await user.keyboard('{ArrowRight}');
+      expect(docs).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('ArrowRight moves to first child when parent is expanded', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs'] },
+      });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('treeitem', { name: 'report.pdf' })).toHaveFocus();
+    });
+
+    it('ArrowRight does nothing on leaf node', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs'] },
+      });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowRight}');
+      const report = screen.getByRole('treeitem', { name: 'report.pdf' });
+      expect(report).toHaveFocus();
+      await user.keyboard('{ArrowRight}');
+      expect(report).toHaveFocus();
+    });
+
+    it('ArrowLeft collapses open parent', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs'] },
+      });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      expect(docs).toHaveAttribute('aria-expanded', 'true');
+      await user.keyboard('{ArrowLeft}');
+      expect(docs).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('ArrowLeft moves to parent from child', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs'] },
+      });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('treeitem', { name: 'report.pdf' })).toHaveFocus();
+      await user.keyboard('{ArrowLeft}');
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveFocus();
+    });
+
+    it('ArrowLeft moves to parent from closed parent', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: nestedNodes, ariaLabel: 'Nested', defaultExpandedIds: ['root'] },
+      });
+
+      screen.getByRole('treeitem', { name: 'Root' }).focus();
+      await user.keyboard('{ArrowRight}');
+      const level1 = screen.getByRole('treeitem', { name: 'Level 1' });
+      expect(level1).toHaveFocus();
+      expect(level1).toHaveAttribute('aria-expanded', 'false');
+      await user.keyboard('{ArrowLeft}');
+      expect(screen.getByRole('treeitem', { name: 'Root' })).toHaveFocus();
+    });
+
+    it('ArrowLeft does nothing on root node', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      expect(docs).toHaveAttribute('aria-expanded', 'false');
+      await user.keyboard('{ArrowLeft}');
+      expect(docs).toHaveFocus();
+    });
+
+    it('Home moves focus to first node', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      screen.getByRole('treeitem', { name: 'readme.md' }).focus();
+      await user.keyboard('{Home}');
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveFocus();
+    });
+
+    it('End moves focus to last visible node', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{End}');
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).toHaveFocus();
+    });
+
+    it('End moves to last visible node when children are expanded', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['images'] },
+      });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{End}');
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).toHaveFocus();
+    });
+
+    it('Enter activates node but does not toggle expansion', async () => {
+      const user = userEvent.setup();
+      const onActivate = vi.fn();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files', onActivate } });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      expect(docs).toHaveAttribute('aria-expanded', 'false');
+      await user.keyboard('{Enter}');
+      expect(docs).toHaveAttribute('aria-expanded', 'false');
+      expect(onActivate).toHaveBeenCalledWith('docs');
+    });
+
+    it('* expands all siblings at current level', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      await user.keyboard('*');
+      expect(docs).toHaveAttribute('aria-expanded', 'true');
+      expect(screen.getByRole('treeitem', { name: 'Images' })).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+    });
+
+    it('collapsed children are skipped during navigation', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('treeitem', { name: 'Images' })).toHaveFocus();
+    });
+  });
+
+  // 🔴 High Priority: Type-ahead
+  describe('APG: Type-ahead', () => {
+    it('focuses matching visible node on character input', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('r');
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).toHaveFocus();
+    });
+
+    it('cycles through matches on repeated character', async () => {
+      const user = userEvent.setup();
+      const nodesWithSamePrefix: TreeNodeData[] = [
+        { id: 'apple', label: 'Apple' },
+        { id: 'apricot', label: 'Apricot' },
+        { id: 'avocado', label: 'Avocado' },
+      ];
+      await renderTree(TreeView, { props: { nodes: nodesWithSamePrefix, ariaLabel: 'Fruits' } });
+
+      screen.getByRole('treeitem', { name: 'Apple' }).focus();
+      await user.keyboard('a');
+      expect(screen.getByRole('treeitem', { name: 'Apricot' })).toHaveFocus();
+      await user.keyboard('a');
+      expect(screen.getByRole('treeitem', { name: 'Avocado' })).toHaveFocus();
+      await user.keyboard('a');
+      expect(screen.getByRole('treeitem', { name: 'Apple' })).toHaveFocus();
+    });
+
+    it('only searches visible nodes', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('r');
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).toHaveFocus();
+    });
+
+    it('matches multiple characters typed quickly', async () => {
+      const user = userEvent.setup();
+      const nodesForTypeAhead: TreeNodeData[] = [
+        { id: 'readme', label: 'readme.md' },
+        { id: 'report', label: 'report.pdf' },
+        { id: 'resources', label: 'resources' },
+      ];
+      await renderTree(TreeView, { props: { nodes: nodesForTypeAhead, ariaLabel: 'Files' } });
+
+      screen.getByRole('treeitem', { name: 'readme.md' }).focus();
+      await user.keyboard('rep');
+      expect(screen.getByRole('treeitem', { name: 'report.pdf' })).toHaveFocus();
+    });
+
+    it('resets buffer after timeout', async () => {
+      const user = userEvent.setup();
+      const nodesForTypeAhead: TreeNodeData[] = [
+        { id: 'readme', label: 'readme.md' },
+        { id: 'report', label: 'report.pdf' },
+        { id: 'resources', label: 'resources' },
+      ];
+      await renderTree(TreeView, {
+        props: { nodes: nodesForTypeAhead, ariaLabel: 'Files', typeAheadTimeout: 100 },
+      });
+
+      screen.getByRole('treeitem', { name: 'readme.md' }).focus();
+      await user.keyboard('r');
+      expect(screen.getByRole('treeitem', { name: 'report.pdf' })).toHaveFocus();
+
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      await user.keyboard('r');
+      expect(screen.getByRole('treeitem', { name: 'resources' })).toHaveFocus();
+    });
+  });
+
+  // 🔴 High Priority: Focus Management
+  describe('APG: Focus Management', () => {
+    it('tree is single Tab stop', async () => {
+      const user = userEvent.setup();
+      await renderTree({
+        components: { TreeView },
+        setup() {
+          return () =>
+            h('div', [
+              h('button', 'Before'),
+              h(TreeView, { nodes: simpleNodes, ariaLabel: 'Files' }),
+              h('button', 'After'),
+            ]);
+        },
+      });
+
+      screen.getByRole('button', { name: 'Before' }).focus();
+      await user.keyboard('{Tab}');
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveFocus();
+      await user.keyboard('{Tab}');
+      expect(screen.getByRole('button', { name: 'After' })).toHaveFocus();
+    });
+
+    it('focused node has tabindex="0"', async () => {
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveAttribute('tabindex', '0');
+    });
+
+    it('other nodes have tabindex="-1"', async () => {
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+      expect(screen.getByRole('treeitem', { name: 'Images' })).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('focus moves to parent when child is focused and parent collapses', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs'] },
+      });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('treeitem', { name: 'report.pdf' })).toHaveFocus();
+      await user.keyboard('{ArrowLeft}');
+      expect(docs).toHaveFocus();
+      await user.keyboard('{ArrowLeft}');
+      expect(docs).toHaveFocus();
+      expect(docs).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('focus moves to parent when parent is collapsed programmatically while child has focus', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs'] },
+      });
+
+      const report = screen.getByRole('treeitem', { name: 'report.pdf' });
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      report.focus();
+      expect(report).toHaveFocus();
+      await user.click(docs);
+      expect(docs).toHaveFocus();
+    });
+
+    it('disabled nodes are focusable', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: nodesWithDisabled, ariaLabel: 'Items' } });
+
+      screen.getByRole('treeitem', { name: 'Item 1' }).focus();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('treeitem', { name: 'Item 2' })).toHaveFocus();
+    });
+
+    it('disabled nodes cannot be selected', async () => {
+      await renderTree(TreeView, { props: { nodes: nodesWithDisabled, ariaLabel: 'Items' } });
+
+      const disabled = screen.getByRole('treeitem', { name: 'Item 2' });
+      disabled.focus();
+      expect(disabled).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('disabled parent nodes cannot be expanded', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: nodesWithDisabledParent, ariaLabel: 'Items' } });
+
+      const parent = screen.getByRole('treeitem', { name: 'Disabled Parent' });
+      parent.focus();
+      expect(parent).toHaveAttribute('aria-expanded', 'false');
+      await user.keyboard('{ArrowRight}');
+      expect(parent).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('disabled nodes do not trigger onActivate on Enter', async () => {
+      const user = userEvent.setup();
+      const onActivate = vi.fn();
+      await renderTree(TreeView, {
+        props: { nodes: nodesWithDisabled, ariaLabel: 'Items', onActivate },
+      });
+
+      screen.getByRole('treeitem', { name: 'Item 2' }).focus();
+      await user.keyboard('{Enter}');
+      expect(onActivate).not.toHaveBeenCalled();
+    });
+
+    it('disabled nodes do not toggle selection on Space in multi-select', async () => {
+      const user = userEvent.setup();
+      const onSelectionChange = vi.fn();
+      await renderTree(TreeView, {
+        props: {
+          nodes: nodesWithDisabled,
+          ariaLabel: 'Items',
+          multiselectable: true,
+          onSelectionChange,
+        },
+      });
+
+      const disabled = screen.getByRole('treeitem', { name: 'Item 2' });
+      disabled.focus();
+      onSelectionChange.mockClear();
+      await user.keyboard(' ');
+      expect(onSelectionChange).not.toHaveBeenCalled();
+      expect(disabled).toHaveAttribute('aria-selected', 'false');
+    });
+  });
+
+  // 🔴 High Priority: Boundary Navigation
+  describe('APG: Boundary Navigation', () => {
+    it('ArrowUp at first node does nothing', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      await user.keyboard('{ArrowUp}');
+      expect(docs).toHaveFocus();
+    });
+
+    it('ArrowDown at last visible node does nothing', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      const readme = screen.getByRole('treeitem', { name: 'readme.md' });
+      readme.focus();
+      await user.keyboard('{ArrowDown}');
+      expect(readme).toHaveFocus();
+    });
+
+    it('ArrowDown at last visible node with expanded children does nothing', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['images'] },
+      });
+
+      const readme = screen.getByRole('treeitem', { name: 'readme.md' });
+      readme.focus();
+      await user.keyboard('{ArrowDown}');
+      expect(readme).toHaveFocus();
+    });
+  });
+
+  // 🔴 High Priority: Selection (Single-Select)
+  describe('APG: Selection (Single-Select)', () => {
+    it('arrow keys move focus only (selection does NOT follow focus)', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultSelectedIds: ['docs'] },
+      });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      const images = screen.getByRole('treeitem', { name: 'Images' });
+      docs.focus();
+      expect(docs).toHaveAttribute('aria-selected', 'true');
+      expect(images).toHaveAttribute('aria-selected', 'false');
+      await user.keyboard('{ArrowDown}');
+      expect(images).toHaveFocus();
+      expect(docs).toHaveAttribute('aria-selected', 'true');
+      expect(images).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('only one node is selected at a time', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, { props: { nodes: simpleNodes, ariaLabel: 'Files' } });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      const images = screen.getByRole('treeitem', { name: 'Images' });
+      docs.focus();
+      await user.keyboard('{Enter}');
+      expect(docs).toHaveAttribute('aria-selected', 'true');
+      await user.keyboard('{ArrowDown}');
+      await user.keyboard('{Enter}');
+      expect(docs).toHaveAttribute('aria-selected', 'false');
+      expect(images).toHaveAttribute('aria-selected', 'true');
+      const selected = screen
+        .getAllByRole('treeitem')
+        .filter((item) => item.getAttribute('aria-selected') === 'true');
+      expect(selected).toHaveLength(1);
+    });
+
+    it('Space selects focused node in single-select mode', async () => {
+      const user = userEvent.setup();
+      const onSelectionChange = vi.fn();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', onSelectionChange },
+      });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      await user.keyboard(' ');
+      expect(onSelectionChange).toHaveBeenCalledWith(['docs']);
+      expect(docs).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('calls onSelectionChange when Enter selects a node', async () => {
+      const user = userEvent.setup();
+      const onSelectionChange = vi.fn();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', onSelectionChange },
+      });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{Enter}');
+      expect(onSelectionChange).toHaveBeenCalledWith(['docs']);
+    });
+  });
+
+  // 🔴 High Priority: Selection (Multi-Select)
+  describe('APG: Selection (Multi-Select)', () => {
+    it('Space toggles selection', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', multiselectable: true },
+      });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      expect(docs).toHaveAttribute('aria-selected', 'false');
+      await user.keyboard(' ');
+      expect(docs).toHaveAttribute('aria-selected', 'true');
+      await user.keyboard(' ');
+      expect(docs).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('arrow keys move focus without changing selection', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: {
+          nodes: simpleNodes,
+          ariaLabel: 'Files',
+          multiselectable: true,
+          defaultSelectedIds: ['docs'],
+        },
+      });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      await user.keyboard('{ArrowDown}');
+      expect(docs).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByRole('treeitem', { name: 'Images' })).toHaveAttribute(
+        'aria-selected',
+        'false'
+      );
+    });
+
+    it('Shift+Arrow extends selection range', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', multiselectable: true },
+      });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      await user.keyboard(' ');
+      await user.keyboard('{Shift>}{ArrowDown}{/Shift}');
+      await user.keyboard('{Shift>}{ArrowDown}{/Shift}');
+      expect(docs).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByRole('treeitem', { name: 'Images' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+    });
+
+    it('Ctrl+A selects all visible nodes', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', multiselectable: true },
+      });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{Control>}a{/Control}');
+      screen.getAllByRole('treeitem').forEach((item) => {
+        expect(item).toHaveAttribute('aria-selected', 'true');
+      });
+    });
+
+    it('Ctrl+A selects only visible nodes (not collapsed children)', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: {
+          nodes: simpleNodes,
+          ariaLabel: 'Files',
+          multiselectable: true,
+          defaultExpandedIds: ['docs'],
+        },
+      });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{Control>}a{/Control}');
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+      expect(screen.getByRole('treeitem', { name: 'report.pdf' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+      expect(screen.getByRole('treeitem', { name: 'notes.txt' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+      expect(screen.getByRole('treeitem', { name: 'Images' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+    });
+
+    it('Ctrl+Space toggles selection without updating anchor', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', multiselectable: true },
+      });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      const images = screen.getByRole('treeitem', { name: 'Images' });
+      const readme = screen.getByRole('treeitem', { name: 'readme.md' });
+      docs.focus();
+      await user.keyboard(' ');
+      expect(docs).toHaveAttribute('aria-selected', 'true');
+      await user.keyboard('{ArrowDown}');
+      expect(images).toHaveFocus();
+      await user.keyboard('{Control>} {/Control}');
+      expect(images).toHaveAttribute('aria-selected', 'true');
+      await user.keyboard('{Shift>}{ArrowDown}{/Shift}');
+      expect(docs).toHaveAttribute('aria-selected', 'true');
+      expect(images).toHaveAttribute('aria-selected', 'true');
+      expect(readme).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('Shift+Home extends selection from anchor to first node', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', multiselectable: true },
+      });
+
+      const readme = screen.getByRole('treeitem', { name: 'readme.md' });
+      readme.focus();
+      await user.keyboard(' ');
+      expect(readme).toHaveAttribute('aria-selected', 'true');
+      await user.keyboard('{Shift>}{Home}{/Shift}');
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveFocus();
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+      expect(screen.getByRole('treeitem', { name: 'Images' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+      expect(readme).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('Shift+End extends selection from anchor to last visible node', async () => {
+      const user = userEvent.setup();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', multiselectable: true },
+      });
+
+      const docs = screen.getByRole('treeitem', { name: 'Documents' });
+      docs.focus();
+      await user.keyboard(' ');
+      expect(docs).toHaveAttribute('aria-selected', 'true');
+      await user.keyboard('{Shift>}{End}{/Shift}');
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).toHaveFocus();
+      expect(docs).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByRole('treeitem', { name: 'Images' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+    });
+  });
+
+  // 🔴 High Priority: Expansion Callbacks
+  describe('Expansion', () => {
+    it('calls onExpandedChange when nodes are expanded', async () => {
+      const user = userEvent.setup();
+      const onExpandedChange = vi.fn();
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', onExpandedChange },
+      });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowRight}');
+      expect(onExpandedChange).toHaveBeenCalledWith(['docs']);
+    });
+
+    it('calls onExpandedChange when nodes are collapsed', async () => {
+      const user = userEvent.setup();
+      const onExpandedChange = vi.fn();
+      await renderTree(TreeView, {
+        props: {
+          nodes: simpleNodes,
+          ariaLabel: 'Files',
+          defaultExpandedIds: ['docs'],
+          onExpandedChange,
+        },
+      });
+
+      screen.getByRole('treeitem', { name: 'Documents' }).focus();
+      await user.keyboard('{ArrowLeft}');
+      expect(onExpandedChange).toHaveBeenCalledWith([]);
+    });
+  });
+
+  // 🟡 Medium Priority: Accessibility
+  describe('Accessibility', () => {
+    it('has no axe violations', async () => {
+      const { container } = await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs'] },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with multi-select', async () => {
+      const { container } = await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', multiselectable: true },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no axe violations with disabled nodes', async () => {
+      const { container } = await renderTree(TreeView, {
+        props: { nodes: nodesWithDisabled, ariaLabel: 'Items' },
+      });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  // 🟢 Low Priority: Props & Behavior
+  describe('Props & Behavior', () => {
+    it('respects defaultExpandedIds', async () => {
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultExpandedIds: ['docs', 'images'] },
+      });
+      expect(screen.getByRole('treeitem', { name: 'Documents' })).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+      expect(screen.getByRole('treeitem', { name: 'Images' })).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+    });
+
+    it('respects defaultSelectedIds', async () => {
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', defaultSelectedIds: ['readme'] },
+      });
+      expect(screen.getByRole('treeitem', { name: 'readme.md' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+    });
+
+    it('applies className to container', async () => {
+      await renderTree(TreeView, {
+        props: { nodes: simpleNodes, ariaLabel: 'Files', class: 'custom-tree' },
+      });
+      expect(screen.getByRole('tree')).toHaveClass('custom-tree');
+    });
+  });
+});

--- a/vitest.astro.config.ts
+++ b/vitest.astro.config.ts
@@ -37,6 +37,12 @@ export default getViteConfig({
       'src/patterns/dialog/Dialog.test.astro.ts',
       'src/patterns/tabs/Tabs.test.astro.ts',
       'src/patterns/toolbar/Toolbar.test.astro.ts',
+      'src/patterns/alert/Alert.test.astro.ts',
+      'src/patterns/data-grid/DataGrid.test.astro.ts',
+      'src/patterns/radio/RadioGroup.test.astro.ts',
+      'src/patterns/slider-multithumb/MultiThumbSlider.test.astro.ts',
+      'src/patterns/treegrid/TreeGrid.test.astro.ts',
+      'src/patterns/treeview/TreeView.test.astro.ts',
     ],
   },
 });


### PR DESCRIPTION
## 概要

plan 002: React 専用だった 6 パターン（alert, radio, slider-multithumb, treegrid, treeview, data-grid）のユニットテストを Vue / Svelte / Astro へ移植する。18 本の新規テストファイル（+11,631 行）を追加し、`vitest.astro.config.ts` の `include` に Astro テストを登録。

- 001（テスト規約の確立）/ 003（Astro Container API テスト）で確立した規約を再利用
- コンポーネント実装は変更しない（テスト追加のみ）

## 移植したパターン

| パターン | vue | svelte | astro |
|---|---|---|---|
| alert | ✅ | ✅ | ✅ |
| radio | ✅ | ✅ | ✅ |
| slider-multithumb | ✅ | ✅ | ✅ |
| treegrid | ✅ | ✅ | ✅ |
| treeview | ✅ | ✅ | ✅ |
| data-grid | ✅ | ✅ | ✅ |

## 移植中に判明した実バグ（`it.skip` で証拠付きコミット済み）

移植の過程で 2 件の実コンポーネントバグを検出。plan 002 の STOP 設計に従い、修正は別プラン扱いとし、該当テストは根拠コメント付きの `it.skip` として残している。

1. **TreeGrid (Svelte) リアクティビティバグ**（P1・別プラン **007** で修正予定）: `TreeGrid.svelte` が `internalExpandedIds` / `internalSelectedRowIds` を plain `let` の SvelteSet として宣言し、各ハンドラで**再代入**している。Svelte 5 runes モードでは plain-`let` 再代入は追跡されず、`$derived` が再実行されないため `aria-expanded` / `aria-selected` が DOM に反映されない。→ `TreeGrid.test.svelte.ts` の 8 ケースが `it.skip`。
2. **TreeView (Svelte) 初期化 `$effect` の再発火**（P3・軽微）: 単一の `defaultExpandedIds` ノードを選択なしで畳むと両セットが空になり init `$effect` が再発火して再展開する。→ `TreeView.test.svelte.ts` の 2 ケースが `it.skip`。

## 検証

- worktree では全ゲート green を確認済み（`test:vue` / `test:svelte` / `test:astro` / types / eslint / prettier）
- Astro 7 stable（`ef8061b`）上に rebase 済み。コンフリクトなし