### PR TITLE
chore(deps): non-breaking audit fix on stable + refresh SECURITY.md advisories

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -99,18 +99,24 @@ For general security questions or concerns, please open a [Discussion](https://g
 
 ---
 
-## Known Advisories (deferred — force-only fixes)
+## Known Advisories
 
-As of 2026-06-15, `npm audit fix` (non-breaking) reduced the total from **21** to **11** vulnerabilities. The remaining items all require `npm audit fix --force` or a major upstream version bump and are deferred until the project migrates away from the intentional alpha dependencies.
+As of 2026-07-12, on the stable Astro 7 toolchain, applying `npm audit fix`
+(non-breaking, **no** `--force`) reduces the audit to **5 findings** (4 critical,
+1 low). Only **1** (low) appears in the production dependency tree; the rest are
+development/build tooling. The remaining findings have no non-breaking fix — they
+require a `--force` major upgrade — and are deferred to maintainer-owned upgrade
+work.
 
-| Advisory ID | Severity | Package | Direct dependency pulling it in | Why deferred |
+| Advisory ID | Severity | Package | How it enters the tree | Status / why deferred |
 |---|---|---|---|---|
-| GHSA-g7r4-m6w7-qqqr | high | esbuild ≤0.28.0 | `astro@7.0.0-alpha.0` | Requires `astro@7.0.0-beta.3+`; outside stated alpha range |
-| GHSA-gv7w-rqvm-qjhr | high | esbuild ≤0.28.0 | `astro@7.0.0-alpha.0` | Same as above |
-| GHSA-48c2-rrv3-qjmp | moderate | yaml (nested in yaml-language-server) | `@astrojs/check` | Fix installs `@astrojs/check@0.9.2`, flagged as breaking change |
-| GHSA-2h32-95rg-cppp | critical | `@vitest/browser` 4.0.17–4.1.5 | `@vitest/browser-playwright` | Affects browser-mode dev tooling only; fix available via `npm audit fix` but did not apply in this run — re-run after upstream vitest release stabilizes |
+| GHSA-g8mr-85jm-7xhm | critical | `@vitest/browser` | `@vitest/browser-playwright` / `@vitest/coverage-v8` / `vitest` (dev; browser-mode test tooling) | No non-breaking fix; needs a `--force` major bump of the Vitest browser packages. Exercised only by `npm run test:browser`, not shipped as part of the static site. |
+| GHSA-2h32-95rg-cppp | critical | `@vitest/browser` | same as above | same as above |
+| GHSA-g7r4-m6w7-qqqr | low | esbuild | `astro` → `vite` (transitive; esbuild version pinned upstream) | esbuild's version is pinned transitively by Vite/Astro, so a non-breaking bump does not apply. Per its advisory the issue is Windows-specific and reachable via the dev server. Clears when Vite/Astro advance their pinned esbuild. |
 
-Per its advisory, the esbuild file-read issue (GHSA-g7r4-m6w7-qqqr) is described as Windows-specific and reachable via the dev server. All items will be resolved when `astro` and `@astrojs/*` alpha pins are advanced to stable or beta releases.
+Re-run `npm audit fix` (non-breaking) periodically to keep the noise floor low.
+The remaining `--force` upgrades (Vitest browser majors; a Vite/Astro bump that
+moves the pinned esbuild) are tracked as separate maintainer-owned work.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -387,9 +387,9 @@
       }
     },
     "node_modules/@astrojs/language-server": {
-      "version": "2.16.10",
-      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.10.tgz",
-      "integrity": "sha512-87VQ/5GSdHlRnUA+hGuerYyIGAj+9RbZmATyuKLEUePinUXhQ5YkRnRrHhOD9sSi5JOErLjrLkHnfZFEvGrV8w==",
+      "version": "2.16.11",
+      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.11.tgz",
+      "integrity": "sha512-sJ/EfnFp0+gurTrkvONtd9qRqmMZLT9bHelfI1SA35CaQVTrRrA74qteOcNT/al1b9Atg3IiH1Jk/qfckyC+fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -402,13 +402,13 @@
         "@volar/language-service": "~2.4.28",
         "muggle-string": "^0.4.1",
         "tinyglobby": "^0.2.16",
-        "volar-service-css": "0.0.70",
-        "volar-service-emmet": "0.0.70",
-        "volar-service-html": "0.0.70",
-        "volar-service-prettier": "0.0.70",
-        "volar-service-typescript": "0.0.70",
-        "volar-service-typescript-twoslash-queries": "0.0.70",
-        "volar-service-yaml": "0.0.70",
+        "volar-service-css": "0.0.71",
+        "volar-service-emmet": "0.0.71",
+        "volar-service-html": "0.0.71",
+        "volar-service-prettier": "0.0.71",
+        "volar-service-typescript": "0.0.71",
+        "volar-service-typescript-twoslash-queries": "0.0.71",
+        "volar-service-yaml": "0.0.71",
         "vscode-html-languageservice": "^5.6.2",
         "vscode-uri": "^3.1.0"
       },
