### PR TITLE
fix(treegrid): make svelte expand/collapse/selection reactive (plan 007)

### DIFF
--- a/src/patterns/treegrid/TreeGrid.svelte
+++ b/src/patterns/treegrid/TreeGrid.svelte
@@ -101,6 +101,14 @@
 
   let internalExpandedIds = new SvelteSet<string>(untrack(() => defaultExpandedIds));
   let internalSelectedRowIds = new SvelteSet<string>(untrack(() => defaultSelectedRowIds));
+
+  // Helper function to sync SvelteSet with new values (using mutation for reactivity)
+  function syncSvelteSet<T>(target: SvelteSet<T>, source: Iterable<T>) {
+    target.clear();
+    for (const item of source) {
+      target.add(item);
+    }
+  }
   let focusedCellIdState = $state<string | null>(null);
   let initialized = $state(false);
 
@@ -197,8 +205,8 @@
 
   $effect(() => {
     if (!initialized && nodes.length > 0) {
-      internalExpandedIds = new SvelteSet(defaultExpandedIds);
-      internalSelectedRowIds = new SvelteSet(defaultSelectedRowIds);
+      syncSvelteSet(internalExpandedIds, defaultExpandedIds);
+      syncSvelteSet(internalSelectedRowIds, defaultSelectedRowIds);
       initialized = true;
     }
   });
@@ -250,7 +258,7 @@
 
   function updateExpandedIds(newExpandedIds: Set<string>) {
     if (!controlledExpandedIds) {
-      internalExpandedIds = newExpandedIds;
+      syncSvelteSet(internalExpandedIds, newExpandedIds);
     }
     onExpandedChange?.([...newExpandedIds]);
   }
@@ -300,7 +308,7 @@
 
   function updateSelectedRowIds(newSelectedIds: Set<string>) {
     if (!controlledSelectedRowIds) {
-      internalSelectedRowIds = newSelectedIds;
+      syncSvelteSet(internalSelectedRowIds, newSelectedIds);
     }
     onSelectionChange?.([...newSelectedIds]);
   }

--- a/src/patterns/treegrid/TreeGrid.test.svelte.ts
+++ b/src/patterns/treegrid/TreeGrid.test.svelte.ts
@@ -14,23 +14,6 @@ import type { TreeGridColumnDef, TreeGridNodeData } from './TreeGrid.svelte';
 //   into the document directly, mirroring the React JSX setup.
 // - The Svelte TreeGrid sets up focusable-element tabindex via an $effect, so `renderTree`
 //   awaits a tick after mounting (mirrors React's synchronous render) before assertions.
-//
-// All titles are ported 1:1. 8 expand/collapse/selection interaction cases are it.skip because
-// they expose a REAL Svelte-only component reactivity bug (NOT an environment/scheduler issue —
-// they fail identically run alone or in the full file, verified). Mechanism: TreeGrid.svelte
-// declares `internalExpandedIds` / `internalSelectedRowIds` as plain `let` bindings (not `$state`)
-// holding `SvelteSet`s. Every expand/collapse/select handler creates a NEW `SvelteSet` and
-// REASSIGNS the binding (`internalExpandedIds = newSet`, `internalSelectedRowIds = newSet`).
-// In Svelte 5 runes mode a plain-`let` reassignment is not tracked, so the `$derived`
-// `expandedIds`/`selectedRowIds` never re-run and `aria-expanded`/`aria-selected` never update in
-// the DOM. The `onExpandedChange`/`onSelectionChange` callbacks DO fire with the right payload
-// (the logic is correct; only the view binding is dead), which is why the callback-only tests
-// pass. `await tick()`/`flushSync()` cannot rescue a non-reactive reassignment. React/Vue update
-// the DOM. Fix is component-side (declare the bindings with `$state`, or mutate the existing
-// SvelteSet via add/delete like TreeView does) — out of scope here. Reported for the reviewer.
-// (The 9th originally-skipped case, "clicking a non-rowheader cell does not toggle expansion",
-// was a test-side query bug — gridcell textContent is " -- " with whitespace, so the exact
-// `=== '--'` match found nothing — now fixed with `.trim()` and un-skipped.)
 const renderTree = async (
   ...args: Parameters<typeof render>
 ): Promise<ReturnType<typeof render>> => {
@@ -522,12 +505,7 @@ describe('TreeGrid (Svelte)', () => {
   });
 
   describe('Keyboard - Tree Operations', () => {
-    // SKIP: real Svelte component reactivity bug (see file header). The expand/collapse/select
-    // handler reassigns the plain-`let` `internal*Ids` binding to a new SvelteSet; in runes mode
-    // that reassignment is not tracked, so the `aria-expanded`/`aria-selected` `$derived` never
-    // re-runs. The callback fires with the correct payload but the DOM attribute never updates.
-    // Fails alone and in the full run alike. Component-side fix needed — do not weaken the assertion.
-    it.skip('ArrowRight expands collapsed parent row at rowheader', async () => {
+    it('ArrowRight expands collapsed parent row at rowheader', async () => {
       const user = userEvent.setup();
       await renderTree(TreeGrid, {
         props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
@@ -565,12 +543,7 @@ describe('TreeGrid (Svelte)', () => {
       expect(screen.getByRole('gridcell', { name: '4 KB' })).toHaveFocus();
     });
 
-    // SKIP: real Svelte component reactivity bug (see file header). The expand/collapse/select
-    // handler reassigns the plain-`let` `internal*Ids` binding to a new SvelteSet; in runes mode
-    // that reassignment is not tracked, so the `aria-expanded`/`aria-selected` `$derived` never
-    // re-runs. The callback fires with the correct payload but the DOM attribute never updates.
-    // Fails alone and in the full run alike. Component-side fix needed — do not weaken the assertion.
-    it.skip('ArrowLeft collapses expanded parent row at rowheader', async () => {
+    it('ArrowLeft collapses expanded parent row at rowheader', async () => {
       const user = userEvent.setup();
       await renderTree(TreeGrid, {
         props: {
@@ -647,12 +620,7 @@ describe('TreeGrid (Svelte)', () => {
       expect(parentRow).toHaveAttribute('aria-expanded', 'false');
     });
 
-    // SKIP: real Svelte component reactivity bug (see file header). The expand/collapse/select
-    // handler reassigns the plain-`let` `internal*Ids` binding to a new SvelteSet; in runes mode
-    // that reassignment is not tracked, so the `aria-expanded`/`aria-selected` `$derived` never
-    // re-runs. The callback fires with the correct payload but the DOM attribute never updates.
-    // Fails alone and in the full run alike. Component-side fix needed — do not weaken the assertion.
-    it.skip('Space toggles row selection', async () => {
+    it('Space toggles row selection', async () => {
       const user = userEvent.setup();
       await renderTree(TreeGrid, {
         props: {
@@ -690,12 +658,7 @@ describe('TreeGrid (Svelte)', () => {
       expect(row).toHaveAttribute('aria-selected', 'false');
     });
 
-    // SKIP: real Svelte component reactivity bug (see file header). The expand/collapse/select
-    // handler reassigns the plain-`let` `internal*Ids` binding to a new SvelteSet; in runes mode
-    // that reassignment is not tracked, so the `aria-expanded`/`aria-selected` `$derived` never
-    // re-runs. The callback fires with the correct payload but the DOM attribute never updates.
-    // Fails alone and in the full run alike. Component-side fix needed — do not weaken the assertion.
-    it.skip('Ctrl+A selects all visible rows (multiselectable)', async () => {
+    it('Ctrl+A selects all visible rows (multiselectable)', async () => {
       const user = userEvent.setup();
       await renderTree(TreeGrid, {
         props: {
@@ -714,12 +677,7 @@ describe('TreeGrid (Svelte)', () => {
       });
     });
 
-    // SKIP: real Svelte component reactivity bug (see file header). The expand/collapse/select
-    // handler reassigns the plain-`let` `internal*Ids` binding to a new SvelteSet; in runes mode
-    // that reassignment is not tracked, so the `aria-expanded`/`aria-selected` `$derived` never
-    // re-runs. The callback fires with the correct payload but the DOM attribute never updates.
-    // Fails alone and in the full run alike. Component-side fix needed — do not weaken the assertion.
-    it.skip('single selection clears previous on Space', async () => {
+    it('single selection clears previous on Space', async () => {
       const user = userEvent.setup();
       await renderTree(TreeGrid, {
         props: {
@@ -992,12 +950,7 @@ describe('TreeGrid (Svelte)', () => {
   });
 
   describe('Mouse interactions', () => {
-    // SKIP: real Svelte component reactivity bug (see file header). The expand/collapse/select
-    // handler reassigns the plain-`let` `internal*Ids` binding to a new SvelteSet; in runes mode
-    // that reassignment is not tracked, so the `aria-expanded`/`aria-selected` `$derived` never
-    // re-runs. The callback fires with the correct payload but the DOM attribute never updates.
-    // Fails alone and in the full run alike. Component-side fix needed — do not weaken the assertion.
-    it.skip('clicking a rowheader of a collapsed parent expands it', async () => {
+    it('clicking a rowheader of a collapsed parent expands it', async () => {
       const user = userEvent.setup();
       await renderTree(TreeGrid, {
         props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },
@@ -1009,12 +962,7 @@ describe('TreeGrid (Svelte)', () => {
       expect(screen.getByRole('rowheader', { name: 'report.pdf' })).toBeInTheDocument();
     });
 
-    // SKIP: real Svelte component reactivity bug (see file header). The expand/collapse/select
-    // handler reassigns the plain-`let` `internal*Ids` binding to a new SvelteSet; in runes mode
-    // that reassignment is not tracked, so the `aria-expanded`/`aria-selected` `$derived` never
-    // re-runs. The callback fires with the correct payload but the DOM attribute never updates.
-    // Fails alone and in the full run alike. Component-side fix needed — do not weaken the assertion.
-    it.skip('clicking a rowheader of an expanded parent collapses it', async () => {
+    it('clicking a rowheader of an expanded parent collapses it', async () => {
       const user = userEvent.setup();
       await renderTree(TreeGrid, {
         props: {
@@ -1084,12 +1032,7 @@ describe('TreeGrid (Svelte)', () => {
       expect(onExpandedChange).not.toHaveBeenCalled();
     });
 
-    // SKIP: real Svelte component reactivity bug (see file header). The expand/collapse/select
-    // handler reassigns the plain-`let` `internal*Ids` binding to a new SvelteSet; in runes mode
-    // that reassignment is not tracked, so the `aria-expanded`/`aria-selected` `$derived` never
-    // re-runs. The callback fires with the correct payload but the DOM attribute never updates.
-    // Fails alone and in the full run alike. Component-side fix needed — do not weaken the assertion.
-    it.skip('clicking the chevron icon inside a rowheader also toggles expansion', async () => {
+    it('clicking the chevron icon inside a rowheader also toggles expansion', async () => {
       const user = userEvent.setup();
       await renderTree(TreeGrid, {
         props: { columns: createBasicColumns(), nodes: createBasicNodes(), ariaLabel: 'Files' },


### PR DESCRIPTION
## 概要

plan 007: Svelte 版 `TreeGrid` の expand/collapse/row-selection が **DOM に反映されない** リアクティビティバグを修正する（plan 002 のテスト移植中に判明、8 ケースを `it.skip` で保留していた）。

## 根本原因

`TreeGrid.svelte` は expand/select 状態を plain `let` の `SvelteSet` として保持し、各ハンドラで**新しい `SvelteSet` を作って束縛を再代入**していた。Svelte 5 runes モードでは plain-`let` の**再代入は追跡されない**ため、`$derived` の `expandedIds` / `selectedRowIds` が再計算されず、`aria-expanded` / `aria-selected` が DOM に反映されない。`onExpandedChange` / `onSelectionChange` は正しいペイロードで発火する（ロジックは正しく、ビュー束縛だけが死んでいる）ため、コールバック検証のテストだけは通っていた。キーボード / スクリーンリーダー利用者にはグリッドが固まって見える状態だった。React / Vue は正常。

## 修正

姉妹コンポーネント `TreeView.svelte` の正しいパターンを踏襲:

- `syncSvelteSet` ヘルパー（`clear()` + `add()` で**既存 SvelteSet を破壊的に更新**）を追加
- 3 箇所の再代入（init `$effect` / `updateExpandedIds` / `updateSelectedRowIds`）を `syncSvelteSet(...)` の mutation に置換

SvelteSet の mutation はリアクティブに追跡されるため `$derived` が再計算され DOM が更新される。宣言（`let internalExpandedIds` / `internalSelectedRowIds`）はそのまま。プロップ / イベント API は不変。

## テスト

`TreeGrid.test.svelte.ts` で本バグを記録していた 8 ケースを un-skip（`it.skip` → `it`、skip 理由コメント / ヘッダ段落を削除）。**アサーションは変更なし** — DOM から `aria-expanded` / `aria-selected` を読むため、通過はビュー束縛が再びリアクティブである証明になる。

## 検証

- 単一ファイル: `TreeGrid.test.svelte.ts` → **64 pass / 0 skip**
- `npm run test:svelte` → **1045 pass**（TreeGrid の skip は 0）
- `lint:types` / eslint（変更ファイル）/ `prettier --check`（変更ファイル）→ すべて exit 0
- 変更は `TreeGrid.svelte` と `TreeGrid.test.svelte.ts` の 2 ファイルのみ