@@ -17625,9 +17625,9 @@
       }
     },
     "node_modules/volar-service-css": {
-      "version": "0.0.70",
-      "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.70.tgz",
-      "integrity": "sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==",
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.71.tgz",
+      "integrity": "sha512-wRRFt9BpjMKCazcgOh67MSjUjiWUCAh99DyYSDIOTuxaRjEtDC7PpB0k1Y1wbJIW/pVtMUSVbpPo3UGSm0Byxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17645,9 +17645,9 @@
       }
     },
     "node_modules/volar-service-emmet": {
-      "version": "0.0.70",
-      "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.70.tgz",
-      "integrity": "sha512-xi5bC4m/VyE3zy/n2CXspKeDZs3qA41tHLTw275/7dNWM/RqE2z3BnDICQybHIVp/6G1iOQj5c1qXMgQC08TNg==",
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.71.tgz",
+      "integrity": "sha512-zqjzt6bN95e3CUstBm0PBFAJnrfz0ZAARka87fart46/gNCLLuP3Vujy8V/J8HEziTFLnfkgIASLFYPUhonJcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17666,9 +17666,9 @@
       }
     },
     "node_modules/volar-service-html": {
-      "version": "0.0.70",
-      "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.70.tgz",
-      "integrity": "sha512-eR6vCgMdmYAo4n+gcT7DSyBQbwB8S3HZZvSagTf0sxNaD4WppMCFfpqWnkrlGStPKMZvMiejRRVmqsX9dYcTvQ==",
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.71.tgz",
+      "integrity": "sha512-e8tHPhgQ7ooLfudAEIku+kgd9pWkq3SSz8RbnQDI1+Eb8wbenkLGHqoirLqz5ORLV6wIMr2Iv08RWBG5eOcgpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17686,9 +17686,9 @@
       }
     },
     "node_modules/volar-service-prettier": {
-      "version": "0.0.70",
-      "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.70.tgz",
-      "integrity": "sha512-Z6BCFSpGVCd8BPAsZ785Kce1BGlWd5ODqmqZGVuB14MJvrR4+CYz6cDy4F+igmE1gMifqfvMhdgT8Aud4M5ngg==",
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.71.tgz",
+      "integrity": "sha512-Rz7JVH3qD108UCdmIEiZvOBNljMt2nLFdbN8AXcDfn7xD9F5I2aCIsDVqBbXw21PsnxG0b7MfwtNF+zPS/NKUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17708,9 +17708,9 @@
       }
     },
     "node_modules/volar-service-typescript": {
-      "version": "0.0.70",
-      "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.70.tgz",
-      "integrity": "sha512-l46Bx4cokkUedTd74ojO5H/zqHZJ8SUuyZ0IB8JN4jfRqUM3bQFBHoOwlZCyZmOeO0A3RQNkMnFclxO4c++gsg==",
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.71.tgz",
+      "integrity": "sha512-yTtM/BVT6hoyEYnDtaCyAtNhdNeS/mhTTABlBOdw3NNiRBUin3IznFJpgfjer4c6RYopiPjjQjc9VFhxVl1mLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17731,9 +17731,9 @@
       }
     },
     "node_modules/volar-service-typescript-twoslash-queries": {
-      "version": "0.0.70",
-      "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.70.tgz",
-      "integrity": "sha512-IdD13Z9N2Bu8EM6CM0fDV1E69olEYGHDU25X51YXmq8Y0CmJ2LNj6gOiBJgpS5JGUqFzECVhMNBW7R0sPdRTMQ==",
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.71.tgz",
+      "integrity": "sha512-9K2k72s4n7rV9s4bX0MyjbX9iBribvKZbBJKuEmTCZfeWJXs6Yh7bGpY4eoc7UufAjvpheBqwyZCOIPBvxCv0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17749,14 +17749,14 @@
       }
     },
     "node_modules/volar-service-yaml": {
-      "version": "0.0.70",
-      "resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.70.tgz",
-      "integrity": "sha512-0c8bXDBeoATF9F6iPIlOuYTuZAC4c+yi0siQo920u7eiBJk8oQmUmg9cDUbR4+Gl++bvGP4plj3fErbJuPqdcQ==",
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.71.tgz",
+      "integrity": "sha512-qYGWGuVpUTnZGu5P/CR4KLK4aIR8RrcVnmfZ2eRcj9q/I8VZCoC5yy9FtEvfNvnDp4MU17yhdJcvpQPIqhJS2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "vscode-uri": "^3.0.8",
-        "yaml-language-server": "~1.20.0"
+        "yaml-language-server": "~1.23.0"
       },
       "peerDependencies": {
         "@volar/language-service": "~2.4.0"
@@ -18335,23 +18335,24 @@
       }
     },
     "node_modules/yaml-language-server": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.20.0.tgz",
-      "integrity": "sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.23.0.tgz",
+      "integrity": "sha512-3qVyCOexLCWw06PQa5kRPwvMWMZ/eZeCRWUvgD6a0OkqL/4iCnxy2WumbWifa937Uo5xhyWJ0uxlU39ljhNh7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vscode/l10n": "^0.0.18",
         "ajv": "^8.17.1",
         "ajv-draft-04": "^1.0.0",
-        "prettier": "^3.5.0",
+        "ajv-i18n": "^4.2.0",
+        "prettier": "^3.8.1",
         "request-light": "^0.5.7",
         "vscode-json-languageservice": "4.1.8",
         "vscode-languageserver": "^9.0.0",
         "vscode-languageserver-textdocument": "^1.0.1",
         "vscode-languageserver-types": "^3.16.0",
         "vscode-uri": "^3.0.2",
-        "yaml": "2.7.1"
+        "yaml": "2.8.3"
       },
       "bin": {
         "yaml-language-server": "bin/yaml-language-server"
@@ -18389,6 +18390,16 @@
         }
       }
     },
+    "node_modules/yaml-language-server/node_modules/ajv-i18n": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ajv-i18n/-/ajv-i18n-4.2.0.tgz",
+      "integrity": "sha512-v/ei2UkCEeuKNXh8RToiFsUclmU+G57LO1Oo22OagNMENIw+Yb8eMwvHu7Vn9fmkjJyv6XclhJ8TbuigSglPkg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.0.0-beta.0"
+      }
+    },
     "node_modules/yaml-language-server/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -18404,16 +18415,19 @@
       "license": "MIT"
     },
     "node_modules/yaml-language-server/node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {


### PR DESCRIPTION
## 概要

plan 006 の残作業: `SECURITY.md` の "Known Advisories" 表が **Astro 7 alpha 時代のまま陳腐化**していた（`astro@7.0.0-alpha.0` を経路に記載、"migrate away from alpha" と記述）。stable 化（#238）後は誤情報のため、stable の実態に合わせて更新する。あわせて stable ツリーで非破壊 `npm audit fix` を再適用する。

## 変更

- **`npm audit fix`（非破壊・`--force` なし）を stable ツリーで再実行**
  - yaml / yaml-language-server / volar-service-yaml / @astrojs/language-server の findings が解消
  - audit: **9 → 5**（critical 4 / low 1）、**production 依存ツリー到達は 1 件**（esbuild, low）
  - `package.json` は不変（framework pin 無傷）、`package-lock.json` のみ更新
- **`SECURITY.md` の advisories 表を stable の実態に書き換え**
  - 残る 5 件の内訳（ユニーク 3 advisory）:
    - `GHSA-g8mr-85jm-7xhm` / `GHSA-2h32-95rg-cppp`（critical）= `@vitest/browser`（browser-mode テスト専用の dev 依存、`npm run test:browser` のみ、静的サイトには含まれない）
    - `GHSA-g7r4-m6w7-qqqr`（low）= esbuild（`astro` → `vite` の transitive pin、Windows dev-server 限定）
  - いずれも非破壊 fix 不可（`--force` major 必要）→ maintainer 判断の別作業として deferred
  - alpha 前提の記述をすべて削除

## 検証

- `DEPLOY_TARGET=github-pages npm run build` → 555 ページ、exit 0
- `npm run test:unit`（vitest + astro）→ pass
- `prettier --check SECURITY.md` → pass